### PR TITLE
Fix action defaulting

### DIFF
--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -793,7 +793,8 @@ func convertRelabelingRule(r RelabelingRule) (*relabel.Config, error) {
 
 	// Validate that the protected target labels are not mutated by the provided relabeling rules.
 	switch rcfg.Action {
-	case relabel.Replace, relabel.HashMod:
+	// Default action is "replace" per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config.
+	case relabel.Replace, relabel.HashMod, "":
 		// These actions write into the target label and it must not be a protected one.
 		if isProtectedLabel(r.TargetLabel) {
 			return nil, errors.Errorf("cannot relabel with action %q onto protected label %q", r.Action, r.TargetLabel)

--- a/pkg/operator/apis/monitoring/v1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1/types_test.go
@@ -539,6 +539,9 @@ func TestPodMonitoring_ScrapeConfig(t *testing.T) {
 							Modulus:      3,
 							TargetLabel:  "__tmp_mod",
 						}, {
+							SourceLabels: []string{"mlabel_4"},
+							TargetLabel:  "mlabel_5",
+						}, {
 							Action:  "keep",
 							Regex:   "foo_.+",
 							Modulus: 3,
@@ -641,6 +644,8 @@ metric_relabel_configs:
   modulus: 3
   target_label: __tmp_mod
   action: hashmod
+- source_labels: [mlabel_4]
+  target_label: mlabel_5
 - regex: foo_.+
   modulus: 3
   action: keep

--- a/pkg/operator/apis/monitoring/v1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1/types_test.go
@@ -232,6 +232,22 @@ func TestValidatePodMonitoringCommon(t *testing.T) {
 				},
 			},
 		}, {
+			desc: "metric relabeling: blank 'action' defaults to 'replace'",
+			eps: []ScrapeEndpoint{
+				{
+					Port:     intstr.FromString("web"),
+					Interval: "10s",
+					MetricRelabeling: []RelabelingRule{
+						{
+							SourceLabels: []string{"foo"},
+							TargetLabel:  "bar",
+							Replacement:  "baz",
+						},
+					},
+				},
+			},
+			fail: false,
+		}, {
 			desc: "invalid URL",
 			eps: []ScrapeEndpoint{
 				{

--- a/pkg/operator/apis/monitoring/v1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1/types_test.go
@@ -232,7 +232,7 @@ func TestValidatePodMonitoringCommon(t *testing.T) {
 				},
 			},
 		}, {
-			desc: "metric relabeling: blank 'action' defaults to 'replace'",
+			desc: "metric relabeling: blank 'action' is valid and it defaults to 'replace'",
 			eps: []ScrapeEndpoint{
 				{
 					Port:     intstr.FromString("web"),


### PR DESCRIPTION
Allow Prometheus to default to `replace` when `RelabelingRule.Action` is unspecified, as per the [docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config).