### PR TITLE
Fix race condition in histogram building

### DIFF
--- a/pkg/export/bench/README.md
+++ b/pkg/export/bench/README.md
@@ -1,0 +1,38 @@
+# Benchmarking
+
+This directory contains a basic benchmarking script. It accepts a Prometheus binary
+and spins it up twice, once exporting to a fake GCM endpoint and once just doing
+regular Prometheus work.
+
+Usage:
+
+```
+PROMETHEUS=path/to/prometheus ./run.sh
+```
+
+The Prometheus binary is typically built locally against the github.com/GoogleCloudPlatform/prometheus
+repository.
+
+When the binary is built with the Go race detector enabled (`-race` compile flag), the
+load broad coverage of potential race conditions, which will be logged.
+
+## Resource usage
+
+The Prometheus server scrapse itself, which allows gauging the resource usage of the Prometheus
+binary as well as the overhead relative to a regular Prometheus server.
+
+The example app allows tweaking its flags to expose more or fewer metrics. Lowering the scrape
+interval and increasing the metrics generally provides more realistic usage estimates.
+
+To analyze resource usage, go to the UI at [localhost:9090](http://localhost:9090) and experiment
+with the common `process_*` and `go_*` metrics which inform about resource usage and runtime
+internals.
+
+One can also provide an additional other Prometheus binary for comparison, e.g. to detect
+performance regressions or improvements in the export package:
+
+```
+PROMETHEUS=path/to/new/prometheus PROMETHEUS_COMPARE=path/to/old/prometheus ./run.sh
+```
+
+The matching scrape section in the `prometheus.yml` needs to be uncommented.

--- a/pkg/export/bench/example_app.go
+++ b/pkg/export/bench/example_app.go
@@ -1,0 +1,304 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/oklog/run"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	addr           = flag.String("listen-address", ":8080", "The address to listen on for HTTP requests.")
+	cpuBurnOps     = flag.Int("cpu-burn-ops", 0, "Operatins per second burning CPU. (Used to simulate high CPU utilization. Sensible values: 0-100.)")
+	memBallastMBs  = flag.Int("memory-ballast-mbs", 0, "Megabytes of memory ballast to allocate. (Used to simulate high memory utilization.)")
+	maxCount       = flag.Int("max-count", labelCombinations, "Maximum metric instance count for all metric types.")
+	histogramCount = flag.Int("histogram-count", -1, "Number of unique instances per histogram metric.")
+	gaugeCount     = flag.Int("gauge-count", -1, "Number of unique instances per gauge metric.")
+	counterCount   = flag.Int("counter-count", -1, "Number of unique instances per counter metric.")
+	summaryCount   = flag.Int("summary-count", -1, "Number of unique instances per summary metric.")
+)
+
+var (
+	availableLabels = map[string][]string{
+		"method": []string{
+			"POST",
+			"PUT",
+			"GET",
+		},
+		"status": []string{
+			"200",
+			"300",
+			"400",
+			"404",
+			"500",
+		},
+		"path": []string{
+			"/",
+			"/index",
+			"/topics",
+			"/topics:new",
+			"/topics/<id>",
+			"/topics/<id>/comment",
+			"/topics/<id>/comment:create",
+			"/topics/<id>/comment:edit",
+			"/imprint",
+		},
+	}
+	labelCombinations = len(availableLabels["method"]) * len(availableLabels["status"]) * len(availableLabels["path"])
+)
+
+var (
+	metricIncomingRequestsPending = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "example_incoming_requests_pending",
+		},
+		[]string{"status", "method", "path"},
+	)
+	metricOutgoingRequestsPending = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "example_outgoing_requests_pending",
+		},
+		[]string{"status", "method", "path"},
+	)
+
+	metricIncomingRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "example_incoming_requests_total",
+		},
+		[]string{"status", "method", "path"},
+	)
+	metricOutgoingRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "example_outgoing_requests_total",
+		},
+		[]string{"status", "method", "path"},
+	)
+	metricIncomingRequestErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "example_incoming_request_errors_total",
+		},
+		[]string{"status", "method", "path"},
+	)
+	metricOutgoingRequestErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "example_outgoing_request_errors_total",
+		},
+		[]string{"status", "method", "path"},
+	)
+
+	metricIncomingRequestDurationHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "example_histogram_incoming_request_duration",
+			Buckets: prometheus.LinearBuckets(0, 100, 8),
+		},
+		[]string{"status", "method", "path"},
+	)
+	metricOutgoingRequestDurationHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "example_histogram_outgoing_request_duration",
+			Buckets: prometheus.LinearBuckets(0, 100, 8),
+		},
+		[]string{"status", "method", "path"},
+	)
+
+	metricIncomingRequestDurationSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "example_summary_incoming_request_duration",
+		},
+		[]string{"status", "method", "path"},
+	)
+	metricOutgoingRequestDurationSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "example_summary_outgoing_request_duration",
+		},
+		[]string{"status", "method", "path"},
+	)
+)
+
+func main() {
+	flag.Parse()
+
+	metrics := prometheus.NewRegistry()
+
+	metrics.MustRegister(
+		prometheus.NewGoCollector(),
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		metricIncomingRequestsPending,
+		metricOutgoingRequestsPending,
+		metricIncomingRequests,
+		metricOutgoingRequests,
+		metricIncomingRequestErrors,
+		metricOutgoingRequestErrors,
+		metricIncomingRequestDurationHistogram,
+		metricOutgoingRequestDurationHistogram,
+		metricIncomingRequestDurationSummary,
+		metricOutgoingRequestDurationSummary,
+	)
+
+	var memoryBallast []byte
+	allocateMemoryBallast(&memoryBallast, *memBallastMBs*1000*1000)
+
+	var g run.Group
+	{
+		// Termination handler.
+		term := make(chan os.Signal, 1)
+		cancel := make(chan struct{})
+		signal.Notify(term, os.Interrupt, syscall.SIGTERM)
+
+		g.Add(
+			func() error {
+				select {
+				case <-term:
+					log.Println("Received SIGTERM, exiting gracefully...")
+				case <-cancel:
+				}
+				return nil
+			},
+			func(err error) {
+				close(cancel)
+			},
+		)
+	}
+	{
+		server := &http.Server{Addr: *addr}
+		http.Handle("/metrics", promhttp.HandlerFor(metrics, promhttp.HandlerOpts{Registry: metrics}))
+
+		g.Add(func() error {
+			return server.ListenAndServe()
+		}, func(err error) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			server.Shutdown(ctx)
+			cancel()
+		})
+	}
+	{
+		ctx, cancel := context.WithCancel(context.Background())
+		g.Add(
+			func() error {
+				return burnCPU(ctx, *cpuBurnOps)
+			},
+			func(err error) {
+				cancel()
+			},
+		)
+	}
+	{
+		ctx, cancel := context.WithCancel(context.Background())
+		g.Add(
+			func() error {
+				return updateMetrics(ctx)
+			},
+			func(err error) {
+				cancel()
+			},
+		)
+	}
+	if err := g.Run(); err != nil {
+		log.Println("Exit with error", err)
+		os.Exit(1)
+	}
+}
+
+func allocateMemoryBallast(buf *[]byte, sz int) {
+	// Fill memory ballast. Fill it with random values so it results in actual memory usage.
+	*buf = make([]byte, sz)
+	_, err := io.ReadFull(rand.New(rand.NewSource(0)), *buf)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// burnCPU burns the given percentage of CPU of a single core.
+func burnCPU(ctx context.Context, ops int) error {
+	for {
+		// Burn some CPU proportional to the input ops.
+		// This must be fixed work, i.e. we cannot spin for a fraction of scheduling will
+		// greatly affect how many times we spin, even without high CPU utilization.
+		for i := 0; i < ops*20000000; i++ {
+		}
+
+		// Wait for some time inversely proportional to the input opts.
+		// The constants are picked empirically. Spin and wait time must both depend
+		// on the input ops for them to result in linearly scaleing CPU usage.
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(time.Duration(100-ops) * 5 * time.Millisecond):
+			// default:
+		}
+	}
+}
+
+func updateMetrics(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(100 * time.Millisecond):
+			forNumInstances(*gaugeCount, func(labels prometheus.Labels) {
+				metricIncomingRequestsPending.With(labels).Set(float64(rand.Intn(200)))
+				metricOutgoingRequestsPending.With(labels).Set(float64(rand.Intn(200)))
+			})
+			forNumInstances(*counterCount, func(labels prometheus.Labels) {
+				metricIncomingRequests.With(labels).Add(float64(rand.Intn(200)))
+				metricOutgoingRequests.With(labels).Add(float64(rand.Intn(100)))
+				metricIncomingRequestErrors.With(labels).Add(float64(rand.Intn(15)))
+				metricOutgoingRequestErrors.With(labels).Add(float64(rand.Intn(5)))
+			})
+			forNumInstances(*histogramCount, func(labels prometheus.Labels) {
+				metricIncomingRequestDurationHistogram.With(labels).Observe(rand.NormFloat64()*300 + 500)
+				metricOutgoingRequestDurationHistogram.With(labels).Observe(rand.NormFloat64()*200 + 300)
+			})
+			forNumInstances(*summaryCount, func(labels prometheus.Labels) {
+				metricIncomingRequestDurationSummary.With(labels).Observe(rand.NormFloat64()*300 + 500)
+				metricOutgoingRequestDurationSummary.With(labels).Observe(rand.NormFloat64()*200 + 300)
+			})
+		}
+	}
+}
+
+func forNumInstances(c int, f func(prometheus.Labels)) {
+	if c < 0 {
+		c = *maxCount
+	}
+	for _, path := range availableLabels["path"] {
+		for _, status := range availableLabels["status"] {
+			for _, method := range availableLabels["method"] {
+				if c <= 0 {
+					return
+				}
+				f(prometheus.Labels{
+					"path":   path,
+					"status": status,
+					"method": method,
+				})
+				c--
+			}
+		}
+	}
+}

