### PR TITLE
Handle cluster location correctly

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -69,8 +69,8 @@ func main() {
 		imageRuleEvaluator = flag.String("image-rule-evaluator", operator.ImageRuleEvaluator,
 			unstableFlagHelp("Override for the container image of the rule evaluator."))
 
-		hostNetwork = flag.Bool("host-network", true,
-			"Whether pods are deployed with hostNetwork enabled. If true, GKE clusters with Workload Identity will not require additional permission for the components deployed by the operator. Must be false on GKE Autopilot clusters.")
+		hostNetwork = flag.Bool("host-network", false,
+			"A legacy option to deploy pods on the hostNetwork to side-step GKE Workload Identity and use the node's compute service account. No longer needed in recent GKE versions.")
 		priorityClass = flag.String("priority-class", "",
 			"Priority class at which the collector pods are run.")
 		gcmEndpoint = flag.String("cloud-monitoring-endpoint", "",

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -45,15 +45,17 @@ func main() {
 	var (
 		defaultProjectID string
 		defaultCluster   string
+		defaultLocation  string
 	)
 	if metadata.OnGCE() {
 		defaultProjectID, _ = metadata.ProjectID()
 		defaultCluster, _ = metadata.InstanceAttributeValue("cluster-name")
+		defaultLocation, _ = metadata.InstanceAttributeValue("cluster-location")
 	}
 	var (
 		logVerbosity      = flag.Int("v", 0, "Logging verbosity")
 		projectID         = flag.String("project-id", defaultProjectID, "Project ID of the cluster. May be left empty on GKE.")
-		location          = flag.String("location", "", "GCP location of the cluster. Maybe be left empty on GKE.")
+		location          = flag.String("location", defaultLocation, "GCP location of the cluster. Maybe be left empty on GKE.")
 		cluster           = flag.String("cluster", defaultCluster, "Name of the cluster the operator acts on. May be left empty on GKE.")
 		operatorNamespace = flag.String("operator-namespace", operator.DefaultOperatorNamespace,
 			"Namespace in which the operator manages its resources.")

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -204,6 +204,7 @@ func generateRules(apiRules *monitoringv1alpha1.Rules, opts Options) (string, er
 	if err := rules.Scope(&rs, map[string]string{
 		export.KeyProjectID: opts.ProjectID,
 		export.KeyCluster:   opts.Cluster,
+		export.KeyLocation:  opts.Location,
 		export.KeyNamespace: apiRules.Namespace,
 	}); err != nil {
 		return "", errors.Wrap(err, "isolating rules failed")
@@ -222,6 +223,7 @@ func generateClusterRules(apiRules *monitoringv1alpha1.ClusterRules, opts Option
 	}
 	if err := rules.Scope(&rs, map[string]string{
 		export.KeyProjectID: opts.ProjectID,
+		export.KeyLocation:  opts.Location,
 		export.KeyCluster:   opts.Cluster,
 	}); err != nil {
 		return "", errors.Wrap(err, "isolating rules failed")


### PR DESCRIPTION
We previously incorrectly assumed we could label data in regional
cluster by the zone of the machine it originated from. That may
cause theoretical collisions however and we must always set location
to the cluster's official location.
This in practice makes our lives easier as we can simply enforce the
location label of all rule data to match the cluster location.