### PR TITLE
Set runAsNonRoot on operator deployment spec

### DIFF
--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -66,3 +66,4 @@ spec:
             - all
           runAsUser: 1000
           runAsGroup: 1000
+          runAsNonRoot: true

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -225,6 +225,7 @@ spec:
             - all
           runAsUser: 1000
           runAsGroup: 1000
+          runAsNonRoot: true
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Following https://github.com/GoogleCloudPlatform/prometheus-engine/pull/179, set the matching `runAsNonRoot` security context on the operator pod