### PR TITLE
make CPU limits configurable

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -85,10 +85,14 @@ func main() {
 		collectorMemoryResource = flag.Int64("collector-memory-resource", 200, "The Memory Resource of collector pod, in mega bytes")
 		collectorMemoryLimit    = flag.Int64("collector-memory-limit", 3000, "The Memory Limit of collector pod, in mega bytes.")
 		collectorCPUResource    = flag.Int64("collector-cpu-resource", 100, "The CPU Resource of collector pod, in milli cpu.")
+		collectorCPULimit       = flag.Int64("collector-cpu-limit", -1,
+			"The CPU Limit of collector pod, in milli cpu. If negative, a limit will not be specified")
 		evaluatorMemoryResource = flag.Int64("evaluator-memory-resource", 200, "The Memory Resource of evaluator pod, in mega bytes.")
 		evaluatorMemoryLimit    = flag.Int64("evaluator-memory-limit", 1000, "The Memory Limit of evaluator pod, in mega bytesv.")
 		evaluatorCPUResource    = flag.Int64("evaluator-cpu-resource", 100, "The CPU Resource of evaluator pod, in milli cpu.")
-		mode                    = flag.String("mode", "kubectl", "how managed collection was provisioned.")
+		evaluatorCPULimit       = flag.Int64("evaluator-cpu-limit", -1,
+			"The CPU Resource of evaluator pod, in milli cpu. If negative, a limit will not be specified.")
+		mode = flag.String("mode", "kubectl", "how managed collection was provisioned.")
 	)
 	flag.Parse()
 
@@ -126,7 +130,9 @@ func main() {
 		CollectorMemoryResource: *collectorMemoryResource,
 		CollectorMemoryLimit:    *collectorMemoryLimit,
 		CollectorCPUResource:    *collectorCPUResource,
+		CollectorCPULimit:       *collectorCPULimit,
 		EvaluatorCPUResource:    *evaluatorCPUResource,
+		EvaluatorCPULimit:       *evaluatorCPULimit,
 		EvaluatorMemoryResource: *evaluatorMemoryResource,
 		EvaluatorMemoryLimit:    *evaluatorMemoryLimit,
 		Mode:                    *mode,

--- a/pkg/operator/e2e/context.go
+++ b/pkg/operator/e2e/context.go
@@ -105,6 +105,8 @@ func newTestContext(t *testing.T) *testContext {
 		PriorityClass:     "gmp-critical",
 		ListenAddr:        ":10250",
 		Mode:              "kubectl",
+		CollectorCPULimit: -1,
+		EvaluatorCPULimit: -1,
 	})
 	if err != nil {
 		t.Fatalf("instantiating operator: %s", err)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -145,6 +145,8 @@ type Options struct {
 	CollectorMemoryResource int64
 	// Collector CPU resource
 	CollectorCPUResource int64
+	// Collector CPU limit
+	CollectorCPULimit int64
 	// Collector memory limit
 	CollectorMemoryLimit int64
 	// Evaluator memory resource
@@ -153,6 +155,8 @@ type Options struct {
 	EvaluatorCPUResource int64
 	// Evaluator memory limit
 	EvaluatorMemoryLimit int64
+	// Evaluator CPU limit
+	EvaluatorCPULimit int64
 	// How managed collection was provisioned.
 	Mode string
 }


### PR DESCRIPTION
For clusters that enforce resource limits on workloads. Tested manually and saw the limits set on the collectors and rule-evaluator.