### PR TITLE
use more accurate self-metrics

### DIFF
--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -402,7 +402,7 @@ func (e *Exporter) Export(metadata MetadataFunc, batch []record.RefSample) {
 	e.mtx.Unlock()
 
 	if !ok {
-		prometheusSamplesDiscarded.WithLabelValues("no-ha-range").Add(float64(len(batch)))
+		prometheusSamplesDiscarded.WithLabelValues("no-ha-range").Add(float64(batchSize))
 		return
 	}
 

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -385,6 +385,11 @@ func (e *Exporter) SetLabelsByIDFunc(f func(storage.SeriesRef) labels.Labels) {
 
 // Export enqueues the samples to be written to Cloud Monitoring.
 func (e *Exporter) Export(metadata MetadataFunc, batch []record.RefSample) {
+	// Wether we're sending data or not, add batchsize of samples exported by
+	// Prometheus from appender commit.
+	batchSize := len(batch)
+	samplesExported.Add(float64(batchSize))
+
 	if e.opts.Disable {
 		return
 	}
@@ -397,7 +402,7 @@ func (e *Exporter) Export(metadata MetadataFunc, batch []record.RefSample) {
 	e.mtx.Unlock()
 
 	if !ok {
-		prometheusSamplesDiscarded.WithLabelValues("no-ha-range").Inc()
+		prometheusSamplesDiscarded.WithLabelValues("no-ha-range").Add(float64(len(batch)))
 		return
 	}
 

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -402,7 +402,7 @@ func (e *Exporter) Export(metadata MetadataFunc, batch []record.RefSample) {
 	e.mtx.Unlock()
 
 	if !ok {
-		prometheusSamplesDiscarded.WithLabelValues("no-ha-range").Add(float64(batchSize))
+		samplesDropped.WithLabelValues("no-ha-range").Add(float64(batchSize))
 		return
 	}
 

--- a/pkg/export/shard.go
+++ b/pkg/export/shard.go
@@ -43,8 +43,6 @@ func (s *shard) enqueue(hash uint64, sample *monitoring_pb.TimeSeries) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	samplesExported.Inc()
-
 	e := queueEntry{
 		hash:   hash,
 		sample: sample,


### PR DESCRIPTION
`samplesExported` is a little confusing - especially with [`samplesSent`](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/d268d39aeb5ecdf1277b533b8640a77568978479/pkg/export/export.go#L804). This makes it more clear and accurate.