### PR TITLE
Add cluster autoscaler annotation to allow safe eviction of collector and rule evaluators

### DIFF
--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -229,6 +229,10 @@ func (r *collectionReconciler) makeCollectorDaemonSet(spec *monitoringv1.Collect
 
 	podAnnotations := map[string]string{
 		AnnotationMetricName: componentName,
+		// Allow cluster autoscaler to evict collector Pods even though the Pods
+		// have an emptyDir volume mounted. This is okay since the node where the
+		// Pod runs will be scaled down and therefore does not need metrics reporting.
+		ClusterAutoscalerSafeEvictionLabel: "true",
 	}
 
 	collectorArgs := []string{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -72,6 +72,10 @@ const (
 	LabelAppName = "app.kubernetes.io/name"
 	// The component name, will be exposed as metric name.
 	AnnotationMetricName = "components.gke.io/component-name"
+	// ClusterAutoscalerSafeEvictionLabel is the annotation label that determines
+	// whether the cluster autoscaler can safely evict a Pod when the Pod doesn't
+	// satisfy certain eviction criteria.
+	ClusterAutoscalerSafeEvictionLabel = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 
 	// The official images to be used with this version of the operator. For debugging
 	// and emergency use cases they may be overwritten through options.

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -79,6 +79,10 @@ func rulesLabels() map[string]string {
 func rulesAnnotations() map[string]string {
 	return map[string]string{
 		AnnotationMetricName: componentName,
+		// Allow cluster autoscaler to evict evaluator Pods even though the Pods
+		// have an emptyDir volume mounted. This is okay since the node where the
+		// Pod runs will be scaled down.
+		ClusterAutoscalerSafeEvictionLabel: "true",
 	}
 }
 


### PR DESCRIPTION
cc/ @pintohutch

This PR adds the necessary annotation to allow autoscaler to evict collectors and rule evaluators when downsizing a cluster.