### PR TITLE
[DRAFT] Create DaemonSet externally and inject config

### DIFF
--- a/cmd/operator/deploy/operator/10-collector.yaml
+++ b/cmd/operator/deploy/operator/10-collector.yaml
@@ -1,0 +1,147 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License. 
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: gmp-system
+  name: collector
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: collector
+  template:
+    metadata:
+      annotations:
+        components.gke.io/component-name: managed_prometheus
+      labels:
+        app: managed-prometheus-collector
+        app.kubernetes.io/name: collector
+    spec:
+      containers:
+      - name: prometheus
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.28.1-gmp.7-gke.0
+        # Do NOT set args. They are set by the operator.
+        args:
+        - --config.file=/prometheus/config_out/config.yaml
+        - --storage.tsdb.path=/prometheus/data
+        - --storage.tsdb.no-lockfile
+        - --storage.tsdb.retention.time=30m
+        - --storage.tsdb.wal-compression
+        - --storage.tsdb.min-block-duration=10m
+        - --storage.tsdb.max-block-duration=10m
+        - --web.listen-address=:19090
+        - --web.enable-lifecycle
+        - --web.route-prefix=/
+        # Some flag values should be set by the operator. To be explicit about which ones those are
+        # we set flags here and the operator injects the required environment variables.
+        - --export.label.project-id=$(PROJECT_ID)
+        - --export.label.location=$(LOCATION)
+        - --export.label.cluster=$(CLUSTER)
+        env:
+        - name: GOGC
+          value: "25"
+        ports:
+        - containerPort: 19090
+          hostPort: 19090
+          name: prom-metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 19090
+            scheme: HTTP
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 19090
+            scheme: HTTP
+        resources:
+          limits:
+            memory: 3G
+          requests:
+            cpu: 100m
+            memory: 200M
+        volumeMounts:
+        - name: storage
+          mountPath: /prometheus/data
+        - name: config-out
+          mountPath: /prometheus/config_out
+          readOnly: true
+        - name: rules-secret
+          mountPath: /etc/secrets
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          capabilities:
+            drop:
+            - all
+          runAsUser: 1000
+          runAsGroup: 1000
+      - name: config-reloader
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.3.3-gke.0
+        args:
+        - --config-file=/prometheus/config/config.yaml
+        - --config-file-output=/prometheus/config_out/config.yaml
+        - --reload-url=http://localhost:19090/-/reload
+        - --listen-address=:19091
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        ports:
+        - name: cfg-rel-metrics
+          containerPort: 19091
+        resources:
+          limits:
+            memory: 32M
+          requests:
+            cpu: 5m
+            memory: 16M
+        volumeMounts:
+        - name: config
+          mountPath: /prometheus/config
+          readOnly: true
+        - name: config-out
+          mountPath: /prometheus/config_out
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          capabilities:
+            drop:
+            - all
+          runAsUser: 1000
+          runAsGroup: 1000
+      serviceAccountName: collector
+      automountServiceAccountToken: true
+      priorityClassName: gmp-critical
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - name: storage
+        emptyDir: {}
+      - name: config
+        configMap:
+          name: collector
+      - name: config-out
+        emptyDir: {}
+      - name: rules-secret
+        secret:
+          secretName: collection

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -16,8 +16,6 @@ package operator
 
 import (
 	"context"
-	"fmt"
-	"path"
 	"sort"
 
 	"github.com/go-logr/logr"
@@ -28,11 +26,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	export "github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
 	monitoringv1alpha1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1alpha1"
 )
 
@@ -193,253 +188,45 @@ func (r *collectionReconciler) ensureCollectorSecrets(ctx context.Context, spec 
 	return nil
 }
 
