### PR TITLE
add build badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![GoDoc](https://pkg.go.dev/badge/github.com/GoogleCloudPlatform/prometheus-engine?status.svg)](https://pkg.go.dev/github.com/GoogleCloudPlatform/prometheus-engine?tab=doc)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/GoogleCloudPlatform/prometheus-engine)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+![Build status](https://github.com/GoogleCloudPlatform/prometheus-engine/actions/workflows/presubmit.yml/badge.svg)
+
 
 This repository contains various binaries and packages for client-side usage
 of Google Cloud Managed Service for Prometheus (GMP), a managed Prometheus offering on top


### PR DESCRIPTION
The badge can be seen [here](https://github.com/GoogleCloudPlatform/prometheus-engine/tree/pintohutch/build-badge). Screenshot below:
![3GmcFi5o4Mv7GER](https://user-images.githubusercontent.com/3731548/165827273-dab64604-5ce2-4a5b-8ffe-24e005e21734.png)