--- a/pkg/export/bench/prometheus.yaml
+++ b/pkg/export/bench/prometheus.yaml
@@ -1,0 +1,60 @@
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+global:
+  scrape_interval: 1s
+  scrape_timeout: 1s
+  external_labels:
+    location: europe
+scrape_configs:
+- job_name: 'prometheus'
+  scrape_interval: 5s
+  static_configs:
+  - targets:
+    - '127.0.0.1:9090'
+- job_name: 'prometheus-noexport'
+  scrape_interval: 5s
+  static_configs:
+  - targets:
+    - '127.0.0.1:9091'
+# Uncomment if running a comparison benchmark:
+#
+# - job_name: 'prometheus-compare'
+#   scrape_interval: 5s
+#   static_configs:
+#   - targets:
+#     - '127.0.0.1:9092'
+- job_name: 'server'
+  scrape_interval: 5s
+  static_configs:
+  - targets:
+    - '127.0.0.1:10002'
+- job_name: "example-1"
+  static_configs:
+  - targets: ['127.0.0.1:8080']
+    labels:
+      replica: "1"
+  - targets: ['127.0.0.1:8080']
+    labels:
+      replica: "2"
+  - targets: ['127.0.0.1:8080']
+    labels:
+      replica: "3"
+  - targets: ['127.0.0.1:8080']
+    labels:
+      replica: "4"
+  - targets: ['127.0.0.1:8080']
+    labels:
+      replica: "5"

