### PR TITLE
GKE Security Posture configuration fixes

### DIFF
--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -71,13 +71,10 @@ spec:
           containerPort: 18080
         securityContext:
           allowPrivilegeEscalation: false
-          privileged: false
           capabilities:
             drop:
             - all
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
+          privileged: false
       priorityClassName: gmp-critical
       tolerations:
       - effect: NoExecute
@@ -94,5 +91,8 @@ spec:
         value: "arm64"
         effect: "NoSchedule"
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault

--- a/cmd/operator/deploy/operator/10-collector.yaml
+++ b/cmd/operator/deploy/operator/10-collector.yaml
@@ -52,6 +52,12 @@ spec:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:20220419
         command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - name: config-out
           mountPath: /prometheus/config_out
@@ -110,13 +116,10 @@ spec:
           readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
-          privileged: false
           capabilities:
             drop:
             - all
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
+          privileged: false
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.5.0-gke.0
         args:
@@ -139,23 +142,23 @@ spec:
           requests:
             cpu: 5m
             memory: 16M
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - name: config
           mountPath: /prometheus/config
           readOnly: true
         - name: config-out
           mountPath: /prometheus/config_out
-        securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
-          capabilities:
-            drop:
-            - all
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
       serviceAccountName: collector
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       automountServiceAccountToken: true

--- a/cmd/operator/deploy/operator/11-rule-evaluator.yaml
+++ b/cmd/operator/deploy/operator/11-rule-evaluator.yaml
@@ -49,11 +49,16 @@ spec:
                 operator: In
                 values:
                 - linux
-      serviceAccountName: collector
       initContainers:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:20220419
         command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - name: config-out
           mountPath: /prometheus/config_out
@@ -89,9 +94,6 @@ spec:
             drop:
             - all
           privileged: false
-          runAsGroup: 1000
-          runAsNonRoot: true
-          runAsUser: 1000
         volumeMounts:
         - name: config-out
           mountPath: /prometheus/config_out
@@ -126,9 +128,6 @@ spec:
             drop:
             - all
           privileged: false
-          runAsGroup: 1000
-          runAsNonRoot: true
-          runAsUser: 1000
         volumeMounts:
         - name: config
           mountPath: /prometheus/config
@@ -157,6 +156,9 @@ spec:
         value: "arm64"
         effect: "NoSchedule"
       securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: collector

--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -64,6 +64,12 @@ spec:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:20220419
         command: ['/bin/bash', '-c', 'touch /alertmanager/config_out/config.yaml && echo -e "receivers:\n  - name: noop\nroute:\n  receiver: noop" > alertmanager/config_out/config.yaml']
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - name: alertmanager-config
           mountPath: /alertmanager/config_out
@@ -94,9 +100,6 @@ spec:
             drop:
             - all
           privileged: false
-          runAsGroup: 1000
-          runAsNonRoot: true
-          runAsUser: 1000
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.5.0-gke.0
         args:
@@ -127,15 +130,15 @@ spec:
           mountPath: /alertmanager/config_out
         securityContext:
           allowPrivilegeEscalation: false
-          privileged: false
           capabilities:
             drop:
             - all
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
+          privileged: false
       priorityClassName: gmp-critical
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       tolerations:

--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -43,6 +43,10 @@ spec:
                 operator: In
                 values:
                 - linux
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       tolerations:
       - effect: NoExecute
         operator: Exists
@@ -82,6 +86,12 @@ spec:
           requests:
             cpu: 100m
             memory: 200M
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - mountPath: /etc/config
           name: config
@@ -106,6 +116,12 @@ spec:
           requests:
             cpu: 5m
             memory: 16M
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - mountPath: /etc/config
           name: config

--- a/examples/frontend.yaml
+++ b/examples/frontend.yaml
@@ -54,6 +54,15 @@ spec:
           httpGet:
             path: /-/ready
             port: web
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
         livenessProbe:
           httpGet:
             path: /-/healthy

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -273,13 +273,10 @@ spec:
           containerPort: 18080
         securityContext:
           allowPrivilegeEscalation: false
-          privileged: false
           capabilities:
             drop:
             - all
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
+          privileged: false
       priorityClassName: gmp-critical
       tolerations:
       - effect: NoExecute
@@ -296,6 +293,9 @@ spec:
         value: "arm64"
         effect: "NoSchedule"
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
 ---
@@ -556,6 +556,12 @@ spec:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:20220419
         command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - name: config-out
           mountPath: /prometheus/config_out
@@ -614,13 +620,10 @@ spec:
           readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
-          privileged: false
           capabilities:
             drop:
             - all
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
+          privileged: false
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.5.0-gke.0
         args:
@@ -643,23 +646,23 @@ spec:
           requests:
             cpu: 5m
             memory: 16M
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - name: config
           mountPath: /prometheus/config
           readOnly: true
         - name: config-out
           mountPath: /prometheus/config_out
-        securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
-          capabilities:
-            drop:
-            - all
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
       serviceAccountName: collector
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       automountServiceAccountToken: true
@@ -727,11 +730,16 @@ spec:
                 operator: In
                 values:
                 - linux
-      serviceAccountName: collector
       initContainers:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:20220419
         command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - name: config-out
           mountPath: /prometheus/config_out
@@ -767,9 +775,6 @@ spec:
             drop:
             - all
           privileged: false
-          runAsGroup: 1000
-          runAsNonRoot: true
-          runAsUser: 1000
         volumeMounts:
         - name: config-out
           mountPath: /prometheus/config_out
@@ -804,9 +809,6 @@ spec:
             drop:
             - all
           privileged: false
-          runAsGroup: 1000
-          runAsNonRoot: true
-          runAsUser: 1000
         volumeMounts:
         - name: config
           mountPath: /prometheus/config
@@ -835,6 +837,9 @@ spec:
         value: "arm64"
         effect: "NoSchedule"
       securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: collector
@@ -908,6 +913,12 @@ spec:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:20220419
         command: ['/bin/bash', '-c', 'touch /alertmanager/config_out/config.yaml && echo -e "receivers:\n  - name: noop\nroute:\n  receiver: noop" > alertmanager/config_out/config.yaml']
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - name: alertmanager-config
           mountPath: /alertmanager/config_out
@@ -938,9 +949,6 @@ spec:
             drop:
             - all
           privileged: false
-          runAsGroup: 1000
-          runAsNonRoot: true
-          runAsUser: 1000
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.5.0-gke.0
         args:
@@ -971,15 +979,15 @@ spec:
           mountPath: /alertmanager/config_out
         securityContext:
           allowPrivilegeEscalation: false
-          privileged: false
           capabilities:
             drop:
             - all
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
+          privileged: false
       priorityClassName: gmp-critical
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       tolerations:

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -75,6 +75,10 @@ spec:
                 operator: In
                 values:
                 - linux
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       tolerations:
       - effect: NoExecute
         operator: Exists
@@ -114,6 +118,12 @@ spec:
           requests:
             cpu: 100m
             memory: 200M
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - mountPath: /etc/config
           name: config
@@ -138,6 +148,12 @@ spec:
           requests:
             cpu: 5m
             memory: 16M
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
         volumeMounts:
         - mountPath: /etc/config
           name: config


### PR DESCRIPTION
This fixes the main configurations as well as a few examples. One of the prominent examples I have not covered here is the node-exporter because that has a few issues and I am not familiar with the exporter enough to determine if it would break anything. To be more specific, they have issues with using the host network and volume mounts which I don't believe we could remove.