### PR TITLE
Use port 10250 for admission webhooks

### DIFF
--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -48,6 +48,7 @@ spec:
         - "--image-collector=gke.gcr.io/prometheus-engine/prometheus:v2.28.1-gmp.7-gke.0"
         - "--image-config-reloader=gke.gcr.io/prometheus-engine/config-reloader:v0.4.0-gke.0"
         - "--image-rule-evaluator=gke.gcr.io/prometheus-engine/rule-evaluator:v0.4.0-gke.0"
+        - "--webhook-addr=:10250"
         ports:
         - name: webhook
           # Note this should match the --listen-addr flag passed in to the operator args.

--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -51,8 +51,8 @@ spec:
         ports:
         - name: webhook
           # Note this should match the --listen-addr flag passed in to the operator args.
-          # Default is 8443.
-          containerPort: 8443
+          # Default is 10250.
+          containerPort: 10250
         - name: metrics
           # Note this should match the --metrics-addr flag passed in to the operator args.
           # Default is 18080.

--- a/cmd/operator/deploy/operator/06-service.yaml
+++ b/cmd/operator/deploy/operator/06-service.yaml
@@ -24,5 +24,5 @@ spec:
     app.kubernetes.io/part-of: gmp
   ports:
   - protocol: TCP
-    port: 8443
+    port: 10250
     targetPort: webhook

--- a/cmd/operator/deploy/operator/08-validatingwebhookconfiguration.yaml
+++ b/cmd/operator/deploy/operator/08-validatingwebhookconfiguration.yaml
@@ -26,7 +26,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/podmonitorings
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -48,7 +48,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/clusterpodmonitorings
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -70,7 +70,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/rules
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -92,7 +92,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/clusterrules
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -114,7 +114,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/globalrules
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -136,7 +136,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/operatorconfigs
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:

--- a/cmd/operator/deploy/operator/09-mutatingwebhookconfiguration.yaml
+++ b/cmd/operator/deploy/operator/09-mutatingwebhookconfiguration.yaml
@@ -26,7 +26,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /default/monitoring.googleapis.com/v1/podmonitorings
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -48,7 +48,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /default/monitoring.googleapis.com/v1/clusterpodmonitorings
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -78,7 +78,7 @@ func main() {
 		tlsCert     = flag.String("tls-cert-base64", "", "The base64-encoded TLS certificate.")
 		tlsKey      = flag.String("tls-key-base64", "", "The base64-encoded TLS key.")
 		caCert      = flag.String("ca-cert-base64", "", "The base64-encoded certificate authority.")
-		webhookAddr = flag.String("webhook-addr", ":8443",
+		webhookAddr = flag.String("webhook-addr", ":10250",
 			"Address to listen to for incoming kube admission webhook connections.")
 		metricsAddr = flag.String("metrics-addr", ":18080", "Address to emit metrics on.")
 

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -207,6 +207,7 @@ spec:
         - "--image-collector=gke.gcr.io/prometheus-engine/prometheus:v2.28.1-gmp.7-gke.0"
         - "--image-config-reloader=gke.gcr.io/prometheus-engine/config-reloader:v0.4.0-gke.0"
         - "--image-rule-evaluator=gke.gcr.io/prometheus-engine/rule-evaluator:v0.4.0-gke.0"
+        - "--webhook-addr=:10250"
         ports:
         - name: webhook
           # Note this should match the --listen-addr flag passed in to the operator args.

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -210,8 +210,8 @@ spec:
         ports:
         - name: webhook
           # Note this should match the --listen-addr flag passed in to the operator args.
-          # Default is 8443.
-          containerPort: 8443
+          # Default is 10250.
+          containerPort: 10250
         - name: metrics
           # Note this should match the --metrics-addr flag passed in to the operator args.
           # Default is 18080.
@@ -237,7 +237,7 @@ spec:
     app.kubernetes.io/part-of: gmp
   ports:
   - protocol: TCP
-    port: 8443
+    port: 10250
     targetPort: webhook
 ---
 apiVersion: monitoring.googleapis.com/v1
@@ -260,7 +260,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/podmonitorings
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -282,7 +282,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/clusterpodmonitorings
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -304,7 +304,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/rules
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -326,7 +326,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/clusterrules
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -348,7 +348,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/globalrules
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -370,7 +370,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/operatorconfigs
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -398,7 +398,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /default/monitoring.googleapis.com/v1/podmonitorings
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -420,7 +420,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /default/monitoring.googleapis.com/v1/clusterpodmonitorings
-      port: 8443
+      port: 10250
   failurePolicy: Fail
   sideEffects: None
   rules:


### PR DESCRIPTION
This enables managed collection to work seamlessly on private GKE clusters with the [default firewall rules](https://cloud.google.com/kubernetes-engine/docs/concepts/firewall-rules#cluster-fws).

Note: for users upgrading using `kubectl` manually, a few attempts may be necessary as the operator is redeployed and the web server becomes available.