### PR TITLE
Removing cert self-sign option from operator

### DIFF
--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -42,7 +42,6 @@ spec:
       - name: operator
         image: gke.gcr.io/prometheus-engine/operator:v0.1.1-gke.0
         args:
-        - "--ca-selfsign=false"
         - "--public-namespace=gmp-public"
         - "--priority-class=gmp-critical"
         - "--image-collector=gke.gcr.io/prometheus-engine/prometheus:v2.28.1-gmp.1-gke.1"

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -73,8 +73,6 @@ func main() {
 			"Priority class at which the collector pods are run.")
 		gcmEndpoint = flag.String("cloud-monitoring-endpoint", "",
 			"Override for the Cloud Monitoring endpoint to use for all collectors.")
-		caSelfSign = flag.Bool("ca-selfsign", true,
-			"Whether to self-sign or have kube-apiserver sign certificate key pair for TLS.")
 		webhookAddr = flag.String("webhook-addr", ":8443",
 			"Address to listen to for incoming kube admission webhook connections.")
 		metricsAddr = flag.String("metrics-addr", ":18080", "Address to emit metrics on.")
@@ -108,7 +106,6 @@ func main() {
 		HostNetwork:             *hostNetwork,
 		PriorityClass:           *priorityClass,
 		CloudMonitoringEndpoint: *gcmEndpoint,
-		CASelfSign:              *caSelfSign,
 		ListenAddr:              *webhookAddr,
 	})
 	if err != nil {

--- a/examples/operator.yaml
+++ b/examples/operator.yaml
@@ -181,7 +181,6 @@ spec:
       - name: operator
         image: gke.gcr.io/prometheus-engine/operator:v0.1.1-gke.0
         args:
-        - "--ca-selfsign=false"
         - "--public-namespace=gmp-public"
         - "--priority-class=gmp-critical"
         - "--image-collector=gke.gcr.io/prometheus-engine/prometheus:v2.28.1-gmp.1-gke.1"

--- a/pkg/operator/e2e/context.go
+++ b/pkg/operator/e2e/context.go
@@ -112,7 +112,6 @@ func newTestContext(t *testing.T) *testContext {
 		OperatorNamespace: tctx.namespace,
 		PublicNamespace:   tctx.pubNamespace,
 		PriorityClass:     "gmp-critical",
-		CASelfSign:        false,
 		ListenAddr:        ":8443",
 	})
 	if err != nil {


### PR DESCRIPTION
Webhooks with self-signed certs will not be accepted by the kubernetes API server.