### PR TITLE
Remove unused RBAC permissions

### DIFF
--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -68,16 +68,11 @@ rules:
 - apiGroups: ["apps"]
   resources:
   - deployments
-  resourceNames: ["collector", "rule-evaluator"]
+  resourceNames: ["rule-evaluator"]
   verbs: ["get", "delete", "patch", "update"]
 - apiGroups: [""]
   resources:
   - services
-  resourceNames: ["alertmanager"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apps"]
-  resources:
-  - statefulsets
   resourceNames: ["alertmanager"]
   verbs: ["get", "list", "watch"]
 ---

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -98,16 +98,11 @@ rules:
 - apiGroups: ["apps"]
   resources:
   - deployments
-  resourceNames: ["collector", "rule-evaluator"]
+  resourceNames: ["rule-evaluator"]
   verbs: ["get", "delete", "patch", "update"]
 - apiGroups: [""]
   resources:
   - services
-  resourceNames: ["alertmanager"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["apps"]
-  resources:
-  - statefulsets
   resourceNames: ["alertmanager"]
   verbs: ["get", "list", "watch"]
 ---

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -223,7 +223,10 @@ func New(logger logr.Logger, clientConfig *rest.Config, registry prometheus.Regi
 						}),
 					},
 					&appsv1.Deployment{}: {
-						Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": opts.OperatorNamespace}),
+						Field: fields.SelectorFromSet(fields.Set{
+							"metadata.namespace": opts.OperatorNamespace,
+							"metadata.name":      NameRuleEvaluator,
+						}),
 					},
 				}})
 		}),


### PR DESCRIPTION
No `StatefulSet`s are used:
```
$ grep -r StatefulSet pkg/
pkg/operator/e2e/context.go:            case *appsv1.StatefulSet:
pkg/operator/e2e/context.go:                    alertmanager := obj.(*appsv1.StatefulSet)
pkg/operator/e2e/context.go:                    if _, err := tctx.kubeClient.AppsV1().StatefulSets(tctx.namespace).Create(ctx, alertmanager, metav1.CreateOptions{}); err != nil {
pkg/operator/e2e/main_test.go:                  ss, err := t.kubeClient.AppsV1().StatefulSets(t.namespace).Get(ctx, operator.NameAlertmanager, metav1.GetOptions{})
pkg/operator/e2e/main_test.go:                          t.Log(errors.Errorf("getting alertmanager StatefulSet failed: %s", err))
pkg/operator/e2e/main_test.go:                          return false, errors.Errorf("getting alertmanager StatefulSet failed: %s", err)
```

No `Deployment` named `collector` exists (just `DaemonSet` and `ConfigMap`):
```
$ grep -r NameCollector pkg/ -B 3 -A 2 --exclude-dir=e2e --exclude=operator_test.go --exclude=operator_config.go
pkg/operator/operator.go-                                       &appsv1.DaemonSet{}: {
pkg/operator/operator.go-                                               Field: fields.SelectorFromSet(fields.Set{
pkg/operator/operator.go-                                                       "metadata.namespace": opts.OperatorNamespace,
pkg/operator/operator.go:                                                       "metadata.name":      NameCollector,
pkg/operator/operator.go-                                               }),
pkg/operator/operator.go-                                       },
--
pkg/operator/operator.go-       // Check the collector DaemonSet.
pkg/operator/operator.go-       var ds appsv1.DaemonSet
pkg/operator/operator.go-       if err := o.client.Get(ctx, client.ObjectKey{
pkg/operator/operator.go:               Name:      NameCollector,
pkg/operator/operator.go-               Namespace: o.opts.OperatorNamespace,
pkg/operator/operator.go-       }, &ds); err != nil && apierrors.IsNotFound(err) {
--
pkg/operator/collection.go-     // Collector ConfigMap and Daemonset filter.
pkg/operator/collection.go-     objFilterCollector := namespacedNamePredicate{
pkg/operator/collection.go-             namespace: op.opts.OperatorNamespace,
pkg/operator/collection.go:             name:      NameCollector,
pkg/operator/collection.go-     }
pkg/operator/collection.go-     // Collector secret.
--
pkg/operator/collection.go-                     Name:      CollectionSecretName,
pkg/operator/collection.go-                     Namespace: r.opts.OperatorNamespace,
pkg/operator/collection.go-                     Labels: map[string]string{
pkg/operator/collection.go:                             LabelAppName: NameCollector,
pkg/operator/collection.go-                     },
pkg/operator/collection.go-                     Annotations: map[string]string{
--
pkg/operator/collection.go-     logger, _ := logr.FromContext(ctx)
pkg/operator/collection.go-
pkg/operator/collection.go-     var ds appsv1.DaemonSet
pkg/operator/collection.go:     err := r.client.Get(ctx, client.ObjectKey{Namespace: r.opts.OperatorNamespace, Name: NameCollector}, &ds)
pkg/operator/collection.go-     // Some users deliberately not want to run the collectors. Only emit a warning but don't cause
pkg/operator/collection.go-     // retries as this logic gets re-triggered anyway if the DaemonSet is created later.
--
pkg/operator/collection.go-     cm := &corev1.ConfigMap{
pkg/operator/collection.go-             ObjectMeta: metav1.ObjectMeta{
pkg/operator/collection.go-                     Namespace: r.opts.OperatorNamespace,
pkg/operator/collection.go:                     Name:      NameCollector,
pkg/operator/collection.go-             },
pkg/operator/collection.go-             Data: map[string]string{
```