### PR TITLE
wait until Prometheus is ready before reloading

### DIFF
--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -71,7 +71,11 @@ func main() {
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 
 	// Poll ready endpoint indefinitely until it's up and running.
-	req, _ := http.NewRequest(http.MethodGet, *readyURLStr, nil)
+	req, err := http.NewRequest(http.MethodGet, *readyURLStr, nil)
+	if err != nil {
+		level.Error(logger).Log("msg", "creating request", "err", err)
+		os.Exit(1)
+	}
 	ticker := time.NewTicker(500 * time.Millisecond)
 	done := make(chan bool)
 	go func() {

--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -63,6 +63,8 @@ func main() {
 	}
 
 	// Poll Prometheus's ready endpoint until it's up and running.
+	// Note: the ready and reload endpoints are expected to be formatted
+	// as per https://prometheus.io/docs/prometheus/latest/management_api/.
 	readyURLStr := strings.Replace(*reloadURLStr, "reload", "ready", 1)
 	req, _ := http.NewRequest(http.MethodGet, readyURLStr, nil)
 	if err := wait.Poll(2*time.Second, 2*time.Minute, func() (bool, error) {

--- a/cmd/operator/deploy/operator/10-collector.yaml
+++ b/cmd/operator/deploy/operator/10-collector.yaml
@@ -123,6 +123,7 @@ spec:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
         - --reload-url=http://localhost:19090/-/reload
+        - --ready-url=http://localhost:19090/-/ready
         - --listen-address=:19091
         env:
         - name: NODE_NAME

--- a/cmd/operator/deploy/operator/11-rule-evaluator.yaml
+++ b/cmd/operator/deploy/operator/11-rule-evaluator.yaml
@@ -110,6 +110,7 @@ spec:
         - --watched-dir=/etc/rules
         - --watched-dir=/etc/secrets
         - --reload-url=http://localhost:19092/-/reload
+        - --ready-url=http://localhost:19092/-/ready
         - --listen-address=:19093
         ports:
         - containerPort: 19093

--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -103,6 +103,7 @@ spec:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml
         - --reload-url=http://localhost:9093/-/reload
+        - --ready-url=http://localhost:9093/-/ready
         - --listen-address=:19091
         env:
         - name: NODE_NAME

--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -60,10 +60,10 @@ spec:
       initContainers:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:20220419
-        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        command: ['/bin/bash', '-c', 'touch /etc/config/config.yaml']
         volumeMounts:
-        - name: config-out
-          mountPath: /prometheus/config_out
+        - name: config
+          mountPath: /etc/config
       containers:
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.5.0-gke.0

--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -57,6 +57,13 @@ spec:
         operator: "Equal"
         value: "arm64"
         effect: "NoSchedule"
+      initContainers:
+      - name: config-init
+        image: gke.gcr.io/gke-distroless/bash:20220419
+        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        volumeMounts:
+        - name: config-out
+          mountPath: /prometheus/config_out
       containers:
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.5.0-gke.0
@@ -94,6 +101,7 @@ spec:
         - --config-file=/etc/config/config.yaml
         - --watched-dir=/etc/rules
         - --reload-url=http://localhost:9092/-/reload
+        - --ready-url=http://localhost:9092/-/ready
         - --listen-address=:9093
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.5.0-gke.0
         ports:

--- a/examples/prometheus.yaml
+++ b/examples/prometheus.yaml
@@ -126,6 +126,7 @@ spec:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
         - --reload-url=http://localhost:9090/-/reload
+        - --ready-url=http://localhost:9090/-/ready
         - --listen-address=:19091
         ports:
         - name: reloader-web

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -627,6 +627,7 @@ spec:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
         - --reload-url=http://localhost:19090/-/reload
+        - --ready-url=http://localhost:19090/-/ready
         - --listen-address=:19091
         env:
         - name: NODE_NAME
@@ -788,6 +789,7 @@ spec:
         - --watched-dir=/etc/rules
         - --watched-dir=/etc/secrets
         - --reload-url=http://localhost:19092/-/reload
+        - --ready-url=http://localhost:19092/-/ready
         - --listen-address=:19093
         ports:
         - containerPort: 19093
@@ -947,6 +949,7 @@ spec:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml
         - --reload-url=http://localhost:9093/-/reload
+        - --ready-url=http://localhost:9093/-/ready
         - --listen-address=:19091
         env:
         - name: NODE_NAME

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -92,10 +92,10 @@ spec:
       initContainers:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:20220419
-        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        command: ['/bin/bash', '-c', 'touch /etc/config/config.yaml']
         volumeMounts:
-        - name: config-out
-          mountPath: /prometheus/config_out
+        - name: config
+          mountPath: /etc/config
       containers:
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.5.0-gke.0

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -89,6 +89,13 @@ spec:
         operator: "Equal"
         value: "arm64"
         effect: "NoSchedule"
+      initContainers:
+      - name: config-init
+        image: gke.gcr.io/gke-distroless/bash:20220419
+        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        volumeMounts:
+        - name: config-out
+          mountPath: /prometheus/config_out
       containers:
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.5.0-gke.0
@@ -126,6 +133,7 @@ spec:
         - --config-file=/etc/config/config.yaml
         - --watched-dir=/etc/rules
         - --reload-url=http://localhost:9092/-/reload
+        - --ready-url=http://localhost:9092/-/ready
         - --listen-address=:9093
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.5.0-gke.0
         ports:


### PR DESCRIPTION
We occasionally see spikes in [`reloader_reload_fails_total`](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/main/vendor/github.com/thanos-io/thanos/pkg/reloader/reloader.go#L157) at startup due to the config-reloader hitting Prometheus's `/-/reload` endpoint before it's ready.

This change waits and polls for 2 minutes before timing out and exiting.

I tried to to do this with [K8s lifecycle `PostStart` hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks), specifically the `httpGet` action, but this didn't work because the container is killed if the hook fails. As the Prometheus server presumably takes some non-determinate amount of time to start, the hook would almost always fail and kill the container.
> If either a PostStart or PreStop hook fails, it kills the Container.

Note: that using an `exec` action to do this in a bash loop is also not possible as the container is based on the [distroless image](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/9eeab46b71ee4d097252cc1904e63bb7d2c10a2b/cmd/config-reloader/Dockerfile#L8).