--- a/pkg/export/bench/run.sh
+++ b/pkg/export/bench/run.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo $PROMETHEUS
+
+PROMETHEUS=$( realpath "${PROMETHEUS}" )
+
+if [ -n "${PROMETHEUS_COMPARE}" ]; then
+  PROMETHEUS_COMPARE=$( realpath "${PROMETHEUS_COMPARE}" )
+fi
+
+pushd "$( dirname "${BASH_SOURCE[0]}" )"
+trap 'kill 0' SIGTERM
+
+rm -rf data1 data2 data3
+
+echo "Starting example metrics application"
+
+go run example_app.go 2>&1 | sed -e "s/^/[example-app] /" &
+
+echo "Starting fake GCM endpoint"
+
+go run server.go --latency=100ms 2>&1 | sed -e "s/^/[server] /" &
+
+sleep 2
+
+common_flags="\
+--config.file=prometheus.yaml \
+--export.debug.disable-auth \
+--export.endpoint=localhost:10001 \
+--export.label.project-id=gpe-test-1 \
+--export.label.location=europe-west1-b \
+--export.label.cluster=test-1 \
+--storage.tsdb.min-block-duration=1h \
+--storage.tsdb.retention=4h \
+"
+
+echo "Starting Prometheus "
+
+${PROMETHEUS} \
+  ${common_flags} \
+  --storage.tsdb.path=data1 \
+  --web.listen-address="0.0.0.0:9090" \
+  2>&1 | sed -e "s/^/[prometheus] /" &
+
+echo "Starting non-exporting Prometheus "
+
+${PROMETHEUS} \
+  ${common_flags} \
+  --export.disable \
+  --storage.tsdb.path=data2 \
+  --web.listen-address="0.0.0.0:9091" \
+  2>&1 | sed -e "s/^/[prometheus-noexport] /" &
+
+
+if [ -n "${PROMETHEUS_COMPARE}" ]; then
+  echo "Starting comparison Prometheus"
+  
+  ${PROMETHEUS_COMPARE} \
+    ${common_flags} \
+    --storage.tsdb.path=data3 \
+    --web.listen-address="0.0.0.0:9092" \
+    2>&1 | sed -e "s/^/[prometheus-compare] /" &
+fi
+
+wait
+popd

