### PR TITLE
Handle histogram with out-of-order buckets

### DIFF
--- a/pkg/export/transform.go
+++ b/pkg/export/transform.go
@@ -405,7 +405,10 @@ Loop:
 				prometheusSamplesDiscarded.WithLabelValues("NaN-bucket-value").Inc()
 				continue
 			}
-			dist.hasInfBucket = math.IsInf(bound, 1)
+			// Handle cases where +Inf bucket is out-of-order by not overwriting on the last-consumed bucket.
+			if !dist.hasInfBucket {
+				dist.hasInfBucket = math.IsInf(bound, 1)
+			}
 			dist.bounds = append(dist.bounds, bound)
 			dist.values = append(dist.values, int64(v))
 


### PR DESCRIPTION
This PR is aimed to fix handling histograms with buckets out of the order. Prometheus does not guarantee buckets order. When `+Inf` bucket is not the last bucket we are not able to build distribution because `hasInfBucket` property will be overwritten. The following example cannot be parsed:
```
# HELP custom_query_time Execution time histogram for slow queries [s]
# TYPE custom_query_time histogram
custom_query_time_bucket{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084",le="+Inf"} 35
custom_query_time_bucket{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084",le="1000"} 22
custom_query_time_bucket{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084",le="125"} 18
custom_query_time_bucket{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084",le="16"} 17
custom_query_time_bucket{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084",le="250"} 18
custom_query_time_bucket{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084",le="32"} 18
custom_query_time_bucket{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084",le="4"} 1
custom_query_time_bucket{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084",le="500"} 20
custom_query_time_bucket{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084",le="63"} 18
custom_query_time_bucket{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084",le="8"} 1
custom_query_time_sum{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084"} 205.824447
custom_query_time_count{role="coordinator",server="crdn-vc7b48n9",shortname="Coordinator0084"} 35
```


I believe that order does not matter because we sort built distribution afterward here: https://github.com/GoogleCloudPlatform/prometheus-engine/blob/main/pkg/export/transform.go#L241