### PR TITLE
Refactor config generation, fix numeric port handling

### DIFF
--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -119,7 +119,10 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the port to scrape.
+                      description: Name or number of the port to scrape. If the specified
+                        port is numeric, the selected pod must either not declare
+                        any ports in its spec or declare the specified port number
+                        as well.
                       x-kubernetes-int-or-string: true
                     proxyUrl:
                       description: Proxy URL to scrape through. Encoded passwords

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -119,7 +119,10 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the port to scrape.
+                      description: Name or number of the port to scrape. If the specified
+                        port is numeric, the selected pod must either not declare
+                        any ports in its spec or declare the specified port number
+                        as well.
                       x-kubernetes-int-or-string: true
                     proxyUrl:
                       description: Proxy URL to scrape through. Encoded passwords

--- a/doc/api.md
+++ b/doc/api.md
@@ -450,7 +450,7 @@ ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| port | Name or number of the port to scrape. | intstr.IntOrString | true |
+| port | Name or number of the port to scrape. If the specified port is numeric, the selected pod must either not declare any ports in its spec or declare the specified port number as well. | intstr.IntOrString | true |
 | scheme | Protocol scheme to use to scrape. | string | false |
 | path | HTTP path to scrape metrics from. Defaults to \"/metrics\". | string | false |
 | params | HTTP GET params to use when scraping. | map[string][]string | false |

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -121,7 +121,10 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the port to scrape.
+                      description: Name or number of the port to scrape. If the specified
+                        port is numeric, the selected pod must either not declare
+                        any ports in its spec or declare the specified port number
+                        as well.
                       x-kubernetes-int-or-string: true
                     proxyUrl:
                       description: Proxy URL to scrape through. Encoded passwords
@@ -947,7 +950,10 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the port to scrape.
+                      description: Name or number of the port to scrape. If the specified
+                        port is numeric, the selected pod must either not declare
+                        any ports in its spec or declare the specified port number
+                        as well.
                       x-kubernetes-int-or-string: true
                     proxyUrl:
                       description: Proxy URL to scrape through. Encoded passwords

