### PR TITLE
Minimize permissions

### DIFF
--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -33,20 +33,56 @@ rules:
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: gmp-system
+  name: operator
+rules:
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["create", "patch", "update"]
+  resourceNames:
+  - collection
+  - rules
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["create", "patch", "update"]
+  resourceNames:
+  - collector
+  - rule-evaluator
+  - rules-generated
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  verbs: ["create", "patch", "update"]
+  resourceNames:
+  - collector
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  verbs: ["create", "patch", "update"]
+  resourceNames:
+  - rule-evaluator
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gmp-system:operator
 rules:
+# The following read permissions are cluster-wide even though they could be namespace-constrained
+# as the controller-runtime library does not allow mixing cluster-wide and namespaced watches.
 - apiGroups: [""]
   resources:
   - configmaps
   - secrets
-  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources:
   - daemonsets
   - deployments
-  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  verbs: ["get", "list", "watch"]
 # Permission to inject CA bundles into webhook configs of fixed name.
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:
@@ -55,7 +91,7 @@ rules:
   resourceNames:
   - gmp-operator.gmp-system.monitoring.googleapis.com
   verbs: ["get", "patch", "update", "watch"]
-# Permission to delete legacy wehbook config the operator directly created
+# Permission to delete legacy webhook config the operator directly created
 # in previous versions.
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:

--- a/cmd/operator/deploy/operator/04-rolebinding.yaml
+++ b/cmd/operator/deploy/operator/04-rolebinding.yaml
@@ -26,6 +26,19 @@ subjects:
   name: operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: gmp-system
+  name: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator
+subjects:
+- kind: ServiceAccount
+  name: operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gmp-system:collector

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -64,6 +64,40 @@ rules:
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: gmp-system
+  name: operator
+rules:
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["create", "patch", "update"]
+  resourceNames:
+  - collection
+  - rules
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["create", "patch", "update"]
+  resourceNames:
+  - collector
+  - rule-evaluator
+  - rules-generated
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  verbs: ["create", "patch", "update"]
+  resourceNames:
+  - collector
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  verbs: ["create", "patch", "update"]
+  resourceNames:
+  - rule-evaluator
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gmp-system:operator
@@ -72,12 +106,12 @@ rules:
   resources:
   - configmaps
   - secrets
-  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources:
   - daemonsets
   - deployments
-  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:
   - validatingwebhookconfigurations
@@ -121,6 +155,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   namespace: gmp-system
+  name: operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: gmp-system
+  name: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator
+subjects:
+- kind: ServiceAccount
   name: operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Split up read and write permissions so that write permissions move to a `Role` and are thus namespaced. Also constrain to the exact resource names that are written by the operator.
Read permissions remain in `ClusterRules` so the non-namespaced watches the controller-runtime library requires us to use keep working.