### PR TITLE
Use port 443 for webhook (operator) service

### DIFF
--- a/cmd/operator/deploy/operator/06-service.yaml
+++ b/cmd/operator/deploy/operator/06-service.yaml
@@ -24,5 +24,5 @@ spec:
     app.kubernetes.io/part-of: gmp
   ports:
   - protocol: TCP
-    port: 10250
+    port: 443
     targetPort: webhook

--- a/cmd/operator/deploy/operator/08-validatingwebhookconfiguration.yaml
+++ b/cmd/operator/deploy/operator/08-validatingwebhookconfiguration.yaml
@@ -26,7 +26,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/podmonitorings
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -48,7 +48,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/clusterpodmonitorings
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -70,7 +70,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/rules
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -92,7 +92,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/clusterrules
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -114,7 +114,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/globalrules
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -136,7 +136,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/operatorconfigs
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:

--- a/cmd/operator/deploy/operator/09-mutatingwebhookconfiguration.yaml
+++ b/cmd/operator/deploy/operator/09-mutatingwebhookconfiguration.yaml
@@ -26,7 +26,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /default/monitoring.googleapis.com/v1/podmonitorings
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -48,7 +48,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /default/monitoring.googleapis.com/v1/clusterpodmonitorings
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -238,7 +238,7 @@ spec:
     app.kubernetes.io/part-of: gmp
   ports:
   - protocol: TCP
-    port: 10250
+    port: 443
     targetPort: webhook
 ---
 apiVersion: monitoring.googleapis.com/v1
@@ -261,7 +261,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/podmonitorings
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -283,7 +283,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/clusterpodmonitorings
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -305,7 +305,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/rules
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -327,7 +327,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/clusterrules
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -349,7 +349,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/globalrules
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -371,7 +371,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /validate/monitoring.googleapis.com/v1/operatorconfigs
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -399,7 +399,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /default/monitoring.googleapis.com/v1/podmonitorings
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:
@@ -421,7 +421,7 @@ webhooks:
       namespace: gmp-system
       name: gmp-operator
       path: /default/monitoring.googleapis.com/v1/clusterpodmonitorings
-      port: 10250
+      port: 443
   failurePolicy: Fail
   sideEffects: None
   rules:

--- a/pkg/operator/e2e/context.go
+++ b/pkg/operator/e2e/context.go
@@ -103,7 +103,7 @@ func newTestContext(t *testing.T) *testContext {
 		OperatorNamespace: tctx.namespace,
 		PublicNamespace:   tctx.pubNamespace,
 		PriorityClass:     "gmp-critical",
-		ListenAddr:        ":8443",
+		ListenAddr:        ":10250",
 		Mode:              "kubectl",
 	})
 	if err != nil {


### PR DESCRIPTION
This is more to follow convention. This is typical of workloads running on GKE clusters.