### PR TITLE
Reorganize examples directory

### DIFF
--- a/examples/gke-control-plane/README.md
+++ b/examples/gke-control-plane/README.md
@@ -1,0 +1,3 @@
+# GKE Control Plane
+
+For more information on ingesting GKE control plane metrics, refer to the [Google Cloud documentation](https://cloud.google.com/stackdriver/docs/solutions/gke/managing-metrics#control-plane-metrics).

--- a/examples/istio/README.md
+++ b/examples/istio/README.md
@@ -1,0 +1,3 @@
+# Istio sample manifests
+
+Please refer to the [Google Cloud documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/istio) for how to use these manifests.

--- a/examples/istio/pod-monitoring.yaml
+++ b/examples/istio/pod-monitoring.yaml
@@ -1,0 +1,50 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: istiod
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: istiod
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  selector:
+    matchLabels:
+      app: istiod
+  endpoints:
+  - port: 15014
+    interval: 60s
+    path: /metrics
+  targetLabels:
+    fromPod:
+    - from: app
+      to: app
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: istio-proxy
+  labels:
+    app.kubernetes.io/name: istio-proxy
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  selector:
+    matchLabels:
+  endpoints:
+  - port: http-envoy-prom
+    scheme: http
+    interval: 60s
+    path: /stats/prometheus

--- a/examples/istio/rules.yaml
+++ b/examples/istio/rules.yaml
@@ -1,0 +1,93 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: Rules
+metadata:
+  name: istio-rules
+  labels:
+    app.kubernetes.io/component: rules
+    app.kubernetes.io/name: istio-rules
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  groups:
+  - name: istio
+    interval: 30s
+    rules:
+    - alert: IstioHighTotalRequestRate
+      expr: sum(rate(istio_requests_total{reporter="destination"}[5m])) > 1000
+      for: 2m
+      labels:
+        severity: warning
+      annotations:
+        summary: Istio high total request rate (instance {{ $labels.instance }})
+        description: |-
+          Global request rate in the service mesh is unusually high.
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
+    - alert: IstioLowTotalRequestRate
+      expr: sum(rate(istio_requests_total{reporter="destination"}[5m])) < 100
+      for: 2m
+      labels:
+        severity: warning
+      annotations:
+        summary: Istio low total request rate (instance {{ $labels.instance }})
+        description: |-
+          Global request rate in the service mesh is unusually low.
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
+    - alert: IstioHigh4xxErrorRate
+      expr: sum(rate(istio_requests_total{reporter="destination", response_code=~"4.*"}[5m])) / sum(rate(istio_requests_total{reporter="destination"}[5m])) * 100 > 5
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: Istio high 4xx error rate (instance {{ $labels.instance }})
+        description: |-
+          High percentage of HTTP 5xx responses in Istio (> 5%).
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
+    - alert: IstioHigh5xxErrorRate
+      expr: sum(rate(istio_requests_total{reporter="destination", response_code=~"5.*"}[5m])) / sum(rate(istio_requests_total{reporter="destination"}[5m])) * 100 > 5
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: Istio high 5xx error rate (instance {{ $labels.instance }})
+        description: |-
+          High percentage of HTTP 5xx responses in Istio (> 5%).
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
+    - alert: IstioHighRequestLatency
+      expr: rate(istio_request_duration_milliseconds_sum{reporter="destination"}[1m]) / rate(istio_request_duration_milliseconds_count{reporter="destination"}[1m]) > 100
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: Istio high request latency (instance {{ $labels.instance }})
+        description: |-
+          Istio average requests execution is longer than 100ms.
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
+    - alert: IstioLatency99Percentile
+      expr: histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[1m])) by (destination_canonical_service, destination_workload_namespace, source_canonical_service, source_workload_namespace, le)) > 1
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: Istio latency 99 percentile (instance {{ $labels.instance }})
+        description: |-
+          Istio 1% slowest requests are longer than 1s.
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}