-// ensureCollectorDaemonSet generates the collector daemon set and creates or updates it.
+// ensureCollectorDaemonSet populates the collector DaemonSet with operator-provided values.
 func (r *collectionReconciler) ensureCollectorDaemonSet(ctx context.Context, spec *monitoringv1alpha1.CollectionSpec) error {
-	ds := r.makeCollectorDaemonSet(spec)
-
-	if err := r.client.Update(ctx, ds); apierrors.IsNotFound(err) {
-		if err := r.client.Create(ctx, ds); err != nil {
-			return errors.Wrap(err, "create collector DaemonSet")
+	var ds appsv1.DaemonSet
+	err := r.client.Get(ctx, client.ObjectKey{Namespace: r.opts.OperatorNamespace, Name: NameCollector}, &ds)
+	// Some users deliberately not want to run the collectors. Only emit a warning but don't cause
+	// retries as this logic gets re-triggered anyway if the DaemonSet is created later.
+	if apierrors.IsNotFound(err) {
+		logr.FromContext(ctx).Error(err, "collector DaemonSet does not exist")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	// Update the envvars that are expected by externally-provided the DaemonSet.
+	vars := map[string]string{
+		"PROJECT_ID": r.opts.ProjectID,
+		"LOCATION":   r.opts.Location,
+		"CLUSTER":    r.opts.Cluster,
+	}
+	for i, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name != "prometheus" {
+			continue
 		}
-	} else if err != nil {
-		return errors.Wrap(err, "update collector DaemonSet")
-	}
-	return nil
-}
+		var repl []corev1.EnvVar
 
-func (r *collectionReconciler) makeCollectorDaemonSet(spec *monitoringv1alpha1.CollectionSpec) *appsv1.DaemonSet {
-	// TODO(freinartz): this just fills in the bare minimum to get semantics right.
-	// Add more configuration of a full deployment: tolerations, resource request/limit,
-	// health checks, priority context, security context, dynamic update strategy params...
+		// Retain existing vars not controlled by the operator.
+		for _, ev := range c.Env {
+			if _, ok := vars[ev.Name]; !ok {
+				repl = append(repl, ev)
+			}
+		}
+		// Append vars controlled by the operator.
+		for k, v := range vars {
+			repl = append(repl, corev1.EnvVar{Name: k, Value: v})
+		}
 
-	// DO NOT MODIFY - label selectors are immutable by the Kubernetes API.
-	// see: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#label-selector-updates.
-	podLabelSelector := map[string]string{
-		LabelAppName: NameCollector,
+		ds.Spec.Template.Spec.Containers[i].Env = repl
 	}
-	podLabels := map[string]string{
-		LabelAppName:      NameCollector,
-		KubernetesAppName: CollectorAppName,
-	}
-
-	podAnnotations := map[string]string{
-		AnnotationMetricName: componentName,
-	}
-
-	collectorArgs := []string{
-		fmt.Sprintf("--config.file=%s", path.Join(configOutDir, configFilename)),
-		fmt.Sprintf("--storage.tsdb.path=%s", storageDir),
-		"--storage.tsdb.no-lockfile",
-		// Keep 30 minutes of data. As we are backed by an emptyDir volume, this will count towards
-		// the containers memory usage. We could lower it further if this becomes problematic, but
-		// it the window for local data is quite convenient for debugging.
-		"--storage.tsdb.retention.time=30m",
-		"--storage.tsdb.wal-compression",
-		// Effectively disable compaction and make blocks short enough so that our retention window
-		// can be kept in practice.
-		"--storage.tsdb.min-block-duration=10m",
-		"--storage.tsdb.max-block-duration=10m",
-		fmt.Sprintf("--web.listen-address=:%d", r.opts.CollectorPort),
-		"--web.enable-lifecycle",
-		"--web.route-prefix=/",
-	}
-
-	// Check for explicitly-set pass-through args.
-	if r.opts.ProjectID != "" {
-		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.label.project-id=%s", r.opts.ProjectID))
-	}
-	if r.opts.Location != "" {
-		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.label.location=%s", r.opts.Location))
-	}
-	if r.opts.Cluster != "" {
-		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.label.cluster=%s", r.opts.Cluster))
-	}
-	if r.opts.DisableExport {
-		collectorArgs = append(collectorArgs, "--export.disable")
-	}
-	if r.opts.CloudMonitoringEndpoint != "" {
-		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.endpoint=%s", r.opts.CloudMonitoringEndpoint))
-	}
-	if spec.Credentials != nil {
-		p := path.Join(secretsDir, pathForSelector(r.opts.PublicNamespace, &monitoringv1alpha1.SecretOrConfigMap{Secret: spec.Credentials}))
-		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.credentials-file=%s", p))
-	}
-	// Populate export filtering from OperatorConfig.
-	for _, matcher := range spec.Filter.MatchOneOf {
-		collectorArgs = append(collectorArgs, fmt.Sprintf("--export.match=%s", matcher))
-	}
-	collectorArgs = append(collectorArgs, fmt.Sprintf("--export.user-agent=prometheus-engine-export/%s prometheus-collector/%s (mode:%s)", export.Version, CollectorVersion, r.opts.Mode))
-
-	ds := appsv1.DaemonSetSpec{
-		Selector: &metav1.LabelSelector{
-			MatchLabels: podLabelSelector,
-		},
-		Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels:      podLabels,
-				Annotations: podAnnotations,
-			},
-			Spec: corev1.PodSpec{
-				// We want to run on every node, even with taints present.
-				Tolerations: []corev1.Toleration{
-					{Effect: "NoExecute", Operator: "Exists"},
-					{Effect: "NoSchedule", Operator: "Exists"},
-				},
-				// The managed collection binaries are only being built for
-				// amd64 arch on Linux.
-				NodeSelector: map[string]string{
-					corev1.LabelOSStable:   "linux",
-					corev1.LabelArchStable: "amd64",
-				},
-				Containers: []corev1.Container{
-					{
-						Name:  "prometheus",
-						Image: r.opts.ImageCollector,
-						// Set an aggressive GC threshold (default is 100%). Since the collector has a lot of
-						// long-lived allocations, this still doesn't result in a high GC rate (compared to stateless
-						// RPC applications) and gives us a more balanced ratio of memory and CPU usage.
-						Env: []corev1.EnvVar{
-							{Name: "GOGC", Value: "25"},
-						},
-						Args: collectorArgs,
-						Ports: []corev1.ContainerPort{
-							{Name: "prom-metrics", ContainerPort: r.opts.CollectorPort},
-						},
-						LivenessProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path: "/-/healthy",
-									Port: intstr.FromInt(int(r.opts.CollectorPort)),
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path: "/-/ready",
-									Port: intstr.FromInt(int(r.opts.CollectorPort)),
-								},
-							},
-						},
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      storageVolumeName,
-								MountPath: storageDir,
-							}, {
-								Name:      configOutVolumeName,
-								MountPath: configOutDir,
-								ReadOnly:  true,
-							}, {
-								Name:      secretVolumeName,
-								MountPath: secretsDir,
-								ReadOnly:  true,
-							},
-						},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    *resource.NewScaledQuantity(100, resource.Milli),
-								corev1.ResourceMemory: *resource.NewScaledQuantity(200, resource.Mega),
-							},
-							// Set no limit on CPU as it's a throttled resource.
-							Limits: corev1.ResourceList{
-								corev1.ResourceMemory: *resource.NewScaledQuantity(3000, resource.Mega),
-							},
-						},
-						SecurityContext: minimalSecurityContext(),
-					}, {
-						Name:  "config-reloader",
-						Image: r.opts.ImageConfigReloader,
-						Args: []string{
-							fmt.Sprintf("--config-file=%s", path.Join(configDir, configFilename)),
-							fmt.Sprintf("--config-file-output=%s", path.Join(configOutDir, configFilename)),
-							fmt.Sprintf("--reload-url=http://localhost:%d/-/reload", r.opts.CollectorPort),
-							fmt.Sprintf("--listen-address=:%d", r.opts.CollectorPort+1),
-						},
-						// Pass node name so the config can filter for targets on the local node,
-						Env: []corev1.EnvVar{
-							{
-								Name: monitoringv1alpha1.EnvVarNodeName,
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "spec.nodeName",
-									},
-								},
-							},
-						},
-						Ports: []corev1.ContainerPort{
-							{Name: "cfg-rel-metrics", ContainerPort: r.opts.CollectorPort + 1},
-						},
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      configVolumeName,
-								MountPath: configDir,
-								ReadOnly:  true,
-							}, {
-								Name:      configOutVolumeName,
-								MountPath: configOutDir,
-							},
-						},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    *resource.NewScaledQuantity(5, resource.Milli),
-								corev1.ResourceMemory: *resource.NewScaledQuantity(16, resource.Mega),
-							},
-							// Set no limit on CPU as it's a throttled resource.
-							Limits: corev1.ResourceList{
-								corev1.ResourceMemory: *resource.NewScaledQuantity(32, resource.Mega),
-							},
-						},
-						SecurityContext: minimalSecurityContext(),
-					},
-				},
-				Volumes: []corev1.Volume{
-					{
-						Name: storageVolumeName,
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{},
-						},
-					}, {
-						Name: configVolumeName,
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: NameCollector,
-								},
-							},
-						},
-					}, {
-						Name: configOutVolumeName,
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{},
-						},
-					}, {
-						// Mirrored config secrets (config specified as filepaths).
-						Name: secretVolumeName,
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: CollectionSecretName,
-							},
-						},
-					},
-				},
-				ServiceAccountName:           NameCollector,
-				AutomountServiceAccountToken: ptr(true),
-				PriorityClassName:            r.opts.PriorityClass,
-			},
-		},
-	}
-	// DNS policy should be set explicitly when using hostNetwork.
-	if r.opts.HostNetwork {
-		ds.Template.Spec.HostNetwork = true
-		ds.Template.Spec.DNSPolicy = "ClusterFirstWithHostNet"
-	}
-	return &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: r.opts.OperatorNamespace,
-			Name:      NameCollector,
-		},
-		Spec: ds,
-	}
+	return r.client.Update(ctx, &ds)
 }
 
 // ensureCollectorConfig generates the collector config and creates or updates it.


### PR DESCRIPTION
Change to an approach where the collector DaemonSet is provided
externally within the operator installation bundle. The operator then
only updates runtime-dependent values into the DaemonSet.
This allows users to do advanced customization (node affinity, priority
class, etc.) without the need for configuration knobs through the
OperatorConfig or operator flags.

This approach would be extended to the rule evaluator deployment if accepted.