--- a/pkg/export/bench/server.go
+++ b/pkg/export/bench/server.go
@@ -1,0 +1,73 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"net/http"
+	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
+	"time"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	monitoring_pb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	var (
+		listenAddress  = flag.String("listen-address", ":10001", "The address to listen on for HTTP requests.")
+		metricsAddress = flag.String("metrics-address", ":10002", "The address to listen on for Prometheus metrics requests.")
+		backendLatency = flag.Duration("latency", 100*time.Millisecond, "The latency of the CreateTimeSeries requests as a Go duration")
+	)
+	flag.Parse()
+	listener, err := net.Listen("tcp", *listenAddress)
+	if err != nil {
+		log.Fatalln("failed to listen on primary port:", err)
+	}
+	grpc_prometheus.EnableHandlingTimeHistogram()
+
+	srv := grpc.NewServer(
+		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
+		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+	)
+	monitoring_pb.RegisterMetricServiceServer(srv, &server{latency: *backendLatency})
+
+	grpc_prometheus.Register(srv)
+	http.Handle("/metrics", promhttp.Handler())
+
+	go func() {
+		log.Fatal(http.ListenAndServe(*metricsAddress, nil))
+	}()
+
+	if err := srv.Serve(listener); err != nil {
+		log.Fatalln("failed to server:", err)
+	}
+}
+
+type server struct {
+	monitoring_pb.MetricServiceServer
+	latency time.Duration
+}
+
+func (srv *server) CreateTimeSeries(_ context.Context, req *monitoring_pb.CreateTimeSeriesRequest) (*empty.Empty, error) {
+	l := srv.latency
+	time.Sleep(time.Duration(l))
+	return &empty.Empty{}, nil
+}

--- a/pkg/export/transform.go
+++ b/pkg/export/transform.go
@@ -312,10 +312,11 @@ func (d *distribution) build(lset labels.Labels) (*distribution_pb.Distribution,
 	// with only a subset of buckets.
 	sort.Sort(d)
 
-	// Reuse slices we already populated to build final bounds and values.
+	// Populate new values and bounds slices for the final proto as d will be returned to
+	// the memory pool while the proto will be enqueued for sending.
 	var (
-		bounds               = d.bounds[:0]
-		values               = d.values[:0]
+		bounds               = make([]float64, 0, len(d.bounds))
+		values               = make([]int64, 0, len(d.values))
 		prevBound, dev, mean float64
 		prevVal              int64
 	)


### PR DESCRIPTION
The histograms used slices for bounds and values in the proto that were
originally allocated for a memory-pooled intermediate struct. The struct
is returned to the pool before the proto is sent.
Thus the next histogram overwrites the slices concurrently. Allocating
unique slices for the proto solves the issue.