### PR TITLE
Reduce ClusterRole

### DIFF
--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -45,7 +45,7 @@ rules:
 - apiGroups: [""]
   resources:
   - secrets
-  resourceNames: ["collection", "rules"]
+  resourceNames: ["collection", "rules", "alertmanager"]
   verbs: ["get", "patch", "update"]
 - apiGroups: [""]
   resources:
@@ -70,6 +70,11 @@ rules:
   - deployments
   resourceNames: ["collector", "rule-evaluator"]
   verbs: ["get", "delete", "patch", "update"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  resourceNames: ["alertmanager"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -84,10 +89,6 @@ rules:
 - apiGroups: ["monitoring.googleapis.com"]
   resources:
   - operatorconfigs
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apps"]
-  resources:
-  - statefulsets
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -45,34 +45,37 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
-  verbs: ["create", "patch", "update"]
+  verbs: ["get", "list", "watch", "create", "patch", "update"]
 - apiGroups: ["apps"]
   resources:
   - daemonsets
-  verbs: ["create", "delete", "patch", "update"]
+  - deployments
+  verbs: ["get", "list", "watch", "delete", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: gmp-public
+  name: operator
+rules:
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["monitoring.googleapis.com"]
+  resources:
+  - operatorconfigs
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources:
-  - deployments
-  verbs: ["create", "delete", "patch", "update"]
+  - statefulsets
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gmp-system:operator
 rules:
-# The following read permissions are cluster-wide even though they could be namespace-constrained
-# as the controller-runtime library does not allow mixing cluster-wide and namespaced watches.
-- apiGroups: [""]
-  resources:
-  - configmaps
-  - secrets
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apps"]
-  resources:
-  - daemonsets
-  - deployments
-  - statefulsets
-  verbs: ["get", "list", "watch"]
 # Permission to inject CA bundles into webhook configs of fixed name.
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:
@@ -96,7 +99,6 @@ rules:
   - clusterpodmonitorings
   - clusterrules
   - globalrules
-  - operatorconfigs
   - podmonitorings
   - rules
   verbs: ["get", "list", "watch"]

--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -41,16 +41,35 @@ rules:
 - apiGroups: [""]
   resources:
   - secrets
-  verbs: ["create", "patch", "update"]
+  verbs: ["list", "watch", "create"]
+- apiGroups: [""]
+  resources:
+  - secrets
+  resourceNames: ["collection", "rules"]
+  verbs: ["get", "patch", "update"]
 - apiGroups: [""]
   resources:
   - configmaps
-  verbs: ["get", "list", "watch", "create", "patch", "update"]
+  verbs: ["list", "watch", "create"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  resourceNames: ["collector", "rule-evaluator", "rules-generated"]
+  verbs: ["get", "patch", "update"]
 - apiGroups: ["apps"]
   resources:
   - daemonsets
-  - deployments
+  resourceNames: ["collector"]
   verbs: ["get", "list", "watch", "delete", "patch", "update"]
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  resourceNames: ["collector", "rule-evaluator"]
+  verbs: ["get", "delete", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cmd/operator/deploy/operator/04-rolebinding.yaml
+++ b/cmd/operator/deploy/operator/04-rolebinding.yaml
@@ -28,6 +28,20 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  namespace: gmp-public
+  name: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator
+subjects:
+- kind: ServiceAccount
+  namespace: gmp-system
+  name: operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   namespace: gmp-system
   name: operator
 roleRef:

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -71,16 +71,35 @@ rules:
 - apiGroups: [""]
   resources:
   - secrets
-  verbs: ["create", "patch", "update"]
+  verbs: ["list", "watch", "create"]
+- apiGroups: [""]
+  resources:
+  - secrets
+  resourceNames: ["collection", "rules"]
+  verbs: ["get", "patch", "update"]
 - apiGroups: [""]
   resources:
   - configmaps
-  verbs: ["get", "list", "watch", "create", "patch", "update"]
+  verbs: ["list", "watch", "create"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  resourceNames: ["collector", "rule-evaluator", "rules-generated"]
+  verbs: ["get", "patch", "update"]
 - apiGroups: ["apps"]
   resources:
   - daemonsets
-  - deployments
+  resourceNames: ["collector"]
   verbs: ["get", "list", "watch", "delete", "patch", "update"]
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  resourceNames: ["collector", "rule-evaluator"]
+  verbs: ["get", "delete", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -75,32 +75,37 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
-  verbs: ["create", "patch", "update"]
+  verbs: ["get", "list", "watch", "create", "patch", "update"]
 - apiGroups: ["apps"]
   resources:
   - daemonsets
-  verbs: ["create", "delete", "patch", "update"]
+  - deployments
+  verbs: ["get", "list", "watch", "delete", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: gmp-public
+  name: operator
+rules:
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["monitoring.googleapis.com"]
+  resources:
+  - operatorconfigs
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources:
-  - deployments
-  verbs: ["create", "delete", "patch", "update"]
+  - statefulsets
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gmp-system:operator
 rules:
-- apiGroups: [""]
-  resources:
-  - configmaps
-  - secrets
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apps"]
-  resources:
-  - daemonsets
-  - deployments
-  - statefulsets
-  verbs: ["get", "list", "watch"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:
   - validatingwebhookconfigurations
@@ -120,7 +125,6 @@ rules:
   - clusterpodmonitorings
   - clusterrules
   - globalrules
-  - operatorconfigs
   - podmonitorings
   - rules
   verbs: ["get", "list", "watch"]
@@ -141,6 +145,20 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: gmp-system:operator
+subjects:
+- kind: ServiceAccount
+  namespace: gmp-system
+  name: operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: gmp-public
+  name: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator
 subjects:
 - kind: ServiceAccount
   namespace: gmp-system

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -75,7 +75,7 @@ rules:
 - apiGroups: [""]
   resources:
   - secrets
-  resourceNames: ["collection", "rules"]
+  resourceNames: ["collection", "rules", "alertmanager"]
   verbs: ["get", "patch", "update"]
 - apiGroups: [""]
   resources:
@@ -100,6 +100,11 @@ rules:
   - deployments
   resourceNames: ["collector", "rule-evaluator"]
   verbs: ["get", "delete", "patch", "update"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  resourceNames: ["alertmanager"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -114,10 +119,6 @@ rules:
 - apiGroups: ["monitoring.googleapis.com"]
   resources:
   - operatorconfigs
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apps"]
-  resources:
-  - statefulsets
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -208,7 +208,10 @@ func New(logger logr.Logger, clientConfig *rest.Config, registry prometheus.Regi
 						Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": opts.PublicNamespace}),
 					},
 					&appsv1.StatefulSet{}: {
-						Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": opts.PublicNamespace}),
+						Field: fields.SelectorFromSet(fields.Set{
+							"metadata.namespace": opts.OperatorNamespace,
+							"metadata.name":      NameAlertmanager,
+						}),
 					},
 					&corev1.ConfigMap{}: {
 						Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": opts.OperatorNamespace}),

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -207,7 +207,10 @@ func New(logger logr.Logger, clientConfig *rest.Config, registry prometheus.Regi
 						Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": opts.OperatorNamespace}),
 					},
 					&appsv1.DaemonSet{}: {
-						Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": opts.OperatorNamespace}),
+						Field: fields.SelectorFromSet(fields.Set{
+							"metadata.namespace": opts.OperatorNamespace,
+							"metadata.name":      NameCollector,
+						}),
 					},
 					&appsv1.Deployment{}: {
 						Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": opts.OperatorNamespace}),

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -126,7 +126,6 @@ func setupOperatorConfigControllers(op *Operator) error {
 			&monitoringv1.OperatorConfig{},
 			builder.WithPredicates(objFilterOperatorConfig),
 		).
-		// // Maintain the rule-evaluator deployment and configuration (as a secret).
 		Watches(
 			&source.Kind{Type: &appsv1.Deployment{}},
 			enqueueConst(objRequest),
@@ -134,11 +133,6 @@ func setupOperatorConfigControllers(op *Operator) error {
 				objFilterRuleEvaluator,
 				predicate.GenerationChangedPredicate{},
 			)).
-		// We must watch all secrets in the cluster as we copy and inline secrets referenced
-		// in the OperatorConfig and need to repeat those steps if affected secrets change.
-		// As the set of secrets to watch is not static, we've to watch them all.
-		// A viable alternative could be for the rule-evaluator (or a sidecar) to generate
-		// the configuration locally and maintain a more constrained watch.
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			enqueueConst(objRequest),


### PR DESCRIPTION
Constrains many of our ClusterRoles to a namespaced Role where possible (e.g. where we were already filtering by gmp-public or gmp-system). Further, this change updates the `controller-runtime` manager's watch-list to only watch those namespaces improving security and performance.