--- a/examples/kube-state-metrics/README.md
+++ b/examples/kube-state-metrics/README.md
@@ -1,0 +1,3 @@
+# Kube State Metrics sample manifests
+
+Please refer to the [Google Cloud documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/kube_state_metrics) for how to use these manifests.

--- a/examples/kube-state-metrics/kube-state-metrics.yaml
+++ b/examples/kube-state-metrics/kube-state-metrics.yaml
@@ -1,0 +1,342 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
+  namespace: gmp-public
+  name: kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  serviceName: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/version: 2.3.0
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - arm64
+                - amd64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - name: kube-state-metric
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        args:
+        - --pod=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE)
+        - --port=8080
+        - --telemetry-port=8081
+        ports:
+        - name: metrics
+          containerPort: 8080
+        - name: metrics-self
+          containerPort: 8081
+        resources:
+          requests:
+            cpu: 100m
+            memory: 190Mi
+          limits:
+            memory: 250Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          capabilities:
+            drop:
+            - all
+          runAsUser: 1000
+          runAsGroup: 1000
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+      serviceAccountName: kube-state-metrics
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
+  namespace: gmp-public
+  name: kube-state-metrics
+spec:
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 8080
+    targetPort: metrics
+  - name: metrics-self
+    port: 8081
+    targetPort: metrics-self
+  selector:
+    app.kubernetes.io/name: kube-state-metrics
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: gmp-public
+  name: kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gmp-public:kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gmp-public:kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  namespace: gmp-public
+  name: kube-state-metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gmp-public:kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get 
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+---
+# TODO(pintohutch): bump to autoscaling/v2 when 1.23 is the default in the GKE
+# stable release channel.
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: kube-state-metrics
+  namespace: gmp-public
+spec:
+  maxReplicas: 10
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: kube-state-metrics
+  metrics:
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 60
+  behavior:
+    scaleDown:
+      policies:
+      - type: Pods
+        value: 1
+        # Under-utilization needs to persist for `periodSeconds` before any action can be taken.
+        # Current supported max from https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2beta2/.
+        periodSeconds: 1800
+      # Current supported max from https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2beta2/.
+      stabilizationWindowSeconds: 3600
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: ClusterPodMonitoring
+metadata:
+  name: kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  endpoints:
+  - port: metrics
+    interval: 60s
+    metricRelabeling:
+    - action: keep
+      regex: kube_(daemonset|deployment|pod|namespace|node|statefulset)_.+
+      sourceLabels: [__name__]
+  targetLabels:
+    metadata: [] # explicitly empty so the metric labels are respected
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  namespace: gmp-public
+  name: kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  endpoints:
+  - port: metrics-self
+    interval: 60s

--- a/examples/kube-state-metrics/rules.yaml
+++ b/examples/kube-state-metrics/rules.yaml
@@ -1,0 +1,73 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: Rules
+metadata:
+  namespace: gmp-public
+  name: kube-state-metrics-rules
+  labels:
+    app.kubernetes.io/component: rules
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  groups:
+    - name: kube-state-metrics
+      interval: 30s
+      rules:
+      - alert: KubeStateMetricsListErrors
+        annotations:
+          description: kube-state-metrics is experiencing errors at an elevated rate in list operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.
+          summary: kube-state-metrics is experiencing errors in list operations.
+        expr: |
+          (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m]))
+            /
+          sum(rate(kube_state_metrics_list_total{job="kube-state-metrics"}[5m])))
+          > 0.01
+        for: 15m
+        labels:
+          severity: critical
+      - alert: KubeStateMetricsWatchErrors
+        annotations:
+          description: kube-state-metrics is experiencing errors at an elevated rate in watch operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.
+          summary: kube-state-metrics is experiencing errors in watch operations.
+        expr: |
+          (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m]))
+            /
+          sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])))
+          > 0.01
+        for: 15m
+        labels:
+          severity: critical
+      - alert: KubeStateMetricsShardingMismatch
+        annotations:
+          description: kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all.
+          summary: kube-state-metrics sharding is misconfigured.
+        expr: |
+          stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) != 0
+        for: 15m
+        labels:
+          severity: critical
+      - alert: KubeStateMetricsShardsMissing
+        annotations:
+          description: kube-state-metrics shards are missing, some Kubernetes objects are not being exposed.
+          summary: kube-state-metrics shards are missing.
+        expr: |
+          2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) - 1
+            -
+          sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"}) )
+          != 0
+        for: 15m
+        labels:
+          severity: critical

