### PR TITLE
Use gmp-public as default public namespace

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -57,7 +57,7 @@ func main() {
 		cluster           = flag.String("cluster", defaultCluster, "Name of the cluster the operator acts on. May be left empty on GKE.")
 		operatorNamespace = flag.String("operator-namespace", operator.DefaultOperatorNamespace,
 			"Namespace in which the operator manages its resources.")
-		publicNamespace = flag.String("public-namespace", operator.DefaultOperatorNamespace,
+		publicNamespace = flag.String("public-namespace", operator.DefaultPublicNamespace,
 			"Namespace in which the operator reads user-provided resources.")
 
 		imageCollector = flag.String("image-collector", operator.ImageCollector,


### PR DESCRIPTION
You had this originally and I asked you to change it.
When testing I realized now though that this will just cause unnecessary confusion so reverting to how you did it initially.