### PR TITLE
Add --web.external-url flag

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -56,6 +56,8 @@ var (
 	listenAddress = flag.String("web.listen-address", ":19090",
 		"Address on which to expose metrics and the query UI.")
 
+	externalURLStr = flag.String("web.external-url", "",  "The URL under which the frontend is externally reachable (for example, if it is served via a reverse proxy). Used for generating relative and absolute links back to the frontend itself. If the URL has a path portion, it will be used to prefix served HTTP endpoints. If omitted, relevant URL components will be derived automatically.")
+
 	targetURLStr = flag.String("query.target-url", fmt.Sprintf("https://monitoring.googleapis.com/v1/projects/%s/location/global/prometheus", projectIDVar),
 		fmt.Sprintf("The URL to forward authenticated requests to. (%s is replaced with the --project-id flag.)", projectIDVar))
 )
@@ -81,6 +83,12 @@ func main() {
 	targetURL, err := url.Parse(strings.ReplaceAll(*targetURLStr, projectIDVar, *projectID))
 	if err != nil {
 		level.Error(logger).Log("msg", "parsing target URL failed", "err", err)
+		os.Exit(1)
+	}
+
+	externalURL, err := url.Parse(*externalURLStr)
+	if err != nil {
+		level.Error(logger).Log("msg", "parsing external URL failed", "err", err)
 		os.Exit(1)
 	}
 
@@ -130,7 +138,7 @@ func main() {
 			fmt.Fprintf(w, "Prometheus frontend is Ready.\n")
 		})
 
-		http.Handle("/", ui.Handler())
+		http.Handle("/", ui.Handler(externalURL))
 
 		g.Add(func() error {
 			level.Info(logger).Log("msg", "Starting web server for metrics", "listen", *listenAddress)

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"path"
 
 	"github.com/prometheus/common/server"
@@ -30,11 +31,11 @@ import (
 	_ "github.com/shurcooL/vfsgen"
 )
 
-func Handler() http.Handler {
+func Handler(externalURL *url.URL) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/graph", http.StatusFound)
+		http.Redirect(w, r, path.Join(externalURL.Path, "/graph"), http.StatusFound)
 	})
 
 	// Serve UI index.


### PR DESCRIPTION
Add the flag with semantics equivalent to upstream Prometheus to
correctly redirect when running behind a reverse proxy.