### PR TITLE
enable operator to pass through cluster label and credentials file

### DIFF
--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -210,6 +210,9 @@ func (r *collectionReconciler) makeCollectorDaemonSet() *appsv1.DaemonSet {
 	if r.opts.CloudMonitoringEndpoint != "" {
 		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.endpoint=%s", r.opts.CloudMonitoringEndpoint))
 	}
+	if r.opts.CredentialsFile != "" {
+		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.credentials-file=%s", r.opts.CredentialsFile))
+	}
 
 	spec := appsv1.DaemonSetSpec{
 		Selector: &metav1.LabelSelector{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -86,6 +86,8 @@ type Options struct {
 	Cluster string
 	// Disable exporting to GCM (mostly for testing).
 	DisableExport bool
+	// Credentials file for authentication with the GCM API.
+	CredentialsFile string
 	// Namespace to which the operator deploys any associated resources.
 	OperatorNamespace string
 	// Listening port of the collector. Configurable to allow multiple


### PR DESCRIPTION
In cases where the GCE metadata server is unavailable (e.g. AKS, EKS, on-prem), customers should be able to label their metric targets with the cluster name in addition to the project and location (already provided as pass-thru options).