### PR TITLE
Add more pass-through args and update e2e tests

### DIFF
--- a/cmd/operator/deploy/operator/operator.yaml
+++ b/cmd/operator/deploy/operator/operator.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccountName: operator
       containers:
       - name: operator
-        image: "gcr.io/gpe-test-1/gpe-operator:bench_20210306_1314"
+        image: "gcr.io/gpe-test-1/gpe-operator:bench_20210508_1502"
         args:
         - "--priority-class=gpe-critical"
         - "--ca-selfsign=false"

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -193,6 +193,17 @@ func (r *collectionReconciler) makeCollectorDaemonSet() *appsv1.DaemonSet {
 		"--web.enable-lifecycle",
 		"--web.route-prefix=/",
 	}
+
+	// Check for explicitly-set pass-through args.
+	if r.opts.ProjectID != "" {
+		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.label.project-id=%q", r.opts.ProjectID))
+	}
+	if r.opts.Location != "" {
+		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.label.location=%q", r.opts.ProjectID))
+	}
+	if r.opts.DisableExport {
+		collectorArgs = append(collectorArgs, "--export.disable")
+	}
 	if r.opts.CloudMonitoringEndpoint != "" {
 		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.endpoint=%s", r.opts.CloudMonitoringEndpoint))
 	}

--- a/pkg/operator/e2e/context.go
+++ b/pkg/operator/e2e/context.go
@@ -91,8 +91,10 @@ func newTestContext(t *testing.T) *testContext {
 	}
 
 	op, err := operator.New(globalLogger, kubeconfig, nil, operator.Options{
-		ProjectID: projectID,
-		Cluster:   cluster,
+		ProjectID:               projectID,
+		Cluster:                 cluster,
+		Location:                location,
+		DisableCollectorsExport: true,
 		// Pick a random port to avoid conflicts with other simultaneous tests in the cluster
 		// as the collector runs on the host network.
 		CollectorPort:     1025 + rand.Int31n(65536-1025),

--- a/pkg/operator/e2e/main_test.go
+++ b/pkg/operator/e2e/main_test.go
@@ -55,11 +55,15 @@ var (
 	kubeconfig *rest.Config
 	projectID  string
 	cluster    string
+	location   string
+	skipGCM    bool
 )
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&projectID, "project-id", "", "The GCP project to write metrics to.")
 	flag.StringVar(&cluster, "cluster", "", "The name of the Kubernetes cluster that's tested against.")
+	flag.StringVar(&location, "location", "", "The location of the Kubernetes cluster that's tested against.")
+	flag.BoolVar(&skipGCM, "skip-gcm", true, "Skip validating GCM ingested points.")
 
 	flag.Parse()
 
@@ -235,8 +239,10 @@ func testCollectorSelfPodMonitoring(ctx context.Context, t *testContext) {
 		t.Errorf("unable to validate PodMonitoring status: %s", err)
 	}
 
-	t.Log("Waiting for up metrics for collector targets")
-	validateCollectorUpMetrics(ctx, t, "collector-podmon")
+	if !skipGCM {
+		t.Log("Waiting for up metrics for collector targets")
+		validateCollectorUpMetrics(ctx, t, "collector-podmon")
+	}
 }
 
 // validateCollectorUpMetrics checks whether the scrape-time up metrics for all collector

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -80,8 +80,12 @@ type Operator struct {
 type Options struct {
 	// ID of the project of the cluster.
 	ProjectID string
+	// Location of the cluster.
+	Location string
 	// Name of the cluster the operator acts on.
 	Cluster string
+	// Disable exporting to GCM (mostly for testing).
+	DisableExport bool
 	// Namespace to which the operator deploys any associated resources.
 	OperatorNamespace string
 	// Listening port of the collector. Configurable to allow multiple

--- a/pkg/operator/webhook_test.go
+++ b/pkg/operator/webhook_test.go
@@ -74,7 +74,7 @@ func TestValidatingWebhookConfig(t *testing.T) {
 				t.Errorf("unexpected webhook config namespace: %s", ns)
 			} else if path := *wh.ClientConfig.Service.Path; path != "/podmonitorings/v1alpha1/validate" {
 				t.Errorf("unexpected webhook path: %s", path)
-			} else if crt := wh.ClientConfig.CABundle; bytes.Compare(crt, c.caBundle) != 0 {
+			} else if crt := wh.ClientConfig.CABundle; !bytes.Equal(crt, c.caBundle) {
 				t.Errorf("unexpected caBundle: %v", crt)
 			} else if rule := wh.Rules[0]; !(rule.Operations[0] == arv1.Create && rule.Operations[1] == arv1.Update) {
 				t.Errorf("unexpected rule operations: %+v", rule)


### PR DESCRIPTION
This gives more configuration around collectors from the operator. In particular, running on non-GKE k8s clusters (e.g. kind).

Also bump operator image