### PR TITLE
Update deploy manifests when building operator image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ifeq ($(DOCKER_PUSH), 1)
 # TODO(pintohutch): this is a bit hacky, but can be useful when testing.
 # Ultimately this should be replaced with go templating.
 	@echo ">> updating manifests with pushed images"
-	find manifests examples -type f -name "*.yaml" -exec sed -i "s#image: .*/$@:.*#image: ${IMAGE_REGISTRY}/$@:${TAG_NAME}#g" {} \;
+	find manifests examples cmd/operator/deploy -type f -name "*.yaml" -exec sed -i "s#image: .*/$@:.*#image: ${IMAGE_REGISTRY}/$@:${TAG_NAME}#g" {} \;
 endif
 	mkdir -p build/bin
 	@echo ">> exporting built image to local 'build/' dir"


### PR DESCRIPTION
Noticed this while testing https://github.com/GoogleCloudPlatform/prometheus-engine/pull/273, it's a little more convenient when this command updates the `deploy` manifests too.

So for example, when running the steps in https://github.com/GoogleCloudPlatform/prometheus-engine/blob/v0.4.3/cmd/operator/README.md#run they will work with custom built images (ie when running `make operator` to build new code)