### PR TITLE
Deploy default AlertManager with operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /**/node_modules/.cache
+.idea/

--- a/cmd/operator/README.md
+++ b/cmd/operator/README.md
@@ -8,6 +8,7 @@ Cloud Prometheus Engine on Kubernetes.
 Create or update cluster resources required by the operator.
 
 ```bash
+kubectl apply -f deploy/crds/
 kubectl apply -f deploy/operator/
 ```
 

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_operatorconfigs.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_operatorconfigs.yaml
@@ -297,6 +297,11 @@ spec:
                       - port
                       type: object
                     type: array
+                  enableDefaultAlertManager:
+                    description: EnableDefaultAlertManager configures the rule-evaluator
+                      to point to a default instance of AlertManager installed by
+                      the operator.
+                    type: boolean
                 type: object
               credentials:
                 description: A reference to GCP service account credentials with which

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_operatorconfigs.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_operatorconfigs.yaml
@@ -297,8 +297,8 @@ spec:
                       - port
                       type: object
                     type: array
-                  enableDefaultAlertManager:
-                    description: EnableDefaultAlertManager configures the rule-evaluator
+                  enableManagedAlertManager:
+                    description: EnableManagedAlertManager configures the rule-evaluator
                       to point to a default instance of AlertManager installed by
                       the operator.
                     type: boolean

--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -71,6 +71,7 @@ rules:
   resources:
   - daemonsets
   - deployments
+  - statefulsets
   verbs: ["get", "list", "watch"]
 # Permission to inject CA bundles into webhook configs of fixed name.
 - apiGroups: ["admissionregistration.k8s.io"]

--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -1,0 +1,145 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: gmp-public
+  name: gmp-alertmanager
+data:
+  config.yaml: |
+    receivers:
+      - name: "noop"
+    route:
+      receiver: "noop"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: gmp-public
+  name: gmp-alertmanager
+spec:
+  selector:
+    app.kubernetes.io/name: gmp-alertmanager
+  clusterIP: None
+  ports:
+  - port: 9093
+    targetPort: 9093
+    name: alertmanager
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  namespace: gmp-public
+  name: gmp-alertmanager
+spec:
+  selector:
+    matchLabels:
+      app: managed-prometheus-alertmanager
+      app.kubernetes.io/name: gmp-alertmanager
+  serviceName: gmp-alertmanager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gmp-alertmanager
+        app: managed-prometheus-alertmanager
+      annotations:
+        components.gke.io/component-name: managed_prometheus
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    spec:
+      containers:
+      - name: alertmanager
+        image: prom/alertmanager:latest
+        args:
+        - --config.file=/alertmanager/config_out/config.yaml
+        - --storage.path=/alertmanager-data
+        ports:
+        - containerPort: 9093
+          name: alertmanager
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1G
+          requests:
+            cpu: 100m
+            memory: 200M
+        volumeMounts:
+        - name: config
+          mountPath: /alertmanager/config_out
+          readOnly: true
+        - name: alertmanager-data
+          mountPath: /alertmanager-data
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+      - name: config-reloader
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.4.1-gke.0
+        args:
+        - --config-file=/alertmanager/config.yaml
+        - --config-file-output=/alertmanager/config_out/config.yaml
+        - --reload-url=http://localhost:9093/-/reload
+        - --listen-address=:19091
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        ports:
+        - name: cfg-rel-metrics
+          containerPort: 19091
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32M
+          requests:
+            cpu: 5m
+            memory: 16M
+        volumeMounts:
+        - name: config
+          mountPath: /alertmanager
+          readOnly: true
+        - name: alertmanager-data
+          mountPath: /alertmanager/config_out
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          capabilities:
+            drop:
+            - all
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      priorityClassName: gmp-critical
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - name: config
+        configMap:
+          name: gmp-alertmanager
+      - name: alertmanager-data
+        emptyDir: {}

--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: gmp-public
-  name: gmp-alertmanager
+  name: alertmanager
 data:
   config.yaml: |
     receivers:
@@ -27,10 +27,10 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: gmp-public
-  name: gmp-alertmanager
+  name: alertmanager
 spec:
   selector:
-    app.kubernetes.io/name: gmp-alertmanager
+    app.kubernetes.io/name: alertmanager
   clusterIP: None
   ports:
   - port: 9093
@@ -41,18 +41,18 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   namespace: gmp-public
-  name: gmp-alertmanager
+  name: alertmanager
 spec:
   selector:
     matchLabels:
       app: managed-prometheus-alertmanager
-      app.kubernetes.io/name: gmp-alertmanager
-  serviceName: gmp-alertmanager
+      app.kubernetes.io/name: alertmanager
+  serviceName: alertmanager
   replicas: 1
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: gmp-alertmanager
+        app.kubernetes.io/name: alertmanager
         app: managed-prometheus-alertmanager
       annotations:
         components.gke.io/component-name: managed_prometheus
