### PR TITLE
Lessen port names to 15 characters

### DIFF
--- a/cmd/operator/deploy/meta-monitoring/pod_monitoring.yaml
+++ b/cmd/operator/deploy/meta-monitoring/pod_monitoring.yaml
@@ -24,7 +24,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: collector
   endpoints:
-  - port: prometheus-http
+  - port: prom-metrics
     interval: 10s
-  - port: reloader-http
+  - port: cfg-rel-metrics
     interval: 10s

--- a/cmd/operator/deploy/rule-evaluator/deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - "--config.file=/etc/config/config.yaml"
         - "--web.listen-address=:9092"
         ports:
-        - name: http
+        - name: r-eval-metrics
           containerPort: 9092
         resources:
           limits:
@@ -62,7 +62,7 @@ spec:
         name: config-reloader
         ports:
         - containerPort: 9093
-          name: reloader-http
+          name: cfg-rel-metrics
           protocol: TCP
         resources:
           limits:

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -143,7 +143,7 @@ const (
 	collectorConfigOutDir        = "/prometheus/config_out"
 	collectorConfigFilename      = "config.yaml"
 	// TODO: rename prometheus-engine component to managed-prometheus?
-	collectorComponentName       = "prometheus-engine"
+	collectorComponentName = "prometheus-engine"
 	// The well-known app name label.
 	LabelAppName = "app.kubernetes.io/name"
 	// The component name, will be exposed as metric name.
@@ -203,7 +203,7 @@ func (r *collectionReconciler) makeCollectorDaemonSet() *appsv1.DaemonSet {
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: podLabels,
+				Labels:      podLabels,
 				Annotations: podAnnotations,
 			},
 			Spec: corev1.PodSpec{
@@ -219,7 +219,7 @@ func (r *collectionReconciler) makeCollectorDaemonSet() *appsv1.DaemonSet {
 						},
 						Args: collectorArgs,
 						Ports: []corev1.ContainerPort{
-							{Name: "prometheus-http-metrics", ContainerPort: r.opts.CollectorPort},
+							{Name: "prom-metrics", ContainerPort: r.opts.CollectorPort},
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -259,7 +259,7 @@ func (r *collectionReconciler) makeCollectorDaemonSet() *appsv1.DaemonSet {
 							},
 						},
 						Ports: []corev1.ContainerPort{
-							{Name: "reloader-http-metrics", ContainerPort: r.opts.CollectorPort + 1},
+							{Name: "cfg-rel-metrics", ContainerPort: r.opts.CollectorPort + 1},
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{

--- a/pkg/operator/e2e/main_test.go
+++ b/pkg/operator/e2e/main_test.go
@@ -197,8 +197,8 @@ func testCollectorSelfPodMonitoring(ctx context.Context, t *testContext) {
 				},
 			},
 			Endpoints: []monitoringv1alpha1.ScrapeEndpoint{
-				{Port: intstr.FromString("prometheus-http"), Interval: "5s"},
-				{Port: intstr.FromString("reloader-http"), Interval: "5s"},
+				{Port: intstr.FromString("prom-metrics"), Interval: "5s"},
+				{Port: intstr.FromString("cfg-rel-metrics"), Interval: "5s"},
 			},
 		},
 	}
@@ -284,7 +284,7 @@ func validateCollectorUpMetrics(ctx context.Context, t *testContext, job string)
 	defer cancel()
 
 	for _, pod := range pods.Items {
-		for _, port := range []string{"prometheus-http", "reloader-http"} {
+		for _, port := range []string{"prom-metrics", "cfg-rel-metrics"} {
 			t.Logf("Poll up metric for pod %q and port %q", pod.Name, port)
 
 			err = wait.PollImmediateUntil(3*time.Second, func() (bool, error) {


### PR DESCRIPTION
Noticed this while running e2e tests on kind k8s cluster.
Specified in: https://github.com/kubernetes/enhancements/blob/115721691f7a4c63af0efd52107195241ac5ac0f/keps/sig-network/0752-endpointslices/README.md#endpointslice-api