### PR TITLE
Update alertmanager to use GKE-built image

### DIFF
--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: prom/alertmanager:latest
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.24.0-gke.0
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -789,7 +789,7 @@ spec:
     spec:
       containers:
       - name: alertmanager
-        image: prom/alertmanager:latest
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.24.0-gke.0
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data


### PR DESCRIPTION
Now that Louhi builds are set up, this change will be necessary to use the Google-built images in managed AM deployment