### PR TITLE
Support filtering exported time series

### DIFF
--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -93,6 +93,11 @@ func main() {
 		os.Exit(2)
 	}
 
+	if *projectID == "" {
+		level.Error(logger).Log("msg", "no --query.project-id was specified or could be derived from the environment")
+		os.Exit(2)
+	}
+
 	*targetURL = strings.ReplaceAll(*targetURL, projectIDVar, *projectID)
 
 	// Don't expand external labels on config file loading. It's a feature we like but we want to remain

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -17,8 +17,8 @@ package export
 import (
 	"context"
 	"fmt"
-	"testing"
 	"sync"
+	"testing"
 
 	gax "github.com/googleapis/gax-go/v2"
 	monitoredres_pb "google.golang.org/genproto/googleapis/api/monitoredres"

--- a/pkg/export/series_cache_test.go
+++ b/pkg/export/series_cache_test.go
@@ -135,7 +135,7 @@ func TestSeriesCache_extractResource(t *testing.T) {
 		t.Run(c.doc, func(t *testing.T) {
 			cache := newSeriesCache(nil, nil, metricTypePrefix, func() labels.Labels {
 				return c.externalLabels
-			})
+			}, nil)
 			resource, lset, err := cache.extractResource(c.seriesLabels)
 			if c.wantOk && err != nil {
 				t.Errorf("expected no error but got: %s", err)
@@ -154,7 +154,7 @@ func TestSeriesCache_extractResource(t *testing.T) {
 }
 
 func TestSeriesCache_garbageCollect(t *testing.T) {
-	cache := newSeriesCache(nil, nil, metricTypePrefix, nil)
+	cache := newSeriesCache(nil, nil, metricTypePrefix, nil, nil)
 	// Always return empty labels. This will cause cache entries to be added but not populated,
 	// which we don't need to test garbage collection.
 	cache.getLabelsByRef = func(uint64) labels.Labels { return nil }

--- a/pkg/export/transform.go
+++ b/pkg/export/transform.go
@@ -137,6 +137,9 @@ func (b *sampleBuilder) next(metadata MetadataFunc, samples []record.RefSample) 
 		prometheusSamplesDiscarded.WithLabelValues("no-cache-series-found").Inc()
 		return nil, 0, tailSamples, nil
 	}
+	if entry.dropped {
+		return nil, 0, tailSamples, nil
+	}
 
 	// Get a shallow copy of the proto so we can overwrite the point field
 	// and safely send it into the remote queues.


### PR DESCRIPTION
Add support for a flag that has semantics compatible to the match[] GET
parameter of Prometheus federation. It allows to easily specify that
only a subset of time series should be exported.

Cache the dropped state as it is expensive to compute on each sample.