### PR TITLE
Remove cpu limits of our deployed resources.

### DIFF
--- a/cmd/operator/deploy/operator/10-collector.yaml
+++ b/cmd/operator/deploy/operator/10-collector.yaml
@@ -82,7 +82,6 @@ spec:
             scheme: HTTP
         resources:
           limits:
-            cpu: 1000m
             memory: 3G
           requests:
             cpu: 100m
@@ -125,7 +124,6 @@ spec:
           containerPort: 19091
         resources:
           limits:
-            cpu: 10m
             memory: 32M
           requests:
             cpu: 5m

--- a/cmd/operator/deploy/operator/11-rule-evaluator.yaml
+++ b/cmd/operator/deploy/operator/11-rule-evaluator.yaml
@@ -65,7 +65,6 @@ spec:
             scheme: HTTP
         resources:
           limits:
-            cpu: 1000m
             memory: 1G
           requests:
             cpu: 100m
@@ -105,7 +104,6 @@ spec:
           name: cfg-rel-metrics
         resources:
           limits:
-            cpu: 10m
             memory: 32M
           requests:
             cpu: 5m

--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -73,7 +73,6 @@ spec:
           name: alertmanager
         resources:
           limits:
-            cpu: 1000m
             memory: 1G
           requests:
             cpu: 100m
@@ -113,7 +112,6 @@ spec:
           containerPort: 19091
         resources:
           limits:
-            cpu: 10m
             memory: 32M
           requests:
             cpu: 5m

--- a/examples/alertmanager.yaml
+++ b/examples/alertmanager.yaml
@@ -98,7 +98,6 @@ spec:
             cpu: 50m
             memory: 25Mi
           limits:
-            cpu: 100m
             memory: 50Mi
         volumeMounts:
         - mountPath: /etc/alertmanager/config

--- a/examples/kube-state-metrics.yaml
+++ b/examples/kube-state-metrics.yaml
@@ -62,7 +62,6 @@ spec:
             cpu: 100m
             memory: 190Mi
           limits:
-            cpu: 200m
             memory: 250Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/examples/node-exporter.yaml
+++ b/examples/node-exporter.yaml
@@ -53,7 +53,6 @@ spec:
           containerPort: 8080
         resources:
           limits:
-            cpu: 250m
             memory: 180Mi
           requests:
             cpu: 102m

--- a/examples/prometheus.yaml
+++ b/examples/prometheus.yaml
@@ -115,7 +115,6 @@ spec:
           containerPort: 8080
         resources:
           limits:
-            cpu: 100m
             memory: 50Mi
           requests:
             cpu: 100m

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -558,7 +558,6 @@ spec:
             scheme: HTTP
         resources:
           limits:
-            cpu: 1000m
             memory: 3G
           requests:
             cpu: 100m
@@ -601,7 +600,6 @@ spec:
           containerPort: 19091
         resources:
           limits:
-            cpu: 10m
             memory: 32M
           requests:
             cpu: 5m
@@ -696,7 +694,6 @@ spec:
             scheme: HTTP
         resources:
           limits:
-            cpu: 1000m
             memory: 1G
           requests:
             cpu: 100m
@@ -736,7 +733,6 @@ spec:
           name: cfg-rel-metrics
         resources:
           limits:
-            cpu: 10m
             memory: 32M
           requests:
             cpu: 5m
@@ -845,7 +841,6 @@ spec:
           name: alertmanager
         resources:
           limits:
-            cpu: 1000m
             memory: 1G
           requests:
             cpu: 100m
@@ -885,7 +880,6 @@ spec:
           containerPort: 19091
         resources:
           limits:
-            cpu: 10m
             memory: 32M
           requests:
             cpu: 5m


### PR DESCRIPTION
CPU is a throttled resource. Specifying a limit can result in premature throttling.

Also nothing prevents people from adding the limit themselves if they have that requirement.