### PR TITLE
Revert "Fix "dockerception" and use sibling containers over child containers"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,6 @@ PROJECT_ID?=$(shell gcloud config get-value core/project)
 GMP_CLUSTER?=gmp-test-cluster
 GMP_LOCATION?=us-central1-c
 API_DIR=pkg/operator/apis
-# For now assume the docker daemon is mounted through a unix socket.
-# TODO(pintohutch): will this work if using a remote docker over tcp?
-DOCKER_HOST?=unix:///var/run/docker.sock
-DOCKER_VOLUME:=$(DOCKER_HOST:unix://%=%)
 
 TAG_NAME?=$(shell date "+gmp-%Y%d%m_%H%M")
 
@@ -66,14 +62,21 @@ else
 	--build-arg RUNCMD='go test `go list ./... | grep -v operator/e2e`' .)
 endif
 
+kindclean: clean
+	docker volume rm -f gcloud-config
+
 kindtest:    ## Run e2e test suite against fresh kind k8s cluster.
-kindtest: clean
+kindtest: kindclean
 	@echo ">> building image"
 	$(call docker_build, -f hack/Dockerfile --target kindtest -t gmp/kindtest .)
+	@echo ">> creating tmp gcloud config volume"
+	docker volume create gcloud-config
+	docker create -v gcloud-config:/data --name tmp busybox true
+	docker cp $(CLOUDSDK_CONFIG) tmp:/data
+	docker rm tmp
 	@echo ">> running container"
-# We lose some isolation by sharing the host network with the kind containers.
-# However, we avoid a gcloud-shell "Dockerception" and save on build times.
-	docker run --network host --rm -v $(DOCKER_VOLUME):/var/run/docker.sock gmp/kindtest ./hack/kind-test.sh
+	docker run --rm -v gcloud-config:/root/.config gmp/kindtest ./hack/kind-test.sh
+	docker volume rm -f gcloud-config
 
 lint:        ## Lint code.
 	@echo ">> linting code"

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -58,7 +58,9 @@ RUN curl -fsSL https://get.docker.com -o get-docker.sh
 RUN sh get-docker.sh && rm get-docker.sh
 
 # Install kubectl.
-RUN apt-get install kubectl
+RUN curl -Lo ./kubectl https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl
+RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
+  && rm kubectl
 
 # Install kind.
 RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # WARNING: It is _strongly_ recommended that you keep this the default
+  # (127.0.0.1) for security reasons. However it is possible to change this.
+  apiServerAddress: "127.0.0.1"
+  # By default the API server listens on a random open port.
+  # You may choose a specific port but probably don't need to in most cases.
+  # Using a random port makes it easier to spin up multiple clusters.
+  apiServerPort: 6443


### PR DESCRIPTION
Reverts GoogleCloudPlatform/prometheus-engine#120

This change made `make kindtest` and `make presubmit` start failing the collector test for me. The collector crashloops as it cannot find default credentials and doesn't get explicit ones either.
This is different from the case for which our tests have the `--skip-gcm` flag, where it has credentails, but they lack permissions.

I'm not entirely sure what the reason is and how it relates to this change. But undoing first so the tests work again.