### PR TITLE
Validate rules resources

### DIFF
--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -37,55 +37,31 @@ kind: ClusterRole
 metadata:
   name: gmp-system:operator
 rules:
-- apiGroups: ["", "apps", "admissionregistration.k8s.io", "monitoring.googleapis.com", "certificates.k8s.io"]
+- apiGroups: [""]
   resources:
-# TODO(pintohutch): restrict access to non-CRD resources to select namespaces only.
-# This can also be enforced via watch/list filters of controllers/managers.
-# Ultimately we'll want that enforced here by the kube-apiserver and configured
-# properly at the controller/manager level.
-  - certificatesigningrequests
-  - clusterrules
-  - clusterrules/status
   - configmaps
+  - secrets
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["apps"]
+  resources:
   - daemonsets
   - deployments
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - validatingwebhookconfigurations
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["monitoring.googleapis.com"]
+  resources:
+  - clusterpodmonitorings
+  - clusterpodmonitorings/status
+  - clusterrules
+  - clusterrules/status
   - globalrules
   - globalrules/status
   - operatorconfigs
   - podmonitorings
   - podmonitorings/status
-  - clusterpodmonitorings
-  - clusterpodmonitorings/status
   - rules
   - rules/status
-  - secrets
-  - validatingwebhookconfigurations
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: gmp-system:csr-approver
-rules:
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests/approval
-  verbs:
-  - update
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - signers
-  resourceNames:
-  - kubernetes.io/kubelet-serving
-  verbs:
-  - approve

--- a/cmd/operator/deploy/operator/04-rolebinding.yaml
+++ b/cmd/operator/deploy/operator/04-rolebinding.yaml
@@ -28,19 +28,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gmp-system:operator-csr
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: gmp-system:csr-approver
-subjects:
-- kind: ServiceAccount
-  namespace: gmp-system
-  name: operator
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
   name: gmp-system:collector
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -68,56 +68,36 @@ kind: ClusterRole
 metadata:
   name: gmp-system:operator
 rules:
-- apiGroups: ["", "apps", "admissionregistration.k8s.io", "monitoring.googleapis.com", "certificates.k8s.io"]
+- apiGroups: [""]
   resources:
-  - certificatesigningrequests
-  - clusterrules
-  - clusterrules/status
   - configmaps
+  - secrets
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["apps"]
+  resources:
   - daemonsets
   - deployments
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - validatingwebhookconfigurations
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["monitoring.googleapis.com"]
+  resources:
+  - clusterpodmonitorings
+  - clusterpodmonitorings/status
+  - clusterrules
+  - clusterrules/status
   - globalrules
   - globalrules/status
   - operatorconfigs
   - podmonitorings
   - podmonitorings/status
-  - clusterpodmonitorings
-  - clusterpodmonitorings/status
   - rules
   - rules/status
-  - secrets
-  - validatingwebhookconfigurations
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: gmp-system:csr-approver
-rules:
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests/approval
-  verbs:
-  - update
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - signers
-  resourceNames:
-  - kubernetes.io/kubelet-serving
-  verbs:
-  - approve
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gmp-system:operator
@@ -125,19 +105,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: gmp-system:operator
-subjects:
-- kind: ServiceAccount
-  namespace: gmp-system
-  name: operator
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: gmp-system:operator-csr
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: gmp-system:csr-approver
 subjects:
 - kind: ServiceAccount
   namespace: gmp-system

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -260,6 +260,9 @@ func (o *Operator) setupAdmissionWebhooks(ctx context.Context, ors ...metav1.Own
 			monitoringv1alpha1.PodMonitoringResource(),
 			monitoringv1alpha1.ClusterPodMonitoringResource(),
 			monitoringv1alpha1.OperatorConfigResource(),
+			monitoringv1alpha1.RulesResource(),
+			monitoringv1alpha1.ClusterRulesResource(),
+			monitoringv1alpha1.GlobalRulesResource(),
 		},
 		ors...,
 	)
@@ -283,6 +286,22 @@ func (o *Operator) setupAdmissionWebhooks(ctx context.Context, ors ...metav1.Own
 		admission.WithCustomValidator(&monitoringv1alpha1.OperatorConfig{}, &operatorConfigValidator{
 			namespace: o.opts.PublicNamespace,
 		}),
+	)
+	s.Register(
+		validatePath(monitoringv1alpha1.RulesResource()),
+		admission.WithCustomValidator(&monitoringv1alpha1.Rules{}, &rulesValidator{
+			opts: o.opts,
+		}),
+	)
+	s.Register(
+		validatePath(monitoringv1alpha1.ClusterRulesResource()),
+		admission.WithCustomValidator(&monitoringv1alpha1.ClusterRules{}, &clusterRulesValidator{
+			opts: o.opts,
+		}),
+	)
+	s.Register(
+		validatePath(monitoringv1alpha1.GlobalRulesResource()),
+		admission.WithCustomValidator(&monitoringv1alpha1.GlobalRules{}, &globalRulesValidator{}),
 	)
 	return nil
 }


### PR DESCRIPTION
Validate the various rules resources including running the upstream
validation logic on the generated result. While this doesn't yield the
best error messages, it gives the best guarantee that the result can
be picked up by the rule-evaluator.