### PR TITLE
Add rule-evaluator Rolebinding

### DIFF
--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -43,6 +43,7 @@ spec:
                 operator: In
                 values:
                 - linux
+      serviceAccountName: rule-evaluator
       tolerations:
       - effect: NoExecute
         operator: Exists

--- a/cmd/operator/deploy/rule-evaluator/02-service-account.yaml
+++ b/cmd/operator/deploy/rule-evaluator/02-service-account.yaml
@@ -1,0 +1,19 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: gmp-system
+  name: rule-evaluator

--- a/cmd/operator/deploy/rule-evaluator/03-rolebinding.yaml
+++ b/cmd/operator/deploy/rule-evaluator/03-rolebinding.yaml
@@ -1,0 +1,40 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: gmp-system
+  name: rule-evaluator
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: gmp-system
+  name: rule-evaluator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rule-evaluator
+subjects:
+- kind: ServiceAccount
+  namespace: gmp-system
+  name: rule-evaluator

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -75,6 +75,7 @@ spec:
                 operator: In
                 values:
                 - linux
+      serviceAccountName: rule-evaluator
       tolerations:
       - effect: NoExecute
         operator: Exists
@@ -152,3 +153,36 @@ spec:
       - name: rules
         configMap:
           name: rules
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: gmp-system
+  name: rule-evaluator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: gmp-system
+  name: rule-evaluator
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: gmp-system
+  name: rule-evaluator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rule-evaluator
+subjects:
+- kind: ServiceAccount
+  namespace: gmp-system
+  name: rule-evaluator


### PR DESCRIPTION
The rule-evaluator uses default serviceAccount in gmp-system namespace.
The rule-evaluator will list and watch Pods, Services, Endpoints, however if the default serviceAccount doesn't have enough role, the listAndWatch will fail.

The following error message is which I observed in my GKE environment.
```
rule-evaluator-74b57ffbd4-9f94g evaluator W1121 06:16:41.234086       1 reflector.go:324] github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:529: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:gmp-system:default" cannot list resource "pods" in API group "" in the namespace "gmp-system"
rule-evaluator-74b57ffbd4-9f94g evaluator E1121 06:16:41.234123       1 reflector.go:138] github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:529: Failed to watch *v1.Pod: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:gmp-system:default" cannot list resource "pods" in API group "" in the namespace "gmp-system"
rule-evaluator-74b57ffbd4-9f94g evaluator W1121 06:16:48.206006       1 reflector.go:324] github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:527: failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:gmp-system:default" cannot list resource "endpoints" in API group "" in the namespace "gmp-system"
rule-evaluator-74b57ffbd4-9f94g evaluator E1121 06:16:48.206042       1 reflector.go:138] github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:527: Failed to watch *v1.Endpoints: failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:gmp-system:default" cannot list resource "endpoints" in API group "" in the namespace "gmp-system"
rule-evaluator-74b57ffbd4-9f94g evaluator W1121 06:17:20.546536       1 reflector.go:324] github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:528: failed to list *v1.Service: services is forbidden: User "system:serviceaccount:gmp-system:default" cannot list resource "services" in API group "" in the namespace "gmp-system"
rule-evaluator-74b57ffbd4-9f94g evaluator E1121 06:17:20.546625       1 reflector.go:138] github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:528: Failed to watch *v1.Service: failed to list *v1.Service: services is forbidden: User "system:serviceaccount:gmp-system:default" cannot list resource "services" in API group "" in the namespace "gmp-system"
```

In this PR, I added the role and rolebinding for `rule-evaluator`.

This is my first contribution for this repository. If you have any advice or review comments or recommendations, please let me know.
Thanks in advance.