### PR TITLE
Fix RBAC by removing resourceNames

### DIFF
--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -42,29 +42,18 @@ rules:
   resources:
   - secrets
   verbs: ["create", "patch", "update"]
-  resourceNames:
-  - collection
-  - rules
 - apiGroups: [""]
   resources:
   - configmaps
   verbs: ["create", "patch", "update"]
-  resourceNames:
-  - collector
-  - rule-evaluator
-  - rules-generated
 - apiGroups: ["apps"]
   resources:
   - daemonsets
   verbs: ["create", "patch", "update"]
-  resourceNames:
-  - collector
 - apiGroups: ["apps"]
   resources:
   - deployments
   verbs: ["create", "patch", "update"]
-  resourceNames:
-  - rule-evaluator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -72,29 +72,18 @@ rules:
   resources:
   - secrets
   verbs: ["create", "patch", "update"]
-  resourceNames:
-  - collection
-  - rules
 - apiGroups: [""]
   resources:
   - configmaps
   verbs: ["create", "patch", "update"]
-  resourceNames:
-  - collector
-  - rule-evaluator
-  - rules-generated
 - apiGroups: ["apps"]
   resources:
   - daemonsets
   verbs: ["create", "patch", "update"]
-  resourceNames:
-  - collector
 - apiGroups: ["apps"]
   resources:
   - deployments
   verbs: ["create", "patch", "update"]
-  resourceNames:
-  - rule-evaluator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/pkg/operator/apis/monitoring/v1alpha1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types_test.go
@@ -203,7 +203,7 @@ func TestValidatePodMonitoringCommon(t *testing.T) {
 			},
 			fail:        true,
 			errContains: `regex n?amespace would drop at least one of the protected labels project_id, location, cluster, namespace, job, instance, __address__`,
-		},  {
+		}, {
 			desc: "metric relabeling: labeldrop default regex",
 			eps: []ScrapeEndpoint{
 				{
@@ -218,7 +218,7 @@ func TestValidatePodMonitoringCommon(t *testing.T) {
 			},
 			fail:        true,
 			errContains: `regex  would drop at least one of the protected labels project_id, location, cluster, namespace, job, instance, __address__`,
-		},  {
+		}, {
 			desc: "metric relabeling: labelkeep default regex",
 			eps: []ScrapeEndpoint{
 				{

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -40,8 +40,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	monitoringv1alpha1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1alpha1"
 	export "github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
+	monitoringv1alpha1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1alpha1"
 )
 
 func ptr(b bool) *bool {

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"strings"
 
+	export "github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
 	monitoringv1alpha1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -46,7 +47,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	export "github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
 )
 
 // Base resource names which may be used for multiple different resource kinds


### PR DESCRIPTION
I noticed that a from-scratch kubectl install from `main` was throwing a lot of permissions issues. For example:
```
"level":"error","ts":1650043097.3943744,"logger":"controller.rules","msg":"Reconciler error","reconciler group":"monitoring.googleapis.com","reconciler kind":"OperatorConfig","name":"config","namespace":"gmp-public","error":"ensure rule configmaps: create generated rules: configmaps is forbidden: User \"system:serviceaccount:gmp-system:operator\" cannot create resource \"configmaps\" in API group \"\" in the namespace \"gmp-system\"","errorVerbose":"configmaps is forbidden: User \"system:serviceaccount:gmp-system:operator\" cannot create resource \"configmaps\" in API group \"\" in the namespace \"gmp-system\"\ncreate generated rules\ngithub.com/GoogleCloudPlatform/prometheus-engine/pkg/operator.(*rulesReconciler).ensureRuleConfigs\n\t/app/pkg/operator/rules.go:191\ngithub.com/GoogleCloudPlatform/prometheus-engine/pkg/operator.(*rulesReconciler).Reconcile\n\t/app/pkg/operator/rules.go:112
```

It turns out that using `resourceNames` with the `create` verb is ineffective. As a result, it seems these policy rules were dropped. From https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources:

> Note: You cannot restrict create or deletecollection requests by their resource name. For create, this limitation is because the name of the new object may not be known at authorization time. If you restrict list or watch by resourceName, clients must include a metadata.name field selector in their list or watch request that matches the specified resourceName in order to be authorized. For example, kubectl get configmaps --field-selector=metadata.name=my-configmap

I removed the `resourceNames` altogether and the operator was able to resume normal behavior.