### PR TITLE
Bump kube-state-metrics to 2.3.0 and add missing labels

### DIFF
--- a/examples/kube-state-metrics.yaml
+++ b/examples/kube-state-metrics.yaml
@@ -17,7 +17,7 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.1.0
+    app.kubernetes.io/version: 2.3.0
   namespace: gmp-public
   name: kube-state-metrics
 spec:
@@ -30,14 +30,14 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.1.0
+        app.kubernetes.io/version: 2.3.0
     spec:
       nodeSelector:
         kubernetes.io/os: linux
         kubernetes.io/arch: amd64
       containers:
       - name: kube-state-metric
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
         env:
         - name: POD_NAME
           valueFrom:
@@ -91,7 +91,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.1.0
+    app.kubernetes.io/version: 2.3.0
   namespace: gmp-public
   name: kube-state-metrics
 spec:
@@ -113,6 +113,7 @@ metadata:
   name: kube-state-metrics
   labels:
     app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -120,6 +121,7 @@ metadata:
   name: gmp-public:kube-state-metrics
   labels:
     app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -135,6 +137,7 @@ metadata:
   name: gmp-public:kube-state-metrics
   labels:
     app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
 rules:
 - apiGroups:
   - ""

--- a/examples/node-exporter.yaml
+++ b/examples/node-exporter.yaml
@@ -19,7 +19,7 @@ metadata:
   name: node-exporter
   labels:
     app.kubernetes.io/name: node-exporter
-    app.kubernetes.io/version: 1.0.1
+    app.kubernetes.io/version: 1.3.1
 spec:
   selector:
     matchLabels:
@@ -32,13 +32,13 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: node-exporter
-        app.kubernetes.io/version: 1.0.1
+        app.kubernetes.io/version: 1.3.1
     spec:
       nodeSelector:
         kubernetes.io/os: linux
       containers:
       - name: node-exporter
-        image: quay.io/prometheus/node-exporter:v1.0.1
+        image: quay.io/prometheus/node-exporter:v1.3.1
         args:
         - --web.listen-address=:8080
         - --path.sysfs=/host/sys
@@ -47,7 +47,7 @@ spec:
         - --no-collector.hwmon
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.netclass.ignored-devices=^(veth.*)$
-        - --collector.netdev.device-blacklist=^(veth.*)$
+        - --collector.netdev.device-exclude=^(veth.*)$
         ports:
         - name: metrics
           containerPort: 8080


### PR DESCRIPTION
-  version [2.3.0](https://github.com/kubernetes/kube-state-metrics/blob/e52d8ace1fae43248f225cd27a9bcc90296d6a01/README.md) has pretty good support from k8s1.19 to 1.23 


- Bump nodeexporter to 1.3.1 and minor deprecated flag change