### PR TITLE
prometheus-adapter HPA example

### DIFF
--- a/examples/hpa/README.md
+++ b/examples/hpa/README.md
@@ -1,0 +1,29 @@
+# prometheus-adapter example instructions
+1. Setup managed-collection on cluster.
+1. Deploy the [frontend](../frontend.yaml).
+1. Install prometheus-adapter on cluster using instructions from
+   the deployment [README](https://github.com/kubernetes-sigs/prometheus-adapter/blob/9008b12a0173e2604e794c1614081b63c17e0340/deploy/README.md).
+1. Deploy the manifests in this directory, which include:
+    * `prometheus-example-app` deployment and service to emit metrics.
+    * PodMonitoring to scrape `prometheus-example-app`.
+    * HorizonalPodAutoscaler to scale workload.
+    * Overwrite for `adapter-config` ConfigMap to expose `http_requests_per_second` to the custom metrics API.
+1. Edit the `custom-metrics-apiserver` Deployment to change the Prometheus URL arg to:
+    ```
+    - --prometheus-url=http://frontend.default.svc:9090/
+    ```
+1. In separate terminal sessions:
+    * Generate http load against `prometheus-example-app` service:
+    ```
+    kubectl run -i --tty load-generator --rm --image=busybox:1.28 --restart=Never -- /bin/sh -c "while sleep 0.01; do wget -q -O- http://prometheus-example-app; done"
+    ```
+    * Watch horizontal pod autoscaler:
+    ```
+    kubectl get hpa prometheus-example-app --watch
+    ```
+    * Watch workload scale up:
+    ```
+    kubectl get po -lapp.kubernetes.io/name=prometheus-example-app --watch
+    ```
+
+1. Stop http load generation via Ctrl+C and watch workload scale back down.

--- a/examples/hpa/cm.yaml
+++ b/examples/hpa/cm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/examples/hpa/cm.yaml
+++ b/examples/hpa/cm.yaml
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: adapter-config
+  namespace: custom-metrics
+data:
+  config.yaml: |
+    rules:
+    - seriesQuery: 'http_requests_total'
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: "^(.*)_total$"
+        as: "${1}_per_second"
+      metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)'

--- a/examples/hpa/example-app.yaml
+++ b/examples/hpa/example-app.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/hpa/example-app.yaml
+++ b/examples/hpa/example-app.yaml
@@ -1,0 +1,48 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus-example-app
+  name: prometheus-example-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-example-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus-example-app
+    spec:
+      containers:
+      - name: prometheus-example-app
+        image: quay.io/brancz/prometheus-example-app:v0.3.0
+        ports:
+        - name: web
+          containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-example-app
+spec:
+  selector:
+    app.kubernetes.io/name: prometheus-example-app
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: web

--- a/examples/hpa/hpa.yaml
+++ b/examples/hpa/hpa.yaml
@@ -1,0 +1,34 @@
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: prometheus-example-app
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: prometheus-example-app
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Pods
+    pods:
+      metric:
+        name: http_requests_per_second
+      target:
+        type: AverageValue
+        averageValue: 10

--- a/examples/hpa/hpa.yaml
+++ b/examples/hpa/hpa.yaml
@@ -1,5 +1,4 @@
-
-# Copyright 2022 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/hpa/pod-monitoring.yaml
+++ b/examples/hpa/pod-monitoring.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/hpa/pod-monitoring.yaml
+++ b/examples/hpa/pod-monitoring.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: prometheus-example-app
+  labels:
+    app.kubernetes.io/name: prometheus-example-app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-example-app
+  endpoints:
+  - port: web
+    interval: 30s


### PR DESCRIPTION
Some example manifests for how to enable prometheus-adapter-powered HPA using GMP data.