### PR TITLE
Allow gzip compression settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /**/node_modules/.cache
+.idea/

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_operatorconfigs.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_operatorconfigs.yaml
@@ -40,6 +40,13 @@ spec:
           collection:
             description: Collection specifies how the operator configures collection.
             properties:
+              compression:
+                description: Compression enables compression of metrics collection
+                  data
+                enum:
+                - none
+                - gzip
+                type: string
               credentials:
                 description: A reference to GCP service account credentials with which
                   Prometheus collectors are run. It needs to have metric write permissions

--- a/doc/api.md
+++ b/doc/api.md
@@ -180,6 +180,7 @@ CollectionSpec specifies how the operator configures collection of metric data.
 | filter | Filter limits which metric data is sent to Cloud Monitoring. | [ExportFilters](#exportfilters) | false |
 | credentials | A reference to GCP service account credentials with which Prometheus collectors are run. It needs to have metric write permissions for all project IDs to which data is written. Within GKE, this can typically be left empty if the compute default service account has the required permissions. | *[v1.SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core) | false |
 | kubeletScraping | Configuration to scrape the metric endpoints of the Kubelets. | *[KubeletScraping](#kubeletscraping) | false |
+| compression | Compression enables compression of metrics collection data | CompressionType | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -1013,6 +1013,13 @@ spec:
           collection:
             description: Collection specifies how the operator configures collection.
             properties:
+              compression:
+                description: Compression enables compression of metrics collection
+                  data
+                enum:
+                - none
+                - gzip
+                type: string
               credentials:
                 description: A reference to GCP service account credentials with which
                   Prometheus collectors are run. It needs to have metric write permissions

--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -103,7 +103,12 @@ type CollectionSpec struct {
 	Credentials *v1.SecretKeySelector `json:"credentials,omitempty"`
 	// Configuration to scrape the metric endpoints of the Kubelets.
 	KubeletScraping *KubeletScraping `json:"kubeletScraping,omitempty"`
+	// Compression enables compression of metrics collection data
+	Compression CompressionType `json:"compression,omitempty"`
 }
+
+// +kubebuilder:validation:Enum=none;gzip
+type CompressionType string
 
 // KubeletScraping allows enabling scraping of the Kubelets' metric endpoints.
 type KubeletScraping struct {

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -225,6 +225,10 @@ func (r *collectionReconciler) ensureCollectorDaemonSet(ctx context.Context, spe
 		flags = append(flags, fmt.Sprintf("--export.credentials-file=%q", p))
 	}
 
+	if len(spec.Compression) > 0 && spec.Compression != "none" {
+		flags = append(flags, fmt.Sprintf("--export.compression=%s", spec.Compression))
+	}
+
 	// Set EXTRA_ARGS envvar in Prometheus container.
 	for i, c := range ds.Spec.Template.Spec.Containers {
 		if c.Name != "prometheus" {


### PR DESCRIPTION
Replacing https://github.com/GoogleCloudPlatform/prometheus-engine/pull/268, following @pintohutch's suggestion:

> for this specific change, my thought would be to change the `OperatorConfig` to add a `Compression CompressionType` field to the `.CollectionSpec` and `.RuleEvaluatorSpec`, where `CompressionType` is a string enum that defaults to `"none"` but can also be `"gzip"`, and maybe other compressions in the future (e.g. snappy)