### PR TITLE
Initial managed rule-evaluator scaffolding

### DIFF
--- a/pkg/operator/apis/monitoring/v1alpha1/register.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/register.go
@@ -62,6 +62,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&PodMonitoringList{},
 		&Rules{},
 		&RulesList{},
+		&OperatorConfig{},
+		&OperatorConfigList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -93,7 +93,7 @@ type AlertmanagerEndpoints struct {
 	// can be "v1" or "v2".
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Timeout is a per-target Alertmanager timeout when pushing alerts.
-	Timeout *string `json:"timeout,omitempty"`
+	Timeout string `json:"timeout,omitempty"`
 }
 
 // SafeAuthorization specifies a subset of the Authorization struct, that is

--- a/pkg/operator/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -60,11 +60,6 @@ func (in *AlertmanagerEndpoints) DeepCopyInto(out *AlertmanagerEndpoints) {
 		*out = new(SafeAuthorization)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Timeout != nil {
-		in, out := &in.Timeout, &out.Timeout
-		*out = new(string)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -143,11 +143,6 @@ const (
 	collectorConfigOutVolumeName = "config-out"
 	collectorConfigOutDir        = "/prometheus/config_out"
 	collectorConfigFilename      = "config.yaml"
-	collectorComponentName       = "managed_prometheus"
-	// The well-known app name label.
-	LabelAppName = "app.kubernetes.io/name"
-	// The component name, will be exposed as metric name.
-	AnnotationMetricName = "components.gke.io/component-name"
 )
 
 // ensureCollectorDaemonSet generates the collector daemon set and creates or updates it.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -45,8 +45,14 @@ const (
 	DefaultOperatorNamespace = "gmp-system"
 
 	// Fixed names used in various resources managed by the operator.
-	NameOperator       = "gmp-operator"
-	nameRulesGenerated = "rules-generated"
+	NameOperator           = "gmp-operator"
+	nameRulesGenerated     = "rules-generated"
+	collectorComponentName = "managed_prometheus"
+
+	// The well-known app name label.
+	LabelAppName = "app.kubernetes.io/name"
+	// The component name, will be exposed as metric name.
+	AnnotationMetricName = "components.gke.io/component-name"
 
 	// The official images to be used with this version of the operator. For debugging
 	// and emergency use cases they may be overwritten through options.
@@ -254,6 +260,9 @@ func (o *Operator) Run(ctx context.Context, ors ...metav1.OwnerReference) error 
 	}
 	if err := setupRulesControllers(o); err != nil {
 		return errors.Wrap(err, "setup rules controllers")
+	}
+	if err := setupOperatorConfigControllers(o); err != nil {
+		return errors.Wrap(err, "setup rule-evaluator controllers")
 	}
 
 	o.logger.Info("starting GMP operator")

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -1,0 +1,93 @@
+package operator
+
+import (
+	"context"
+
+	monitoringv1alpha1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1alpha1"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	RuleEvaluatorName = "rule-evaluator"
+)
+
+// setupOperatorConfigControllers ensures a rule-evaluator
+// deployment as part of managed collection.
+func setupOperatorConfigControllers(op *Operator) error {
+	// Canonical filter to only capture events for the generated
+	// rule evaluator deployment.
+	objFilter := namespacedNamePredicate{
+		namespace: op.opts.OperatorNamespace,
+		name:      RuleEvaluatorName,
+	}
+
+	err := ctrl.NewControllerManagedBy(op.manager).
+		Named("operator-config").
+		For(
+			&monitoringv1alpha1.OperatorConfig{},
+		).
+		Owns(
+			&corev1.ConfigMap{},
+			builder.WithPredicates(objFilter)).
+		Owns(
+			&appsv1.Deployment{},
+			builder.WithPredicates(objFilter)).
+		Complete(newOperatorConfigReconciler(op.manager.GetClient(), op.opts))
+
+	if err != nil {
+		return errors.Wrap(err, "operator-config controller")
+	}
+	return nil
+}
+
+// operatorConfigReconciler reconciles the OperatorConfig CRD.
+type operatorConfigReconciler struct {
+	client client.Client
+	opts   Options
+}
+
+// newOperatorConfigReconciler creates a new operatorConfigReconciler.
+func newOperatorConfigReconciler(c client.Client, opts Options) *operatorConfigReconciler {
+	return &operatorConfigReconciler{
+		client: c,
+		opts:   opts,
+	}
+}
+
+// Reconcile ensures the OperatorConfig resource is reconciled.
+func (r *operatorConfigReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger := logr.FromContext(ctx).WithValues("operatorconfig", req.NamespacedName)
+	logger.Info("reconciling operatorconfig")
+
+	var config = &monitoringv1alpha1.OperatorConfig{}
+	if err := r.client.Get(ctx, req.NamespacedName, config); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "get operatorconfig")
+	}
+	if err := r.ensureRuleEvaluatorConfig(ctx, config); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "ensure rule-evaluator config")
+	}
+	if err := r.ensureRuleEvaluatorDeployment(ctx); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "ensure rule-evaluator deploy")
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// ensureRuleEvaluatorConfig reconciles the ConfigMap for rule-evaluator.
+func (r *operatorConfigReconciler) ensureRuleEvaluatorConfig(ctx context.Context, config *monitoringv1alpha1.OperatorConfig) error {
+	// TODO(pintohutch): fill out
+	return nil
+}
+
+// ensureRuleEvaluatorDeployment reconciles the Deployment for rule-evaluator.
+func (r *operatorConfigReconciler) ensureRuleEvaluatorDeployment(ctx context.Context) error {
+	// TODO(pintohutch): fill out
+	return nil
+}

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -66,7 +66,7 @@ func setupRulesControllers(op *Operator) error {
 		).
 		Complete(newRulesReconciler(op.manager.GetClient(), op.opts))
 	if err != nil {
-		return errors.Wrap(err, "create collector config controller")
+		return errors.Wrap(err, "create rules config controller")
 	}
 	return nil
 }


### PR DESCRIPTION
This sets up the scaffolding for the OperatorConfig reconcile loop that will enable many GMP components.

Initially, this will focus on the rule-evaluator deployment and configmap. Right now the code doesn't do anything (as noted by the TODOs) but will still compile and run.