### PR TITLE
Add ListTimeSeries to the FakeMetricServer

### DIFF
--- a/pkg/e2e/fake_metric_server.go
+++ b/pkg/e2e/fake_metric_server.go
@@ -115,6 +115,7 @@ func (fms *FakeMetricServer) ListTimeSeries(ctx context.Context, req *monitoring
 	if req.View == monitoringpb.ListTimeSeriesRequest_HEADERS {
 		return nil, errors.New("header view is not supported")
 	}
+
 	// The filter string MUST be in the form:
 	//		metric.type = <string>
 	// return an error if it is not in this form
@@ -122,7 +123,15 @@ func (fms *FakeMetricServer) ListTimeSeries(ctx context.Context, req *monitoring
 	if len(filter) != 2 || strings.ToLower(strings.TrimSpace(filter[0])) != "metric.type" {
 		return nil, fmt.Errorf("filter string %q is malformed - only metric.type supported", req.Filter)
 	}
-	response := &monitoringpb.ListTimeSeriesResponse{}
 
+	var matchingTimeSeries []*monitoringpb.TimeSeries
+	for _, timeSeries := range fms.timeSeriesByProject[req.Name] {
+		if timeSeries.Metric.Type == filter[1] {
+			matchingTimeSeries = append(matchingTimeSeries, timeSeries)
+		}
+	}
+	response := &monitoringpb.ListTimeSeriesResponse{
+		TimeSeries: matchingTimeSeries,
+	}
 	return response, nil
 }

--- a/pkg/e2e/fake_metric_server.go
+++ b/pkg/e2e/fake_metric_server.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 )
@@ -72,8 +72,8 @@ func (fms *FakeMetricServer) CreateTimeSeries(ctx context.Context, req *monitori
 				toAddResource := singleTimeSeriesToAdd.Resource
 
 				// if this specific time series already exists, add it
-				if inMemMetric.Type == toAddMetric.Type && reflect.DeepEqual(inMemMetric.Labels, toAddMetric.Labels) &&
-					inMemResource.Type == toAddResource.Type && reflect.DeepEqual(inMemResource.Labels, toAddResource.Labels) {
+				if inMemMetric.Type == toAddMetric.Type && cmp.Equal(inMemMetric.Labels, toAddMetric.Labels) &&
+					inMemResource.Type == toAddResource.Type && cmp.Equal(inMemResource.Labels, toAddResource.Labels) {
 					// only add this point if the start time of the point to add is greater than the end point latest in this time series
 					if singleTimeSeriesToAdd.Points[0].Interval.StartTime.AsTime().After(singleTimeSeriesInMemory.Points[len(singleTimeSeriesInMemory.Points)-1].Interval.EndTime.AsTime()) {
 						// add the new point to the beginning

--- a/pkg/e2e/fake_metric_server.go
+++ b/pkg/e2e/fake_metric_server.go
@@ -121,7 +121,9 @@ func (fms *FakeMetricServer) ListTimeSeries(ctx context.Context, req *monitoring
 	//		metric.type = <string>
 	// return an error if it is not in this form
 	filter := strings.Split(req.Filter, "=")
-	if len(filter) != 2 || strings.ToLower(strings.TrimSpace(filter[0])) != "metric.type" {
+	filter[0] = strings.ToLower(strings.TrimSpace(filter[0]))
+	filter[1] = strings.TrimSpace(filter[1])
+	if len(filter) != 2 || filter[0] != "metric.type" {
 		return nil, fmt.Errorf("filter string %q is malformed - only metric.type supported", req.Filter)
 	}
 

--- a/pkg/e2e/fake_metric_server.go
+++ b/pkg/e2e/fake_metric_server.go
@@ -63,7 +63,7 @@ func (fms *FakeMetricServer) CreateTimeSeries(ctx context.Context, req *monitori
 	for _, singleTimeSeriesToAdd := range timeSeriesToProcess {
 		// new project with a timeseries
 		if fms.timeSeriesByProject[req.Name] == nil {
-			fms.timeSeriesByProject[req.Name] = req.TimeSeries
+			fms.timeSeriesByProject[req.Name] = []*monitoringpb.TimeSeries{singleTimeSeriesToAdd}
 		} else { // project already exists
 			for i, singleTimeSeriesInMemory := range fms.timeSeriesByProject[req.Name] {
 				inMemMetric := singleTimeSeriesInMemory.Metric

--- a/pkg/e2e/fake_metric_server.go
+++ b/pkg/e2e/fake_metric_server.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
@@ -114,7 +115,13 @@ func (fms *FakeMetricServer) ListTimeSeries(ctx context.Context, req *monitoring
 	if req.View == monitoringpb.ListTimeSeriesRequest_HEADERS {
 		return nil, errors.New("header view is not supported")
 	}
-
+	// The filter string MUST be in the form:
+	//		metric.type = <string>
+	// return an error if it is not in this form
+	filter := strings.Split(req.Filter, "=")
+	if len(filter) != 2 || strings.ToLower(strings.TrimSpace(filter[0])) != "metric.type" {
+		return nil, fmt.Errorf("filter string %q is malformed - only metric.type supported", req.Filter)
+	}
 	response := &monitoringpb.ListTimeSeriesResponse{}
 
 	return response, nil

--- a/pkg/e2e/fake_metric_server_test.go
+++ b/pkg/e2e/fake_metric_server_test.go
@@ -92,7 +92,10 @@ func TestCreateTimeSeriesBadInput(t *testing.T) {
 
 	// these are the subtests
 	tests := []*createTimeSeriesTest{
-		{testName: "TestNil"},
+		{
+			testName:                 "TestNil",
+			createTimeSeriesRequests: []*monitoringpb.CreateTimeSeriesRequest{nil},
+		},
 		{
 			testName: "TestExceedMaxTimeSeriesPerRequest",
 			createTimeSeriesRequests: []*monitoringpb.CreateTimeSeriesRequest{
@@ -335,13 +338,61 @@ func TestCreateTimeSeries(t *testing.T) {
 
 func TestListTimeSeriesBadInput(t *testing.T) {
 	fms := NewFakeMetricServer(200)
-	//projectName := "projects/1234"
+	projectName := "projects/1234"
+	filter := "metric.type = prometheus_target"
 
 	// these are the subtests
 	tests := []*listTimeSeriesTest{
 		{
 			testName:               "TestListTimeSeriesNilRequest",
 			listTimeSeriesRequests: []*monitoringpb.ListTimeSeriesRequest{nil},
+		},
+		{},
+		{
+			testName: "TestListTimeSeriesAggregation",
+			listTimeSeriesRequests: []*monitoringpb.ListTimeSeriesRequest{
+				{
+					Name:        projectName,
+					Aggregation: &monitoringpb.Aggregation{},
+					Filter:      filter,
+				},
+			},
+		},
+		{
+			testName: "TestListTimeSeriesNoInterval",
+			listTimeSeriesRequests: []*monitoringpb.ListTimeSeriesRequest{
+				{
+					Name:   projectName,
+					Filter: filter,
+				},
+			},
+		},
+		{
+			testName: "TestListTimeSeriesHeadersView",
+			listTimeSeriesRequests: []*monitoringpb.ListTimeSeriesRequest{
+				{
+					Name:   projectName,
+					Filter: filter,
+					Interval: &monitoringpb.TimeInterval{
+						StartTime: &timestamppb.Timestamp{Seconds: 1},
+						EndTime:   &timestamppb.Timestamp{Seconds: 2},
+					},
+					View: monitoringpb.ListTimeSeriesRequest_HEADERS,
+				},
+			},
+		},
+		{
+			testName: "TestListTimeSeriesMalformedFilter",
+			listTimeSeriesRequests: []*monitoringpb.ListTimeSeriesRequest{
+				{
+					Name:   projectName,
+					Filter: "metric.type = prometheus-target AND metric.labels.location = europe",
+					Interval: &monitoringpb.TimeInterval{
+						StartTime: &timestamppb.Timestamp{Seconds: 1},
+						EndTime:   &timestamppb.Timestamp{Seconds: 2},
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/e2e/fake_metric_server_test.go
+++ b/pkg/e2e/fake_metric_server_test.go
@@ -32,6 +32,12 @@ type createTimeSeriesTest struct {
 	pointsIndexToCheck       []int
 }
 
+type listTimeSeriesTest struct {
+	testName                 string
+	createTimeSeriesRequests []*monitoringpb.CreateTimeSeriesRequest
+	listTimeSeriesRequests   []*monitoringpb.ListTimeSeriesRequest
+}
+
 // Returns true if every field in TimeSeries a is deeply equal to TimeSeries b
 // ignoring the Points field. False otherwise.
 func timeSeriesEqualsExceptPoints(a *monitoringpb.TimeSeries, b *monitoringpb.TimeSeries) bool {
@@ -193,7 +199,7 @@ func TestCreateTimeSeries(t *testing.T) {
 		{
 			testName:               "TestCreateTimeSeries-NewProject-NewTimeSeries-NewPoint",
 			timeSeriesIndexToCheck: []int{0, 1, 1},
-			pointsIndexToCheck:     []int{0, 0, 1},
+			pointsIndexToCheck:     []int{0, 0, 0},
 			createTimeSeriesRequests: []*monitoringpb.CreateTimeSeriesRequest{
 				{
 					Name: projectName,

--- a/pkg/e2e/fake_metric_server_test.go
+++ b/pkg/e2e/fake_metric_server_test.go
@@ -407,3 +407,12 @@ func TestListTimeSeriesBadInput(t *testing.T) {
 		})
 	}
 }
+
+// func TestListTimeSeries(t *testing.T) {
+// 	fms := NewFakeMetricServer(200)
+// 	projectName := "projects/1234"
+// 	filter := "metric.type = prometheus_target"
+
+// 	// these are the subtests
+// 	tests := []*createTimeSeriesTest{}
+// }

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -498,7 +498,7 @@ func (e *Exporter) Run(ctx context.Context) error {
 	// user configuration or, even worse, runtime changes to the shard number.
 
 	curBatch := newBatch(e.logger, e.opts.BatchSize)
-	e.metricClient
+
 	// Send the currently accumulated batch to GCM asynchronously.
 	send := func() {
 		// Send the batch and once it completed, trigger next to process remaining data in the

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -498,7 +498,7 @@ func (e *Exporter) Run(ctx context.Context) error {
 	// user configuration or, even worse, runtime changes to the shard number.
 
 	curBatch := newBatch(e.logger, e.opts.BatchSize)
-
+	e.metricClient
 	// Send the currently accumulated batch to GCM asynchronously.
 	send := func() {
 		// Send the batch and once it completed, trigger next to process remaining data in the


### PR DESCRIPTION
This pull requests does the following:

- Adds `ListTimeSeries` to the `FakeMetricServer` that acts as a drop in replacement for the [endpoints listed here](https://cloud.google.com/monitoring/api/ref_v3/rpc#google.monitoring.v3.metricservice). 
- Adds unit tests to ensure the `FakeMetricServer`'s `ListTimeSeries` is behaving as expected.
- Stores points in the time series in the `FakeMetricServer` in decreasing timestamp order (the way we should return it in `ListTimeSeries`.
- Fixes the unit tests that changed as a result of the above.
- Fixes the `TestNil` test in `TestCreateTimeSeriesBadInput` -- it previously was not running.
- Fixes a bug in `CreateTimeSeries` where it did not properly add multiple time series and adds a test to test the scenario

This is the second of a few PRs that will create a robust testing solution to verify GMP behavior with tests using a local kind cluster and E2E tests using a real GKE cluster.
