### PR TITLE
Fix numerical port behavior

### DIFF
--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -119,10 +119,9 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the port to scrape. If the specified
-                        port is numeric, the selected pod must either not declare
-                        any ports in its spec or declare the specified port number
-                        as well.
+                      description: Name or number of the port to scrape. The container
+                        metadata label is only populated if the port is referenced
+                        by name because port numbers are not unique across containers.
                       x-kubernetes-int-or-string: true
                     proxyUrl:
                       description: Proxy URL to scrape through. Encoded passwords
@@ -235,10 +234,11 @@ spec:
                     description: Pod metadata labels that are set on all scraped targets.
                       Permitted keys are `pod`, `container`, and `node` for PodMonitoring
                       and `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring.
-                      Defaults to [pod, container] for PodMonitoring and [namespace,
-                      pod, container] for ClusterPodMonitoring. If set to null, it
-                      will be interpreted as the empty list for PodMonitoring and
-                      to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
+                      The `container` label is only populated if the scrape port is
+                      referenced by name. Defaults to [pod, container] for PodMonitoring
+                      and [namespace, pod, container] for ClusterPodMonitoring. If
+                      set to null, it will be interpreted as the empty list for PodMonitoring
+                      and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
                       only.
                     items:
                       type: string

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -119,10 +119,9 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the port to scrape. If the specified
-                        port is numeric, the selected pod must either not declare
-                        any ports in its spec or declare the specified port number
-                        as well.
+                      description: Name or number of the port to scrape. The container
+                        metadata label is only populated if the port is referenced
+                        by name because port numbers are not unique across containers.
                       x-kubernetes-int-or-string: true
                     proxyUrl:
                       description: Proxy URL to scrape through. Encoded passwords
@@ -235,10 +234,11 @@ spec:
                     description: Pod metadata labels that are set on all scraped targets.
                       Permitted keys are `pod`, `container`, and `node` for PodMonitoring
                       and `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring.
-                      Defaults to [pod, container] for PodMonitoring and [namespace,
-                      pod, container] for ClusterPodMonitoring. If set to null, it
-                      will be interpreted as the empty list for PodMonitoring and
-                      to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
+                      The `container` label is only populated if the scrape port is
+                      referenced by name. Defaults to [pod, container] for PodMonitoring
+                      and [namespace, pod, container] for ClusterPodMonitoring. If
+                      set to null, it will be interpreted as the empty list for PodMonitoring
+                      and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
                       only.
                     items:
                       type: string

--- a/doc/api.md
+++ b/doc/api.md
@@ -466,7 +466,7 @@ ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| port | Name or number of the port to scrape. If the specified port is numeric, the selected pod must either not declare any ports in its spec or declare the specified port number as well. | intstr.IntOrString | true |
+| port | Name or number of the port to scrape. The container metadata label is only populated if the port is referenced by name because port numbers are not unique across containers. | intstr.IntOrString | true |
 | scheme | Protocol scheme to use to scrape. | string | false |
 | path | HTTP path to scrape metrics from. Defaults to \"/metrics\". | string | false |
 | params | HTTP GET params to use when scraping. | map[string][]string | false |
@@ -533,7 +533,7 @@ TargetLabels configures labels for the discovered Prometheus targets.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| metadata | Pod metadata labels that are set on all scraped targets. Permitted keys are `pod`, `container`, and `node` for PodMonitoring and `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring. Defaults to [pod, container] for PodMonitoring and [namespace, pod, container] for ClusterPodMonitoring. If set to null, it will be interpreted as the empty list for PodMonitoring and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility only. | *[]string | false |
+| metadata | Pod metadata labels that are set on all scraped targets. Permitted keys are `pod`, `container`, and `node` for PodMonitoring and `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring. The `container` label is only populated if the scrape port is referenced by name. Defaults to [pod, container] for PodMonitoring and [namespace, pod, container] for ClusterPodMonitoring. If set to null, it will be interpreted as the empty list for PodMonitoring and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility only. | *[]string | false |
 | fromPod | Labels to transfer from the Kubernetes Pod to Prometheus target labels. Mappings are applied in order. | [][LabelMapping](#labelmapping) | false |
 
 [Back to TOC](#table-of-contents)

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -121,10 +121,9 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the port to scrape. If the specified
-                        port is numeric, the selected pod must either not declare
-                        any ports in its spec or declare the specified port number
-                        as well.
+                      description: Name or number of the port to scrape. The container
+                        metadata label is only populated if the port is referenced
+                        by name because port numbers are not unique across containers.
                       x-kubernetes-int-or-string: true
                     proxyUrl:
                       description: Proxy URL to scrape through. Encoded passwords
@@ -237,10 +236,11 @@ spec:
                     description: Pod metadata labels that are set on all scraped targets.
                       Permitted keys are `pod`, `container`, and `node` for PodMonitoring
                       and `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring.
-                      Defaults to [pod, container] for PodMonitoring and [namespace,
-                      pod, container] for ClusterPodMonitoring. If set to null, it
-                      will be interpreted as the empty list for PodMonitoring and
-                      to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
+                      The `container` label is only populated if the scrape port is
+                      referenced by name. Defaults to [pod, container] for PodMonitoring
+                      and [namespace, pod, container] for ClusterPodMonitoring. If
+                      set to null, it will be interpreted as the empty list for PodMonitoring
+                      and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
                       only.
                     items:
                       type: string
@@ -1723,10 +1723,9 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the port to scrape. If the specified
-                        port is numeric, the selected pod must either not declare
-                        any ports in its spec or declare the specified port number
-                        as well.
+                      description: Name or number of the port to scrape. The container
+                        metadata label is only populated if the port is referenced
+                        by name because port numbers are not unique across containers.
                       x-kubernetes-int-or-string: true
                     proxyUrl:
                       description: Proxy URL to scrape through. Encoded passwords
@@ -1839,10 +1838,11 @@ spec:
                     description: Pod metadata labels that are set on all scraped targets.
                       Permitted keys are `pod`, `container`, and `node` for PodMonitoring
                       and `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring.
-                      Defaults to [pod, container] for PodMonitoring and [namespace,
-                      pod, container] for ClusterPodMonitoring. If set to null, it
-                      will be interpreted as the empty list for PodMonitoring and
-                      to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
+                      The `container` label is only populated if the scrape port is
+                      referenced by name. Defaults to [pod, container] for PodMonitoring
+                      and [namespace, pod, container] for ClusterPodMonitoring. If
+                      set to null, it will be interpreted as the empty list for PodMonitoring
+                      and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
                       only.
                     items:
                       type: string

--- a/pkg/operator/apis/monitoring/v1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1/types_test.go
@@ -658,9 +658,8 @@ relabel_configs:
   target_label: __tmp_instance
   replacement: $1
   action: replace
-- source_labels: [__meta_kubernetes_pod_container_port_number]
-  regex: (8080)?
-  action: keep
+- regex: container
+  action: labeldrop
 - source_labels: [__tmp_instance]
   target_label: instance
   replacement: $1:8080
@@ -845,9 +844,8 @@ relabel_configs:
   target_label: __tmp_instance
   replacement: $1
   action: replace
-- source_labels: [__meta_kubernetes_pod_container_port_number]
-  regex: (8080)?
-  action: keep
+- regex: container
+  action: labeldrop
 - source_labels: [__tmp_instance]
   target_label: instance
   replacement: $1:8080


### PR DESCRIPTION
When a scrape port is specified by number no longer generate a container
label to rely on Prmetheus' target deduplication behavior to ensure the
port is scraped exactly once whether it is declared in the Pod or not.