--- a/examples/kubelet-cadvisor/README.md
+++ b/examples/kubelet-cadvisor/README.md
@@ -1,0 +1,3 @@
+# Kubelet / cAdvisor
+
+For more information on ingesting Kubelet / cAdvisor metrics, refer to the [Google Cloud documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/kubelet-cadvisor).

--- a/examples/nginx/README.md
+++ b/examples/nginx/README.md
@@ -1,0 +1,3 @@
+# Nginx sample manifests
+
+Please refer to the [Google Cloud documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/nginx) for how to use these manifests.

--- a/examples/nginx/exporter.yaml.snippet
+++ b/examples/nginx/exporter.yaml.snippet
@@ -1,0 +1,91 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx
+data:
+  default.conf: |
+    server {
+        listen       80 default_server;
+        server_name  _;
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
++       location /status {
++           stub_status on;
++           access_log off;
++           allow 127.0.0.1;
++           allow 10.0.0.0/8;
++           allow 172.16.0.0/12;
++           allow 192.168.0.0/16;
++           deny all;
++       }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  ...
+  template:
+    metadata:
+      labels:
++       app.kubernetes.io/name: nginx
+    spec:
+      containers:
++     - name: nginx-exporter
++       image: nginx/nginx-prometheus-exporter:0.10.0
++       args:
++       - "-nginx.scrape-uri=http://localhost/status"
++       ports:
++       - containerPort: 9113
++         name: prometheus
++       readinessProbe:
++         httpGet:
++           path: /metrics
++           port: prometheus
++       livenessProbe:
++         httpGet:
++           path: /metrics
++           port: prometheus
+      - name: nginx
+        image: nginx:1.14.2
++       ports:
++       - containerPort: 80
++         name: http
++       readinessProbe:
++         httpGet:
++           path: /status
++           port: http
++       livenessProbe:
++         httpGet:
++           path: /status
++           port: http
++       volumeMounts:
++       - mountPath: /etc/nginx/conf.d/default.conf
++         subPath: default.conf
++         name: config
++     volumes:
++     - name: config
++       configMap:
++         name: nginx
++         items:
++         - key: default.conf
++           path: default.conf

--- a/examples/nginx/pod-monitoring.yaml
+++ b/examples/nginx/pod-monitoring.yaml
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  endpoints:
+  - port: prometheus
+    scheme: http
+    interval: 60s
+    path: /metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx

--- a/examples/nginx/rules.yaml
+++ b/examples/nginx/rules.yaml
@@ -1,0 +1,71 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: Rules
+metadata:
+  name: nginx-rules
+  labels:
+    app.kubernetes.io/component: rules
+    app.kubernetes.io/name: nginx-rules
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  groups:
+  - name: nginx
+    interval: 30s
+    rules:
+    - alert: NginxDown
+      annotations:
+        description: |-
+          Nginx instance is down
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: Nginx down (instance {{ $labels.instance }})
+      expr: nginx_up{job="nginx"} == 0
+      for: 5m
+      labels:
+        severity: critical
+    - alert: NginxDroppedConnections
+      annotations:
+        description: |-
+         Too many dropped connections (> 5%)
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: Number of dropped connections is high (instance {{ $labels.instance }})
+      expr: (rate(nginx_connections_accepted{job="nginx"}[1m]) - rate(nginx_connections_handled{job="nginx"}[1m])) / rate(nginx_connections_accepted{job="nginx"}[1m]) > 0.05
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NginxTrafficSpike
+      annotations:
+        description: |-
+          Increase in total number of HTTP requests received (> 20%)
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: Spike in HTTP traffic (instance {{ $labels.instance }})
+      expr: rate(nginx_http_requests_total{job="nginx"}[1m])/ rate(nginx_http_requests_total{job="nginx"}[1m] offset 5m) > 1.2
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NginxTrafficDrop
+      annotations:
+        description: |-
+           Decrease in total number of HTTP requests received (> 20%)
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: Drop in HTTP traffic (instance {{ $labels.instance }})
+      expr: rate(nginx_http_requests_total{job="nginx"}[1m])/ rate(nginx_http_requests_total{job="nginx"}[1m] offset 5m) < 0.8
+      for: 5m
+      labels:
+        severity: warning

--- a/examples/node-exporter/README.md
+++ b/examples/node-exporter/README.md
@@ -1,0 +1,3 @@
+# Node Exporter sample manifests
+
+Please refer to the [Google Cloud documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/node_exporter) for how to use these manifests.

--- a/examples/node-exporter/node-exporter.yaml
+++ b/examples/node-exporter/node-exporter.yaml
@@ -1,0 +1,108 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: gmp-public
+  name: node-exporter
+  labels:
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/version: 1.3.1
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-exporter
+        app.kubernetes.io/version: 1.3.1
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - arm64
+                - amd64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - name: node-exporter
+        image: quay.io/prometheus/node-exporter:v1.3.1
+        args:
+        - --web.listen-address=:8080
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --no-collector.wifi
+        - --no-collector.hwmon
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        - --collector.netclass.ignored-devices=^(veth.*)$
+        - --collector.netdev.device-exclude=^(veth.*)$
+        ports:
+        - name: metrics
+          containerPort: 8080
+        resources:
+          limits:
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/sys
+          mountPropagation: HostToContainer
+          name: sys
+          readOnly: true
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      hostNetwork: true
+      hostPID: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      volumes:
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  namespace: gmp-public
+  name: node-exporter
+  labels:
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+  endpoints:
+  - port: metrics
+    interval: 30s

--- a/examples/node-exporter/rules.yaml
+++ b/examples/node-exporter/rules.yaml
@@ -1,0 +1,350 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: Rules
+metadata:
+  namespace: gmp-public
+  name: node-exporter-rules
+  labels:
+    app.kubernetes.io/component: rules
+    app.kubernetes.io/name: node-exporter-rules
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  groups:
+  - name: node-exporter
+    interval: 30s
+    rules:
+    - alert: NodeFilesystemSpaceFillingUp
+      annotations:
+        description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+          has only {{ printf "%.2f" $value }}% available space left and is filling
+          up.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemspacefillingup
+        summary: Filesystem is predicted to run out of space within the next 24 hours.
+      expr: |
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 15
+        and
+          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 24 * 60 * 60) < 0
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+        )
+      for: 1h
+      labels:
+        severity: warning
+    - alert: NodeFilesystemSpaceFillingUp
+      annotations:
+        description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+          has only {{ printf "%.2f" $value }}% available space left and is filling
+          up fast.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemspacefillingup
+        summary: Filesystem is predicted to run out of space within the next 4 hours.
+      expr: |
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 10
+        and
+          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+        )
+      for: 1h
+      labels:
+        severity: critical
+    - alert: NodeFilesystemAlmostOutOfSpace
+      annotations:
+        description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+          has only {{ printf "%.2f" $value }}% available space left.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemalmostoutofspace
+        summary: Filesystem has less than 5% space left.
+      expr: |
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 5
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+        )
+      for: 30m
+      labels:
+        severity: warning
+    - alert: NodeFilesystemAlmostOutOfSpace
+      annotations:
+        description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+          has only {{ printf "%.2f" $value }}% available space left.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemalmostoutofspace
+        summary: Filesystem has less than 3% space left.
+      expr: |
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 3
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+        )
+      for: 30m
+      labels:
+        severity: critical
+    - alert: NodeFilesystemFilesFillingUp
+      annotations:
+        description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+          has only {{ printf "%.2f" $value }}% available inodes left and is filling
+          up.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemfilesfillingup
+        summary: Filesystem is predicted to run out of inodes within the next 24 hours.
+      expr: |
+        (
+          node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 40
+        and
+          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 24*60*60) < 0
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+        )
+      for: 1h
+      labels:
+        severity: warning
+    - alert: NodeFilesystemFilesFillingUp
+      annotations:
+        description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+          has only {{ printf "%.2f" $value }}% available inodes left and is filling
+          up fast.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemfilesfillingup
+        summary: Filesystem is predicted to run out of inodes within the next 4 hours.
+      expr: |
+        (
+          node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 20
+        and
+          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+        )
+      for: 1h
+      labels:
+        severity: critical
+    - alert: NodeFilesystemAlmostOutOfFiles
+      annotations:
+        description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+          has only {{ printf "%.2f" $value }}% available inodes left.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemalmostoutoffiles
+        summary: Filesystem has less than 5% inodes left.
+      expr: |
+        (
+          node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 5
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+        )
+      for: 1h
+      labels:
+        severity: warning
+    - alert: NodeFilesystemAlmostOutOfFiles
+      annotations:
+        description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+          has only {{ printf "%.2f" $value }}% available inodes left.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemalmostoutoffiles
+        summary: Filesystem has less than 3% inodes left.
+      expr: |
+        (
+          node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 3
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+        )
+      for: 1h
+      labels:
+        severity: critical
+    - alert: NodeNetworkReceiveErrs
+      annotations:
+        description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered
+          {{ printf "%.0f" $value }} receive errors in the last two minutes.'
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodenetworkreceiveerrs
+        summary: Network interface is reporting many receive errors.
+      expr: |
+        rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01
+      for: 1h
+      labels:
+        severity: warning
+    - alert: NodeNetworkTransmitErrs
+      annotations:
+        description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered
+          {{ printf "%.0f" $value }} transmit errors in the last two minutes.'
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodenetworktransmiterrs
+        summary: Network interface is reporting many transmit errors.
+      expr: |
+        rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01
+      for: 1h
+      labels:
+        severity: warning
+    - alert: NodeHighNumberConntrackEntriesUsed
+      annotations:
+        description: '{{ $value | humanizePercentage }} of conntrack entries are used.'
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodehighnumberconntrackentriesused
+        summary: Number of conntrack are getting close to the limit.
+      expr: |
+        (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
+      labels:
+        severity: warning
+    - alert: NodeTextFileCollectorScrapeError
+      annotations:
+        description: Node Exporter text file collector failed to scrape.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodetextfilecollectorscrapeerror
+        summary: Node Exporter text file collector failed to scrape.
+      expr: |
+        node_textfile_scrape_error{job="node-exporter"} == 1
+      labels:
+        severity: warning
+    - alert: NodeClockSkewDetected
+      annotations:
+        description: Clock on {{ $labels.instance }} is out of sync by more than 300s.
+          Ensure NTP is configured correctly on this host.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodeclockskewdetected
+        summary: Clock skew detected.
+      expr: |
+        (
+          node_timex_offset_seconds{job="node-exporter"} > 0.05
+        and
+          deriv(node_timex_offset_seconds{job="node-exporter"}[5m]) >= 0
+        )
+        or
+        (
+          node_timex_offset_seconds{job="node-exporter"} < -0.05
+        and
+          deriv(node_timex_offset_seconds{job="node-exporter"}[5m]) <= 0
+        )
+      for: 10m
+      labels:
+        severity: warning
+    - alert: NodeClockNotSynchronising
+      annotations:
+        description: Clock on {{ $labels.instance }} is not synchronising. Ensure
+          NTP is configured on this host.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodeclocknotsynchronising
+        summary: Clock not synchronising.
+      expr: |
+        min_over_time(node_timex_sync_status{job="node-exporter"}[5m]) == 0
+        and
+        node_timex_maxerror_seconds{job="node-exporter"} >= 16
+      for: 10m
+      labels:
+        severity: warning
+    - alert: NodeRAIDDegraded
+      annotations:
+        description: RAID array '{{ $labels.device }}' on {{ $labels.instance }} is
+          in degraded state due to one or more disks failures. Number of spare drives
+          is insufficient to fix issue automatically.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/noderaiddegraded
+        summary: RAID Array is degraded
+      expr: |
+        node_md_disks_required{job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+)"} - ignoring (state) (node_md_disks{state="active",job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+)"}) > 0
+      for: 15m
+      labels:
+        severity: critical
+    - alert: NodeRAIDDiskFailure
+      annotations:
+        description: At least one device in RAID array on {{ $labels.instance }} failed.
+          Array '{{ $labels.device }}' needs attention and possibly a disk swap.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/noderaiddiskfailure
+        summary: Failed device in RAID array
+      expr: |
+        node_md_disks{state="failed",job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+)"} > 0
+      labels:
+        severity: warning
+    - alert: NodeFileDescriptorLimit
+      annotations:
+        description: File descriptors limit at {{ $labels.instance }} is currently
+          at {{ printf "%.2f" $value }}%.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefiledescriptorlimit
+        summary: Kernel is predicted to exhaust file descriptors limit soon.
+      expr: |
+        (
+          node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} > 70
+        )
+      for: 15m
+      labels:
+        severity: warning
+    - alert: NodeFileDescriptorLimit
+      annotations:
+        description: File descriptors limit at {{ $labels.instance }} is currently
+          at {{ printf "%.2f" $value }}%.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefiledescriptorlimit
+        summary: Kernel is predicted to exhaust file descriptors limit soon.
+      expr: |
+        (
+          node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} > 90
+        )
+      for: 15m
+      labels:
+        severity: critical
+  - name: node-exporter.rules
+    interval: 30s
+    rules:
+    - expr: |
+        count without (cpu, mode) (
+          node_cpu_seconds_total{job="node-exporter",mode="idle"}
+        )
+      record: instance:node_num_cpu:sum
+    - expr: |
+        1 - avg without (cpu) (
+          sum without (mode) (rate(node_cpu_seconds_total{job="node-exporter", mode=~"idle|iowait|steal"}[5m]))
+        )
+      record: instance:node_cpu_utilisation:rate5m
+    - expr: |
+        (
+          node_load1{job="node-exporter"}
+        /
+          instance:node_num_cpu:sum{job="node-exporter"}
+        )
+      record: instance:node_load1_per_cpu:ratio
+    - expr: |
+        1 - (
+          (
+            node_memory_MemAvailable_bytes{job="node-exporter"}
+            or
+            (
+              node_memory_Buffers_bytes{job="node-exporter"}
+              +
+              node_memory_Cached_bytes{job="node-exporter"}
+              +
+              node_memory_MemFree_bytes{job="node-exporter"}
+              +
+              node_memory_Slab_bytes{job="node-exporter"}
+            )
+          )
+        /
+          node_memory_MemTotal_bytes{job="node-exporter"}
+        )
+      record: instance:node_memory_utilisation:ratio
+    - expr: |
+        rate(node_vmstat_pgmajfault{job="node-exporter"}[5m])
+      record: instance:node_vmstat_pgmajfault:rate5m
+    - expr: |
+        rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+)"}[5m])
+      record: instance_device:node_disk_io_time_seconds:rate5m
+    - expr: |
+        rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+)"}[5m])
+      record: instance_device:node_disk_io_time_weighted_seconds:rate5m
+    - expr: |
+        sum without (device) (
+          rate(node_network_receive_bytes_total{job="node-exporter", device!="lo"}[5m])
+        )
+      record: instance:node_network_receive_bytes_excluding_lo:rate5m
+    - expr: |
+        sum without (device) (
+          rate(node_network_transmit_bytes_total{job="node-exporter", device!="lo"}[5m])
+        )
+      record: instance:node_network_transmit_bytes_excluding_lo:rate5m
+    - expr: |
+        sum without (device) (
+          rate(node_network_receive_drop_total{job="node-exporter", device!="lo"}[5m])
+        )
+      record: instance:node_network_receive_drop_excluding_lo:rate5m
+    - expr: |
+        sum without (device) (
+          rate(node_network_transmit_drop_total{job="node-exporter", device!="lo"}[5m])
+        )
+      record: instance:node_network_transmit_drop_excluding_lo:rate5m

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -1,0 +1,3 @@
+# Redis sample manifests
+
+Please refer to the [Google Cloud documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/redis) for how to use these manifests.

