### PR TITLE
Initialize empty config for collector and evaluator pods

### DIFF
--- a/cmd/operator/deploy/operator/10-collector.yaml
+++ b/cmd/operator/deploy/operator/10-collector.yaml
@@ -35,6 +35,13 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux
+      initContainers:
+      - name: config-init
+        image: gke.gcr.io/gke-distroless/bash
+        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        volumeMounts:
+        - name: config-out
+          mountPath: /prometheus/config_out
       containers:
       - name: prometheus
         image: gke.gcr.io/prometheus-engine/prometheus:v2.35.0-gmp.2-gke.0

--- a/cmd/operator/deploy/operator/11-rule-evaluator.yaml
+++ b/cmd/operator/deploy/operator/11-rule-evaluator.yaml
@@ -36,6 +36,13 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux
+      initContainers:
+      - name: config-init
+        image: gke.gcr.io/gke-distroless/bash
+        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        volumeMounts:
+        - name: config-out
+          mountPath: /prometheus/config_out
       containers:
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.4.1-gke.0

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -468,6 +468,13 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux
+      initContainers:
+      - name: config-init
+        image: gke.gcr.io/gke-distroless/bash
+        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        volumeMounts:
+        - name: config-out
+          mountPath: /prometheus/config_out
       containers:
       - name: prometheus
         image: gke.gcr.io/prometheus-engine/prometheus:v2.35.0-gmp.2-gke.0
@@ -617,6 +624,13 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux
+      initContainers:
+      - name: config-init
+        image: gke.gcr.io/gke-distroless/bash
+        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        volumeMounts:
+        - name: config-out
+          mountPath: /prometheus/config_out
       containers:
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.4.1-gke.0


### PR DESCRIPTION
This fixes a bug where the collector and rule-evaluator pods start up before the config-reloader, causing the collector/evaluator to restart due to not being able to find a config. For example:
```
$ kubectl logs pod/rule-evaluator -n gmp-system -c evaluator
level=error ts=2022-07-25T19:14:05.872221429Z caller=main.go:144 msg="Error loading config (--config.file=/prometheus/config_out/config.yaml)" err="open /prometheus/config_out/config.yaml: no such file or directory"
```
this adds an init container to both pods that just creates the empty config file. in my testing, this appeared to fix the issue