### PR TITLE
Change node-exporter to not use gmp-system ns

### DIFF
--- a/examples/node-exporter.yaml
+++ b/examples/node-exporter.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  namespace: gmp-system
+  namespace: monitoring
   name: node-exporter
   labels:
     app.kubernetes.io/name: node-exporter
@@ -83,7 +83,7 @@ spec:
 apiVersion: monitoring.googleapis.com/v1
 kind: PodMonitoring
 metadata:
-  namespace: gmp-system
+  namespace: monitoring
   name: node-exporter
   labels:
     app.kubernetes.io/name: node-exporter


### PR DESCRIPTION
gmp-system is supposed to be reserved (and will actually not be accessible on Autopilot); "monitoring" is also used by the kube-state-metrics manifest so we can do the same here.