@@ -140,6 +140,6 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: gmp-alertmanager
+          name: alertmanager
       - name: alertmanager-data
         emptyDir: {}

--- a/doc/api.md
+++ b/doc/api.md
@@ -61,7 +61,7 @@ AlertingSpec defines alerting configuration.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | alertmanagers | Alertmanagers contains endpoint configuration for designated Alertmanagers. | [][AlertmanagerEndpoints](#alertmanagerendpoints) | false |
-| enableDefaultAlertManager | EnableDefaultAlertManager configures the rule-evaluator to point to a default instance of AlertManager installed by the operator. | bool | false |
+| enableManagedAlertManager | EnableManagedAlertManager configures the rule-evaluator to point to a default instance of AlertManager installed by the operator. | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -61,6 +61,7 @@ AlertingSpec defines alerting configuration.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | alertmanagers | Alertmanagers contains endpoint configuration for designated Alertmanagers. | [][AlertmanagerEndpoints](#alertmanagerendpoints) | false |
+| enableDefaultAlertManager | EnableDefaultAlertManager configures the rule-evaluator to point to a default instance of AlertManager installed by the operator. | bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -730,7 +730,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: gmp-public
-  name: gmp-alertmanager
+  name: alertmanager
 data:
   config.yaml: |
     receivers:
@@ -742,10 +742,10 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: gmp-public
-  name: gmp-alertmanager
+  name: alertmanager
 spec:
   selector:
-    app.kubernetes.io/name: gmp-alertmanager
+    app.kubernetes.io/name: alertmanager
   clusterIP: None
   ports:
   - port: 9093
@@ -756,18 +756,18 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   namespace: gmp-public
-  name: gmp-alertmanager
+  name: alertmanager
 spec:
   selector:
     matchLabels:
       app: managed-prometheus-alertmanager
-      app.kubernetes.io/name: gmp-alertmanager
-  serviceName: gmp-alertmanager
+      app.kubernetes.io/name: alertmanager
+  serviceName: alertmanager
   replicas: 1
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: gmp-alertmanager
+        app.kubernetes.io/name: alertmanager
         app: managed-prometheus-alertmanager
       annotations:
         components.gke.io/component-name: managed_prometheus
@@ -855,6 +855,6 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: gmp-alertmanager
+          name: alertmanager
       - name: alertmanager-data
         emptyDir: {}

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -99,6 +99,7 @@ rules:
   resources:
   - daemonsets
   - deployments
+  - statefulsets
   verbs: ["get", "list", "watch"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:
@@ -724,3 +725,136 @@ spec:
         secret:
           defaultMode: 420
           secretName: rules
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: gmp-public
+  name: gmp-alertmanager
+data:
+  config.yaml: |
+    receivers:
+      - name: "noop"
+    route:
+      receiver: "noop"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: gmp-public
+  name: gmp-alertmanager
+spec:
+  selector:
+    app.kubernetes.io/name: gmp-alertmanager
+  clusterIP: None
+  ports:
+  - port: 9093
+    targetPort: 9093
+    name: alertmanager
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  namespace: gmp-public
+  name: gmp-alertmanager
+spec:
+  selector:
+    matchLabels:
+      app: managed-prometheus-alertmanager
+      app.kubernetes.io/name: gmp-alertmanager
+  serviceName: gmp-alertmanager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gmp-alertmanager
+        app: managed-prometheus-alertmanager
+      annotations:
+        components.gke.io/component-name: managed_prometheus
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    spec:
+      containers:
+      - name: alertmanager
+        image: prom/alertmanager:latest
+        args:
+        - --config.file=/alertmanager/config_out/config.yaml
+        - --storage.path=/alertmanager-data
+        ports:
+        - containerPort: 9093
+          name: alertmanager
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1G
+          requests:
+            cpu: 100m
+            memory: 200M
+        volumeMounts:
+        - name: config
+          mountPath: /alertmanager/config_out
+          readOnly: true
+        - name: alertmanager-data
+          mountPath: /alertmanager-data
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+      - name: config-reloader
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.4.1-gke.0
+        args:
+        - --config-file=/alertmanager/config.yaml
+        - --config-file-output=/alertmanager/config_out/config.yaml
+        - --reload-url=http://localhost:9093/-/reload
+        - --listen-address=:19091
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        ports:
+        - name: cfg-rel-metrics
+          containerPort: 19091
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32M
+          requests:
+            cpu: 5m
+            memory: 16M
+        volumeMounts:
+        - name: config
+          mountPath: /alertmanager
+          readOnly: true
+        - name: alertmanager-data
+          mountPath: /alertmanager/config_out
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          capabilities:
+            drop:
+            - all
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      priorityClassName: gmp-critical
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - name: config
+        configMap:
+          name: gmp-alertmanager
+      - name: alertmanager-data
+        emptyDir: {}

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -1270,8 +1270,8 @@ spec:
                       - port
                       type: object
                     type: array
-                  enableDefaultAlertManager:
-                    description: EnableDefaultAlertManager configures the rule-evaluator
+                  enableManagedAlertManager:
+                    description: EnableManagedAlertManager configures the rule-evaluator
                       to point to a default instance of AlertManager installed by
                       the operator.
                     type: boolean

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -1270,6 +1270,11 @@ spec:
                       - port
                       type: object
                     type: array
+                  enableDefaultAlertManager:
+                    description: EnableDefaultAlertManager configures the rule-evaluator
+                      to point to a default instance of AlertManager installed by
+                      the operator.
+                    type: boolean
                 type: object
               credentials:
                 description: A reference to GCP service account credentials with which

--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -125,6 +125,10 @@ type ExportFilters struct {
 type AlertingSpec struct {
 	// Alertmanagers contains endpoint configuration for designated Alertmanagers.
 	Alertmanagers []AlertmanagerEndpoints `json:"alertmanagers,omitempty"`
+	// EnableDefaultAlertManager configures the rule-evaluator to point to a
+	// default instance of AlertManager installed by the operator.
+	// +kubebuilder:default=true
+	EnableDefaultAlertManager bool `json:"enableDefaultAlertManager,omitempty"`
 }
 
 // AlertmanagerEndpoints defines a selection of a single Endpoints object

--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -127,7 +127,6 @@ type AlertingSpec struct {
 	Alertmanagers []AlertmanagerEndpoints `json:"alertmanagers,omitempty"`
 	// EnableDefaultAlertManager configures the rule-evaluator to point to a
 	// default instance of AlertManager installed by the operator.
-	// +kubebuilder:default=true
 	EnableDefaultAlertManager bool `json:"enableDefaultAlertManager,omitempty"`
 }
 

--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -125,9 +125,9 @@ type ExportFilters struct {
 type AlertingSpec struct {
 	// Alertmanagers contains endpoint configuration for designated Alertmanagers.
 	Alertmanagers []AlertmanagerEndpoints `json:"alertmanagers,omitempty"`
-	// EnableDefaultAlertManager configures the rule-evaluator to point to a
+	// EnableManagedAlertManager configures the rule-evaluator to point to a
 	// default instance of AlertManager installed by the operator.
-	EnableDefaultAlertManager bool `json:"enableDefaultAlertManager,omitempty"`
+	EnableManagedAlertManager bool `json:"enableManagedAlertManager,omitempty"`
 }
 
 // AlertmanagerEndpoints defines a selection of a single Endpoints object

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -352,7 +352,7 @@ func (r *operatorConfigReconciler) makeAlertManagerConfigs(ctx context.Context, 
 	)
 
 	alertManagers := spec.Alertmanagers
-	if spec.EnableDefaultAlertManager {
+	if spec.EnableManagedAlertManager {
 		amNamespacedName := types.NamespacedName{
 			Namespace: r.opts.PublicNamespace,
 			Name:      "gmp-alertmanager",

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -354,7 +354,7 @@ func (r *operatorConfigReconciler) makeAlertManagerConfigs(ctx context.Context, 
 	alertManagers := spec.Alertmanagers
 	if spec.EnableDefaultAlertManager {
 		amNamespacedName := types.NamespacedName{
-			Namespace: r.opts.OperatorNamespace,
+			Namespace: r.opts.PublicNamespace,
 			Name:      "gmp-alertmanager",
 		}
 

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -349,7 +350,25 @@ func (r *operatorConfigReconciler) makeAlertManagerConfigs(ctx context.Context, 
 		configs    promconfig.AlertmanagerConfigs
 		secretData = make(map[string][]byte)
 	)
-	for _, am := range spec.Alertmanagers {
+
+	alertManagers := spec.Alertmanagers
+	if spec.EnableDefaultAlertManager {
+		amNamespacedName := types.NamespacedName{
+			Namespace: r.opts.OperatorNamespace,
+			Name:      "gmp-alertmanager",
+		}
+
+		// if the default AlertManager exists, append it to the list of spec.Alertmanagers
+		if resourceErr := r.client.Get(ctx, amNamespacedName, &appsv1.StatefulSet{}); resourceErr == nil {
+			alertManagers = append(alertManagers, monitoringv1.AlertmanagerEndpoints{
+				Name:      amNamespacedName.Name,
+				Namespace: amNamespacedName.Namespace,
+				Port:      intstr.FromInt(9093),
+			})
+		}
+	}
+
+	for _, am := range alertManagers {
 		// The upstream struct is lacking the omitempty field on the API version. Thus it looks
 		// like we explicitly set it to empty (invalid) even if left empty after marshalling.
 		// Thus we initialize the config with defaulting. Similar applies for the embedded HTTPConfig.


### PR DESCRIPTION
This adds a manifest for a default AlertManager instance, as well as a boolean in the OperatorConfig to enable (or disable) wiring the rule-evaluator to point to this AlertManager.