### PR TITLE
Specify automount of SA token everywhere.

### DIFF
--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -38,6 +38,7 @@ spec:
         app.kubernetes.io/part-of: gmp
     spec:
       serviceAccountName: operator
+      automountServiceAccountToken: true
       containers:
       - name: operator
         image: gke.gcr.io/prometheus-engine/operator:v0.3.3-gke.0

--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -28,6 +28,7 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
     spec:
+      automountServiceAccountToken: true
       nodeSelector:
         kubernetes.io/os: linux
         kubernetes.io/arch: amd64

--- a/examples/frontend.yaml
+++ b/examples/frontend.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: frontend
     spec:
+      automountServiceAccountToken: true
       nodeSelector:
         kubernetes.io/os: linux
         kubernetes.io/arch: amd64

--- a/examples/prometheus.yaml
+++ b/examples/prometheus.yaml
@@ -72,6 +72,7 @@ spec:
         app: prometheus
         prometheus: test
     spec:
+      automountServiceAccountToken: true
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux

--- a/hack/presubmit.sh
+++ b/hack/presubmit.sh
@@ -86,15 +86,16 @@ update_crdgen() {
   API_DIR=${SCRIPT_ROOT}/pkg/operator/apis/...
   CRD_DIR=${SCRIPT_ROOT}/cmd/operator/deploy/crds
 
-  # Currently this will regenerate the status section of the CRD, which is
-  # not ideal.
-  # There is an open issue: https://github.com/kubernetes-sigs/controller-tools/issues/456.
-  # Until then, we have to manually delete the status field in the generated CRD yamls.
   controller-gen crd paths=./$API_DIR output:crd:dir=$CRD_DIR
 
   CRD_YAMLS=$(find ${CRD_DIR} -iname '*.yaml' | sort)
   for i in $CRD_YAMLS; do
     sed -i '0,/---/{/---/d}' $i
+    # Currently controller-gen regenerates the status section of the CRD, which is
+    # not ideal.
+    # There is an open issue: https://github.com/kubernetes-sigs/controller-tools/issues/456.
+    # Until then, we manually delete the status field in the generated CRD yamls here.
+    sed -i '/^status:*/,$d' $i
     echo "$(cat ${SCRIPT_ROOT}/hack/boilerplate.txt)$(cat $i)" > $i
   done
 

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -162,6 +162,7 @@ spec:
         app.kubernetes.io/part-of: gmp
     spec:
       serviceAccountName: operator
+      automountServiceAccountToken: true
       containers:
       - name: operator
         image: gke.gcr.io/prometheus-engine/operator:v0.3.3-gke.0

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -61,6 +61,7 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
     spec:
+      automountServiceAccountToken: true
       nodeSelector:
         kubernetes.io/os: linux
         kubernetes.io/arch: amd64

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -43,6 +43,10 @@ import (
 	monitoringv1alpha1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1alpha1"
 )
 
+var (
+	TrueVar = true
+)
+
 func setupCollectionControllers(op *Operator) error {
 	// The singleton OperatorConfig is the request object we reconcile against.
 	objRequest := reconcile.Request{
@@ -406,8 +410,9 @@ func (r *collectionReconciler) makeCollectorDaemonSet(spec *monitoringv1alpha1.C
 						},
 					},
 				},
-				ServiceAccountName: NameCollector,
-				PriorityClassName:  r.opts.PriorityClass,
+				ServiceAccountName:           NameCollector,
+				AutomountServiceAccountToken: &TrueVar,
+				PriorityClassName:            r.opts.PriorityClass,
 			},
 		},
 	}

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -43,9 +43,9 @@ import (
 	monitoringv1alpha1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1alpha1"
 )
 
-var (
-	TrueVar = true
-)
+func ptr(b bool) *bool {
+	return &b
+}
 
 func setupCollectionControllers(op *Operator) error {
 	// The singleton OperatorConfig is the request object we reconcile against.
@@ -411,7 +411,7 @@ func (r *collectionReconciler) makeCollectorDaemonSet(spec *monitoringv1alpha1.C
 					},
 				},
 				ServiceAccountName:           NameCollector,
-				AutomountServiceAccountToken: &TrueVar,
+				AutomountServiceAccountToken: ptr(true),
 				PriorityClassName:            r.opts.PriorityClass,
 			},
 		},

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -496,9 +496,10 @@ func (r *operatorConfigReconciler) makeRuleEvaluatorDeployment(spec *monitoringv
 				// Collector service account used for K8s endpoints-based SD.
 				// TODO(pintohutch): confirm minimum serviceAccount credentials needed for rule-evaluator
 				// and create dedicated serviceAccount.
-				ServiceAccountName: NameCollector,
-				PriorityClassName:  r.opts.PriorityClass,
-				HostNetwork:        r.opts.HostNetwork,
+				ServiceAccountName:           NameCollector,
+				AutomountServiceAccountToken: &TrueVar,
+				PriorityClassName:            r.opts.PriorityClass,
+				HostNetwork:                  r.opts.HostNetwork,
 			},
 		},
 	}

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -497,7 +497,7 @@ func (r *operatorConfigReconciler) makeRuleEvaluatorDeployment(spec *monitoringv
 				// TODO(pintohutch): confirm minimum serviceAccount credentials needed for rule-evaluator
 				// and create dedicated serviceAccount.
 				ServiceAccountName:           NameCollector,
-				AutomountServiceAccountToken: &TrueVar,
+				AutomountServiceAccountToken: ptr(true),
 				PriorityClassName:            r.opts.PriorityClass,
 				HostNetwork:                  r.opts.HostNetwork,
 			},


### PR DESCRIPTION
* The motivation to make this explicitly true everywhere was the [terraform provider](https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/latest/submodules/workload-identity#inputs) for WI-enabled GKE clusters defaults `automountServiceToken=false`, which prevents images from reaching necessary GCP endpoints (i.e. monitoring API). As the pod spec `automountServiceAccountToken` field [takes precedence](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server) over the service account's field, we set it everywhere we can to ensure access.
* Also automate deletion of extra CRD status field