### PR TITLE
Use gcp alertmanager

### DIFF
--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -64,7 +64,7 @@ spec:
           mountPath: /alertmanager/config_out
       containers:
       - name: alertmanager
-        image: prom/alertmanager:latest
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.24.0-gmp.0-gke.0
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -836,7 +836,7 @@ spec:
           mountPath: /alertmanager/config_out
       containers:
       - name: alertmanager
-        image: prom/alertmanager:latest
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.24.0-gmp.0-gke.0
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data


### PR DESCRIPTION
We forgot to put this in the v0.5.0 tag, but it's not a huge deal for those who kubectl apply these manifests.