--- a/examples/redis/exporter.yaml.snippet
+++ b/examples/redis/exporter.yaml.snippet
@@ -1,0 +1,43 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  selector:
+    matchLabels:
++     app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
++       app.kubernetes.io/name: redis
+    spec:
+      containers:
+      - name: redis
+        image: "redis:6.2"
+        ... 
++     - name: redis-exporter
++       image: oliver006/redis_exporter:v1.43.1
++       args: [--include-system-metrics]
++       resources:
++         requests:
++           cpu: 100m
++           memory: 100Mi
++       ports:
++       - containerPort: 9121
+    ...

--- a/examples/redis/pod-monitoring.yaml
+++ b/examples/redis/pod-monitoring.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  endpoints:
+  - port: 9121
+    interval: 30s

--- a/examples/redis/rules.yaml
+++ b/examples/redis/rules.yaml
@@ -1,0 +1,96 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: Rules
+metadata:
+  name: redis-rules
+  labels:
+    app.kubernetes.io/component: rules
+    app.kubernetes.io/name: redis-rules
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  groups:
+  - name: redis
+    interval: 30s
+    rules:
+    - alert: RedisDown
+      annotations:
+        description: |-
+          Redis instance is down 
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: Redis down (instance {{ $labels.instance }})
+      expr: redis_up{job="redis"} == 0
+      for: 5m
+      labels:
+        severity: critical
+    - alert: RedisOutOfMemory
+      annotations:
+        description: |-
+          Redis is running out of memory (> 90%)
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: Redis out of memory (instance {{ $labels.instance }})
+      expr: redis_memory_used_bytes{job="redis"} / redis_total_system_memory_bytes{job="redis"}
+        * 100 > 90
+      for: 5m
+      labels:
+        severity: warning
+    - alert: RedisTooManyConnections
+      annotations:
+        description: |-
+          Redis instance has too many connections
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: Redis too many connections (instance {{ $labels.instance }})
+      expr: redis_connected_clients{job="redis"} > 100
+      for: 5m
+      labels:
+        severity: warning
+    - alert: RedisClusterSlotFail
+      annotations:
+        description: |-
+          Redis cluster has slots fail
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: Number of hash slots mapping to a node in FAIL state (instance {{ $labels.instance }})
+      expr: redis_cluster_slots_fail{job="redis"} > 0
+      for: 5m
+      labels:
+        severity: warning
+    - alert: RedisClusterSlotPfail
+      annotations:
+        description: |-
+          Redis cluster has slots pfail
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: Number of hash slots mapping to a node in PFAIL state (instance {{ $labels.instance }})
+      expr: redis_cluster_slots_pfail{job="redis"} > 0
+      for: 5m
+      labels:
+        severity: warning
+    - alert: RedisClusterStateNotOk
+      annotations:
+        description: |-
+          Redis cluster is not ok 
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: Redis cluster state is not ok (instance {{ $labels.instance }})
+      expr: redis_cluster_state{job="redis"} == 0
+      for: 5m
+      labels:
+        severity: critical
+    - expr: redis_memory_used_rss_bytes{job="redis"} / redis_memory_used_bytes{job="redis"}
+      record: redis_memory_fragmentation_ratio


### PR DESCRIPTION
- one subdirectory for every exporter we have documentation for
- add recommended rules when applicable
- use `.yaml.snippet` extension when snippet shows the recommended delta and cannot be applied as-is as standalone yaml
- add minimal README for each subdirectory pointing readers to the docs pages