--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -335,35 +335,6 @@ func (status *PodMonitoringStatus) SetPodMonitoringCondition(gen int64, now meta
 const EnvVarNodeName = "NODE_NAME"
 
 func (pm *PodMonitoring) endpointScrapeConfig(index int) (*promconfig.ScrapeConfig, error) {
-	// The Prometheus configuration structs do not generally have validation methods and embed their
-	// validation logic in the UnmarshalYAML methods. To keep things reasonable we don't re-validate
-	// everything and simply do a final marshal-unmarshal cycle at the end to run all validation
-	// upstream provides at the end of this method.
-
-	// Configure how Prometheus talks to the Kubernetes API server to discover targets.
-	// This configuration is the same for all scrape jobs (esp. selectors).
-	// This ensures that Prometheus can reuse the underlying client and caches, which reduces
-	// load on the Kubernetes API server.
-	discoveryCfgs := discovery.Configs{
-		&discoverykube.SDConfig{
-			HTTPClientConfig: config.DefaultHTTPClientConfig,
-			Role:             discoverykube.RolePod,
-			// Drop all potential targets not the same node as the collector. The $(NODE_NAME) variable
-			// is interpolated by the config reloader sidecar before the config reaches the Prometheus collector.
-			// Doing it through selectors rather than relabeling should substantially reduce the client and
-			// server side load.
-			Selectors: []discoverykube.SelectorConfig{
-				{
-					Role:  discoverykube.RolePod,
-					Field: fmt.Sprintf("spec.nodeName=$(%s)", EnvVarNodeName),
-				},
-			},
-		},
-	}
-
-	ep := pm.Spec.Endpoints[index]
-
-	// TODO(freinartz): validate all generated regular expressions.
 	relabelCfgs := []*relabel.Config{
 		// Filter targets by namespace of the PodMonitoring configuration.
 		{
@@ -373,18 +344,82 @@ func (pm *PodMonitoring) endpointScrapeConfig(index int) (*promconfig.ScrapeConf
 		},
 	}
 
-	// Filter targets that belong to selected services.
+	// Filter targets that belong to selected pods.
+	selectors, err := relabelingsForSelector(pm.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	relabelCfgs = append(relabelCfgs, selectors...)
 
+	metadataLabels := map[string]struct{}{}
+	// The metadata list must be always set in general but we allow the null case
+	// for backwards compatibility and won't add any labels in that case.
+	if pm.Spec.TargetLabels.Metadata != nil {
+		for _, l := range *pm.Spec.TargetLabels.Metadata {
+			if allowed := []string{"pod", "container", "node"}; !containsString(allowed, l) {
+				return nil, errors.Errorf("metadata label %q not allowed, must be one of %v", l, allowed)
+			}
+			metadataLabels[l] = struct{}{}
+		}
+	}
+	if _, ok := metadataLabels["pod"]; ok {
+		relabelCfgs = append(relabelCfgs, &relabel.Config{
+			Action:       relabel.Replace,
+			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_name"},
+			TargetLabel:  "pod",
+		})
+	}
+	if _, ok := metadataLabels["container"]; ok {
+		relabelCfgs = append(relabelCfgs, &relabel.Config{
+			Action:       relabel.Replace,
+			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_container_name"},
+			TargetLabel:  "container",
+		})
+	}
+	if _, ok := metadataLabels["node"]; ok {
+		relabelCfgs = append(relabelCfgs, &relabel.Config{
+			Action:       relabel.Replace,
+			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_node_name"},
+			TargetLabel:  "node",
+		})
+	}
+
+	// The namespace label is always set for PodMonitorings.
+	relabelCfgs = append(relabelCfgs, &relabel.Config{
+		Action:       relabel.Replace,
+		SourceLabels: prommodel.LabelNames{"__meta_kubernetes_namespace"},
+		TargetLabel:  "namespace",
+	})
+	relabelCfgs = append(relabelCfgs, &relabel.Config{
+		Action:      relabel.Replace,
+		Replacement: pm.Name,
+		TargetLabel: "job",
+	})
+
+	return endpointScrapeConfig(
+		fmt.Sprintf("PodMonitoring/%s/%s", pm.Namespace, pm.Name),
+		pm.Spec.Endpoints[index],
+		relabelCfgs,
+		pm.Spec.TargetLabels.FromPod,
+		pm.Spec.Limits,
+	)
+}
+
+// relabelingsForSelector generates a sequence of relabeling rules that implement
+// the label selector for the meta labels produced by the Kubernetes service discovery.
+func relabelingsForSelector(selector metav1.LabelSelector) ([]*relabel.Config, error) {
 	// Simple equal matchers. Sort by keys first to ensure that generated configs are reproducible.
 	// (Go map iteration is non-deterministic.)
 	var selectorKeys []string
-	for k := range pm.Spec.Selector.MatchLabels {
+	for k := range selector.MatchLabels {
 		selectorKeys = append(selectorKeys, k)
 	}
 	sort.Strings(selectorKeys)
 
+	var relabelCfgs []*relabel.Config
+
 	for _, k := range selectorKeys {
-		re, err := relabel.NewRegexp(pm.Spec.Selector.MatchLabels[k])
+		re, err := relabel.NewRegexp(selector.MatchLabels[k])
 		if err != nil {
 			return nil, err
 		}
@@ -395,7 +430,7 @@ func (pm *PodMonitoring) endpointScrapeConfig(index int) (*promconfig.ScrapeConf
 		})
 	}
 	// Expression matchers are mapped to relabeling rules with the same behavior.
-	for _, exp := range pm.Spec.Selector.MatchExpressions {
+	for _, exp := range selector.MatchExpressions {
 		switch exp.Operator {
 		case metav1.LabelSelectorOpIn:
 			re, err := relabel.NewRegexp(strings.Join(exp.Values, "|"))
@@ -432,50 +467,30 @@ func (pm *PodMonitoring) endpointScrapeConfig(index int) (*promconfig.ScrapeConf
 		}
 	}
 
-	metadataLabels := map[string]struct{}{}
-	// The metadata list must be always set in general but we allow the null case
-	// for backwards compatibility and won't add any labels in that case.
-	if pm.Spec.TargetLabels.Metadata != nil {
-		for _, l := range *pm.Spec.TargetLabels.Metadata {
-			if allowed := []string{"pod", "container", "node"}; !containsString(allowed, l) {
-				return nil, errors.Errorf("metadata label %q not allowed, must be one of %v", l, allowed)
-			}
-			metadataLabels[l] = struct{}{}
-		}
-	}
-	if _, ok := metadataLabels["pod"]; ok {
-		relabelCfgs = append(relabelCfgs, &relabel.Config{
-			Action:       relabel.Replace,
-			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_name"},
-			TargetLabel:  "pod",
-		})
-	}
-	if _, ok := metadataLabels["container"]; ok {
-		relabelCfgs = append(relabelCfgs, &relabel.Config{
-			Action:       relabel.Replace,
-			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_container_name"},
-			TargetLabel:  "container",
-		})
-	}
-	if _, ok := metadataLabels["node"]; ok {
-		relabelCfgs = append(relabelCfgs, &relabel.Config{
-			Action:       relabel.Replace,
-			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_node_name"},
-			TargetLabel:  "node",
-		})
-	}
+	return relabelCfgs, nil
+}
 
-	// Set a clean namespace, job, and instance label that provide sufficient uniqueness.
-	relabelCfgs = append(relabelCfgs, &relabel.Config{
-		Action:       relabel.Replace,
-		SourceLabels: prommodel.LabelNames{"__meta_kubernetes_namespace"},
-		TargetLabel:  "namespace",
-	})
-	relabelCfgs = append(relabelCfgs, &relabel.Config{
-		Action:      relabel.Replace,
-		Replacement: pm.Name,
-		TargetLabel: "job",
-	})
+func endpointScrapeConfig(id string, ep ScrapeEndpoint, relabelCfgs []*relabel.Config, podLabels []LabelMapping, limits *ScrapeLimits) (*promconfig.ScrapeConfig, error) {
+	// Configure how Prometheus talks to the Kubernetes API server to discover targets.
+	// This configuration is the same for all scrape jobs (esp. selectors).
+	// This ensures that Prometheus can reuse the underlying client and caches, which reduces
+	// load on the Kubernetes API server.
+	discoveryCfgs := discovery.Configs{
+		&discoverykube.SDConfig{
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
+			Role:             discoverykube.RolePod,
+			// Drop all potential targets not the same node as the collector. The $(NODE_NAME) variable
+			// is interpolated by the config reloader sidecar before the config reaches the Prometheus collector.
+			// Doing it through selectors rather than relabeling should substantially reduce the client and
+			// server side load.
+			Selectors: []discoverykube.SelectorConfig{
+				{
+					Role:  discoverykube.RolePod,
+					Field: fmt.Sprintf("spec.nodeName=$(%s)", EnvVarNodeName),
+				},
+			},
+		},
+	}
 
 	// Filter targets by the configured port.
 	//
@@ -526,12 +541,12 @@ func (pm *PodMonitoring) endpointScrapeConfig(index int) (*promconfig.ScrapeConf
 			TargetLabel:  "__address__",
 		})
 	} else {
-		return nil, errors.New("port must be set for PodMonitoring")
+		return nil, errors.New("port must be set")
 	}
 
-	// Incorporate k8s label remappings from CRD.
-	if pCfgs, err := labelMappingRelabelConfigs(pm.Spec.TargetLabels.FromPod, "__meta_kubernetes_pod_label_"); err != nil {
-		return nil, errors.Wrap(err, "invalid PodMonitoring target labels")
+	// Add pod labels.
+	if pCfgs, err := labelMappingRelabelConfigs(podLabels, "__meta_kubernetes_pod_label_"); err != nil {
+		return nil, errors.Wrap(err, "invalid pod label mapping")
 	} else {
 		relabelCfgs = append(relabelCfgs, pCfgs...)
 	}
@@ -567,6 +582,7 @@ func (pm *PodMonitoring) endpointScrapeConfig(index int) (*promconfig.ScrapeConf
 
 	httpCfg := config.DefaultHTTPClientConfig
 	if ep.ProxyURL != "" {
+
 		proxyURL, err := url.Parse(ep.ProxyURL)
 		if err != nil {
 			return nil, errors.Wrap(err, "invalid proxy URL")
@@ -584,7 +600,7 @@ func (pm *PodMonitoring) endpointScrapeConfig(index int) (*promconfig.ScrapeConf
 	scrapeCfg := &promconfig.ScrapeConfig{
 		// Generate a job name to make it easy to track what generated the scrape configuration.
 		// The actual job label attached to its metrics is overwritten via relabeling.
-		JobName:                 fmt.Sprintf("PodMonitoring/%s/%s/%s", pm.Namespace, pm.Name, &ep.Port),
+		JobName:                 fmt.Sprintf("%s/%s", id, &ep.Port),
 		ServiceDiscoveryConfigs: discoveryCfgs,
 		MetricsPath:             metricsPath,
 		Scheme:                  ep.Scheme,
@@ -595,14 +611,16 @@ func (pm *PodMonitoring) endpointScrapeConfig(index int) (*promconfig.ScrapeConf
 		RelabelConfigs:          relabelCfgs,
 		MetricRelabelConfigs:    metricRelabelCfgs,
 	}
-	if pm.Spec.Limits != nil {
-		scrapeCfg.SampleLimit = uint(pm.Spec.Limits.Samples)
-		scrapeCfg.LabelLimit = uint(pm.Spec.Limits.Labels)
-		scrapeCfg.LabelNameLengthLimit = uint(pm.Spec.Limits.LabelNameLength)
-		scrapeCfg.LabelValueLengthLimit = uint(pm.Spec.Limits.LabelValueLength)
+	if limits != nil {
+		scrapeCfg.SampleLimit = uint(limits.Samples)
+		scrapeCfg.LabelLimit = uint(limits.Labels)
+		scrapeCfg.LabelNameLengthLimit = uint(limits.LabelNameLength)
+		scrapeCfg.LabelValueLengthLimit = uint(limits.LabelValueLength)
 	}
-	// Do a marshal/unmarshal cycle to run all upstream validation. Throw away the result
-	// to not fill in all the defaults that get set in the process.
+	// The Prometheus configuration structs do not generally have validation methods and embed their
+	// validation logic in the UnmarshalYAML methods. To keep things reasonable we don't re-validate
+	// everything and simply do a final marshal-unmarshal cycle at the end to run all validation
+	// upstream provides at the end of this method.
 	b, err := yaml.Marshal(scrapeCfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "scrape config cannot be marshalled")
@@ -615,101 +633,10 @@ func (pm *PodMonitoring) endpointScrapeConfig(index int) (*promconfig.ScrapeConf
 }
 
 func (cm *ClusterPodMonitoring) endpointScrapeConfig(index int) (*promconfig.ScrapeConfig, error) {
-	// The Prometheus configuration structs do not generally have validation methods and embed their
-	// validation logic in the UnmarshalYAML methods. To keep things reasonable we don't re-validate
-	// everything and simply do a final marshal-unmarshal cycle at the end to run all validation
-	// upstream provides at the end of this method.
-
-	// Configure how Prometheus talks to the Kubernetes API server to discover targets.
-	// This configuration is the same for all scrape jobs (esp. selectors).
-	// This ensures that Prometheus can reuse the underlying client and caches, which reduces
-	// load on the Kubernetes API server.
-	discoveryCfgs := discovery.Configs{
-		&discoverykube.SDConfig{
-			HTTPClientConfig: config.DefaultHTTPClientConfig,
-			Role:             discoverykube.RolePod,
-			// Drop all potential targets not the same node as the collector. The $(NODE_NAME) variable
-			// is interpolated by the config reloader sidecar before the config reaches the Prometheus collector.
-			// Doing it through selectors rather than relabeling should substantially reduce the client and
-			// server side load.
-			Selectors: []discoverykube.SelectorConfig{
-				{
-					Role:  discoverykube.RolePod,
-					Field: fmt.Sprintf("spec.nodeName=$(%s)", EnvVarNodeName),
-				},
-			},
-		},
-	}
-
-	ep := cm.Spec.Endpoints[index]
-
-	// TODO(freinartz): validate all generated regular expressions.
-	relabelCfgs := []*relabel.Config{
-		// Filter targets by namespace of the PodMonitoring configuration.
-		{
-			Action:       relabel.Keep,
-			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_namespace"},
-			Regex:        relabel.MustNewRegexp("(.*)"),
-		},
-	}
-
-	// Filter targets that belong to selected services.
-
-	// Simple equal matchers. Sort by keys first to ensure that generated configs are reproducible.
-	// (Go map iteration is non-deterministic.)
-	var selectorKeys []string
-	for k := range cm.Spec.Selector.MatchLabels {
-		selectorKeys = append(selectorKeys, k)
-	}
-	sort.Strings(selectorKeys)
-
-	for _, k := range selectorKeys {
-		re, err := relabel.NewRegexp(cm.Spec.Selector.MatchLabels[k])
-		if err != nil {
-			return nil, err
-		}
-		relabelCfgs = append(relabelCfgs, &relabel.Config{
-			Action:       relabel.Keep,
-			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_label_" + sanitizeLabelName(k)},
-			Regex:        re,
-		})
-	}
-	// Expression matchers are mapped to relabeling rules with the same behavior.
-	for _, exp := range cm.Spec.Selector.MatchExpressions {
-		switch exp.Operator {
-		case metav1.LabelSelectorOpIn:
-			re, err := relabel.NewRegexp(strings.Join(exp.Values, "|"))
-			if err != nil {
-				return nil, err
-			}
-			relabelCfgs = append(relabelCfgs, &relabel.Config{
-				Action:       relabel.Keep,
-				SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_label_" + sanitizeLabelName(exp.Key)},
-				Regex:        re,
-			})
-		case metav1.LabelSelectorOpNotIn:
-			re, err := relabel.NewRegexp(strings.Join(exp.Values, "|"))
-			if err != nil {
-				return nil, err
-			}
-			relabelCfgs = append(relabelCfgs, &relabel.Config{
-				Action:       relabel.Drop,
-				SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_label_" + sanitizeLabelName(exp.Key)},
-				Regex:        re,
-			})
-		case metav1.LabelSelectorOpExists:
-			relabelCfgs = append(relabelCfgs, &relabel.Config{
-				Action:       relabel.Keep,
-				SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key)},
-				Regex:        relabel.MustNewRegexp("true"),
-			})
-		case metav1.LabelSelectorOpDoesNotExist:
-			relabelCfgs = append(relabelCfgs, &relabel.Config{
-				Action:       relabel.Drop,
-				SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_labelpresent_" + sanitizeLabelName(exp.Key)},
-				Regex:        relabel.MustNewRegexp("true"),
-			})
-		}
+	// Filter targets that belong to selected pods.
+	relabelCfgs, err := relabelingsForSelector(cm.Spec.Selector)
+	if err != nil {
+		return nil, err
 	}
 
 	metadataLabels := map[string]struct{}{}
@@ -756,149 +683,19 @@ func (cm *ClusterPodMonitoring) endpointScrapeConfig(index int) (*promconfig.Scr
 		})
 	}
 
-	// Set a clean job and instance label that provide sufficient uniqueness.
 	relabelCfgs = append(relabelCfgs, &relabel.Config{
 		Action:      relabel.Replace,
 		Replacement: cm.Name,
 		TargetLabel: "job",
 	})
 
-	// Filter targets by the configured port.
-	//
-	// If a port number is configured we don't filter by the __meta_kubernetes_pod_container_port_number
-	// label but instead hardcode it into the config and rely on Prometheus' target deduplication to
-	// ensure only one final target is produced.
-	// We do this because a user may not be able to ensure that all Pods sufficiently declare ports
-	// but should still be able to enforce a specific port being scraped.
-	//
-	// This approach works in our case for two reasons:
-	//   1. if a Pod specifies no ports at all as Prometheus will still generate a single substitute target
-	//   2. we generate a scrape config for each specified endpoint and can thus safely force all candidates
-	//      to have a static port number without preventing other ports from being scraped.
-	if ep.Port.StrVal != "" {
-		portValue, err := relabel.NewRegexp(ep.Port.StrVal)
-		if err != nil {
-			return nil, errors.Wrapf(err, "invalid port name %q", ep.Port)
-		}
-		relabelCfgs = append(relabelCfgs, &relabel.Config{
-			Action:       relabel.Keep,
-			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_container_port_name"},
-			Regex:        portValue,
-		})
-		// The instance label being the pod name would be ideal UX-wise. But we cannot be certain
-		// that multiple metrics endpoints on a pod don't expose metrics with the same name. Thus
-		// we have to disambiguate along the port as well.
-		relabelCfgs = append(relabelCfgs, &relabel.Config{
-			Action:       relabel.Replace,
-			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_name", "__meta_kubernetes_pod_container_port_name"},
-			Regex:        relabel.MustNewRegexp("(.+);(.+)"),
-			Replacement:  "$1:$2",
-			TargetLabel:  "instance",
-		})
-	} else if ep.Port.IntVal != 0 {
-		relabelCfgs = append(relabelCfgs, &relabel.Config{
-			Action:       relabel.Replace,
-			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_name"},
-			Replacement:  fmt.Sprintf("$1:%d", ep.Port.IntVal),
-			TargetLabel:  "instance",
-		})
-		// If the input target was produced by a port declared in the Pod, this port number
-		// is pre-filled in the __address__ label that's actually used for scraping. Thus
-		// we need to explicitly override it.
-		relabelCfgs = append(relabelCfgs, &relabel.Config{
-			Action:       relabel.Replace,
-			SourceLabels: prommodel.LabelNames{"__meta_kubernetes_pod_ip"},
-			Replacement:  fmt.Sprintf("$1:%d", ep.Port.IntVal),
-			TargetLabel:  "__address__",
-		})
-	} else {
-		return nil, errors.New("port must be set for ClusterPodMonitoring")
-	}
-
-	// Incorporate k8s label remappings from CRD.
-	if pCfgs, err := labelMappingRelabelConfigs(cm.Spec.TargetLabels.FromPod, "__meta_kubernetes_pod_label_"); err != nil {
-		return nil, errors.Wrap(err, "invalid ClusterPodMonitoring target labels")
-	} else {
-		relabelCfgs = append(relabelCfgs, pCfgs...)
-	}
-
-	interval, err := prommodel.ParseDuration(ep.Interval)
-	if err != nil {
-		return nil, errors.Wrap(err, "invalid scrape interval")
-	}
-	timeout := interval
-	if ep.Timeout != "" {
-		timeout, err = prommodel.ParseDuration(ep.Timeout)
-		if err != nil {
-			return nil, errors.Wrap(err, "invalid scrape timeout")
-		}
-		if timeout > interval {
-			return nil, errors.Errorf("scrape timeout %v must not be greater than scrape interval %v", timeout, interval)
-		}
-	}
-
-	metricsPath := "/metrics"
-	if ep.Path != "" {
-		metricsPath = ep.Path
-	}
-
-	var metricRelabelCfgs []*relabel.Config
-	for _, r := range ep.MetricRelabeling {
-		rcfg, err := convertRelabelingRule(r)
-		if err != nil {
-			return nil, err
-		}
-		metricRelabelCfgs = append(metricRelabelCfgs, rcfg)
-	}
-
-	httpCfg := config.DefaultHTTPClientConfig
-	if ep.ProxyURL != "" {
-
-		proxyURL, err := url.Parse(ep.ProxyURL)
-		if err != nil {
-			return nil, errors.Wrap(err, "invalid proxy URL")
-		}
-		// Marshalling the config will redact the password, so we don't support those.
-		// It's not a good idea anyway and we will later support basic auth based on secrets to
-		// cover the general use case.
-		if _, ok := proxyURL.User.Password(); ok {
-			return nil, errors.New("passwords encoded in URLs are not supported")
-		}
-		// Initialize from default as encode/decode does not work correctly with the type definition.
-		httpCfg.ProxyURL.URL = proxyURL
-	}
-
-	scrapeCfg := &promconfig.ScrapeConfig{
-		// Generate a job name to make it easy to track what generated the scrape configuration.
-		// The actual job label attached to its metrics is overwritten via relabeling.
-		JobName:                 fmt.Sprintf("ClusterPodMonitoring/%s/%s", cm.Name, &ep.Port),
-		ServiceDiscoveryConfigs: discoveryCfgs,
-		MetricsPath:             metricsPath,
-		Scheme:                  ep.Scheme,
-		Params:                  ep.Params,
-		HTTPClientConfig:        httpCfg,
-		ScrapeInterval:          interval,
-		ScrapeTimeout:           timeout,
-		RelabelConfigs:          relabelCfgs,
-		MetricRelabelConfigs:    metricRelabelCfgs,
-	}
-	if cm.Spec.Limits != nil {
-		scrapeCfg.SampleLimit = uint(cm.Spec.Limits.Samples)
-		scrapeCfg.LabelLimit = uint(cm.Spec.Limits.Labels)
-		scrapeCfg.LabelNameLengthLimit = uint(cm.Spec.Limits.LabelNameLength)
-		scrapeCfg.LabelValueLengthLimit = uint(cm.Spec.Limits.LabelValueLength)
-	}
-	// Do a marshal/unmarshal cycle to run all upstream validation. Throw away the result
-	// to not fill in all the defaults that get set in the process.
-	b, err := yaml.Marshal(scrapeCfg)
-	if err != nil {
-		return nil, errors.Wrap(err, "scrape config cannot be marshalled")
-	}
-	var scrapeCfgCopy promconfig.ScrapeConfig
-	if err := yaml.Unmarshal(b, &scrapeCfgCopy); err != nil {
-		return nil, errors.Wrap(err, "invalid scrape configuration")
-	}
-	return scrapeCfg, nil
+	return endpointScrapeConfig(
+		fmt.Sprintf("ClusterPodMonitoring/%s", cm.Name),
+		cm.Spec.Endpoints[index],
+		relabelCfgs,
+		cm.Spec.TargetLabels.FromPod,
+		cm.Spec.Limits,
+	)
 }
 
 // convertRelabelingRule converts the rule to a relabel configuration. An error is returned

--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -516,12 +516,13 @@ func endpointScrapeConfig(id string, ep ScrapeEndpoint, relabelCfgs []*relabel.C
 	} else if ep.Port.IntVal != 0 {
 		// Prometheus produces a target candidate for each declared port in a pod. If a pod
 		// has no declared ports, a single candidate without port info is generated.
-		// Some users do not declare ports but expect PodMonitoring's to work with a numeric port
+		// Some users do not declare ports but expect PodMonitorings to work with a numeric port
 		// specified nonetheless.
 		//
-		// We can support this by hard-overriding the address with the respective numeric port. If a pod
-		// has multiple declared ports that will produce multiple identical targets from the candidates. If
-		// the container metadata label is added however, they may differ by the `container` target label
+		// We could support this by hard-overriding the address with the configured PodMonitoring
+		// numeric port. As a result, a pod with multiple declared ports will produce multiple
+		// identical targets from the candidates.
+		// If the container metadata label is added however, they may differ by the `container` target label
 		// and not be deduplicated. This will cause the same endpoint to be scraped as different targets.
 		// Thus, we must still filter by numeric port IFF the target candidate does contain port info.
 		//
@@ -880,6 +881,8 @@ type ClusterPodMonitoringSpec struct {
 // ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.
 type ScrapeEndpoint struct {
 	// Name or number of the port to scrape.
+	// If the specified port is numeric, the selected pod must either not declare any
+	// ports in its spec or declare the specified port number as well.
 	Port intstr.IntOrString `json:"port"`
 	// Protocol scheme to use to scrape.
 	Scheme string `json:"scheme,omitempty"`

--- a/pkg/operator/apis/monitoring/v1alpha1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types_test.go
@@ -638,6 +638,9 @@ relabel_configs:
 - target_label: job
   replacement: name1
   action: replace
+- source_labels: [__meta_kubernetes_pod_container_port_number]
+  regex: (8080)?
+  action: keep
 - source_labels: [__meta_kubernetes_pod_name]
   target_label: instance
   replacement: $1:8080
@@ -800,6 +803,9 @@ relabel_configs:
 - target_label: job
   replacement: name1
   action: replace
+- source_labels: [__meta_kubernetes_pod_container_port_number]
+  regex: (8080)?
+  action: keep
 - source_labels: [__meta_kubernetes_pod_name]
   target_label: instance
   replacement: $1:8080

--- a/pkg/operator/apis/monitoring/v1alpha1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types_test.go
@@ -203,7 +203,7 @@ func TestValidatePodMonitoringCommon(t *testing.T) {
 			},
 			fail:        true,
 			errContains: `regex n?amespace would drop at least one of the protected labels project_id, location, cluster, namespace, job, instance, __address__`,
-		},  {
+		}, {
 			desc: "metric relabeling: labeldrop default regex",
 			eps: []ScrapeEndpoint{
 				{
@@ -218,7 +218,7 @@ func TestValidatePodMonitoringCommon(t *testing.T) {
 			},
 			fail:        true,
 			errContains: `regex  would drop at least one of the protected labels project_id, location, cluster, namespace, job, instance, __address__`,
-		},  {
+		}, {
 			desc: "metric relabeling: labelkeep default regex",
 			eps: []ScrapeEndpoint{
 				{
@@ -745,9 +745,6 @@ label_value_length_limit: 4
 follow_redirects: true
 relabel_configs:
 - source_labels: [__meta_kubernetes_namespace]
-  regex: (.*)
-  action: keep
-- source_labels: [__meta_kubernetes_namespace]
   target_label: namespace
   action: replace
 - target_label: job
@@ -797,9 +794,6 @@ label_value_length_limit: 4
 proxy_url: http://foo.bar/test
 follow_redirects: true
 relabel_configs:
-- source_labels: [__meta_kubernetes_namespace]
-  regex: (.*)
-  action: keep
 - source_labels: [__meta_kubernetes_namespace]
   target_label: namespace
   action: replace

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -40,8 +40,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	monitoringv1alpha1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1alpha1"
 	export "github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
+	monitoringv1alpha1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1alpha1"
 )
 
 func ptr(b bool) *bool {
@@ -268,11 +268,7 @@ func (r *collectionReconciler) makeCollectorDaemonSet(spec *monitoringv1alpha1.C
 	for _, matcher := range spec.Filter.MatchOneOf {
 		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.match=%s", matcher))
 	}
-	if r.opts.Mode != "" {
-		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.user-agent=prometheus-engine-export/%s prometheus-collector/%s (mode:%s)", export.Version, CollectorVersion, r.opts.Mode))
-	} else {
-		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.user-agent=prometheus-engine-export/%s prometheus-collector/%s", export.Version, CollectorVersion))
-	}
+	collectorArgs = append(collectorArgs, fmt.Sprintf("--export.user-agent=prometheus-engine-export/%s prometheus-collector/%s (mode:%s)", export.Version, CollectorVersion, r.opts.Mode))
 
 	ds := appsv1.DaemonSetSpec{
 		Selector: &metav1.LabelSelector{

--- a/pkg/operator/e2e/context.go
+++ b/pkg/operator/e2e/context.go
@@ -113,6 +113,7 @@ func newTestContext(t *testing.T) *testContext {
 		PublicNamespace:   tctx.pubNamespace,
 		PriorityClass:     "gmp-critical",
 		ListenAddr:        ":8443",
+		Mode:              "kubectl",
 	})
 	if err != nil {
 		t.Fatalf("instantiating operator: %s", err)

--- a/pkg/operator/e2e/main_test.go
+++ b/pkg/operator/e2e/main_test.go
@@ -352,6 +352,7 @@ func testRuleEvaluatorDeployment(ctx context.Context, t *testContext) {
 				fmt.Sprintf("--export.label.location=%s", location),
 				fmt.Sprintf("--export.label.cluster=%s", cluster),
 				fmt.Sprintf("--query.project-id=%s", projectID),
+				"--export.user-agent=prometheus-engine-export/0.3.3 rule-evaluator/0.3.3 (mode:kubectl)",
 			}
 			if skipGCM {
 				wantArgs = append(wantArgs, "--export.disable")
@@ -553,6 +554,7 @@ func testCollectorDeployed(ctx context.Context, t *testContext) {
 				fmt.Sprintf("--export.label.cluster=%s", cluster),
 				"--export.match={job='foo'}",
 				"--export.match={__name__=~'up'}",
+				"--export.user-agent=prometheus-engine-export/0.3.3 prometheus-collector/2.28.1-gmp.7 (mode:kubectl)",
 			}
 			if skipGCM {
 				wantArgs = append(wantArgs, "--export.disable")

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"strings"
 
+	export "github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
 	monitoringv1alpha1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -46,7 +47,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	export "github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
 )
 
 // Base resource names which may be used for multiple different resource kinds
@@ -321,12 +321,8 @@ func (r *operatorConfigReconciler) makeRuleEvaluatorDeployment(spec *monitoringv
 	if r.opts.CloudMonitoringEndpoint != "" {
 		evaluatorArgs = append(evaluatorArgs, fmt.Sprintf("--export.endpoint=%s", r.opts.CloudMonitoringEndpoint))
 	}
+	evaluatorArgs = append(evaluatorArgs, fmt.Sprintf("--export.user-agent=prometheus-engine-export/%s rule-evaluator/%s (mode:%s)", export.Version, export.Version, r.opts.Mode))
 
-	if r.opts.Mode != "" {
-		evaluatorArgs = append(evaluatorArgs, fmt.Sprintf("--export.user-agent=prometheus-engine-export/%s rule-evaluator/%s (mode:%s)", export.Version, CollectorVersion, r.opts.Mode))
-	} else {
-		evaluatorArgs = append(evaluatorArgs, fmt.Sprintf("--export.user-agent=prometheus-engine-export/%s rule-evaluator/%s", export.Version, CollectorVersion))
-	}
 	// If no explicit project ID is set, use the one provided to the operator. On GKE the rule-evaluator
 	// can also auto-detect the cluster's project but this won't work in other Kubernetes environments.
 	queryProjectID := r.opts.ProjectID


### PR DESCRIPTION
The fix of numeric port handling may make certain configurations that worked before no longer work.
This is a necessary part of the bug fix unfortunately and we'll need to mention it in the release notes.