### PR TITLE
Explicit node type selector for windows/arm nodes

### DIFF
--- a/examples/prometheus.yaml
+++ b/examples/prometheus.yaml
@@ -72,6 +72,9 @@ spec:
         app: prometheus
         prometheus: test
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
       - name: prometheus
         image: gke.gcr.io/prometheus-engine/prometheus:v2.28.1-gmp.5-gke.0


### PR DESCRIPTION
Update example to support heterogenous on prem clusters that may have windows/arm64 nodes.