### PR TITLE
format user agent

### DIFF
--- a/cmd/operator/deploy/operator/10-collector.yaml
+++ b/cmd/operator/deploy/operator/10-collector.yaml
@@ -104,7 +104,7 @@ spec:
         - --web.listen-address=:19090
         - --web.enable-lifecycle
         - --web.route-prefix=/
-        - --export.user-agent=prometheus/2.35.0-gmp.2 (mode:kubectl)
+        - --export.user-agent-mode=kubectl
         ports:
         - name: prom-metrics
           containerPort: 19090

--- a/cmd/operator/deploy/operator/11-rule-evaluator.yaml
+++ b/cmd/operator/deploy/operator/11-rule-evaluator.yaml
@@ -94,7 +94,7 @@ spec:
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
-        - --export.user-agent=rule-evaluator/0.5.0 (mode:kubectl)
+        - --export.user-agent-mode=kubectl
         ports:
         - name: r-eval-metrics
           containerPort: 19092

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -608,7 +608,7 @@ spec:
         - --web.listen-address=:19090
         - --web.enable-lifecycle
         - --web.route-prefix=/
-        - --export.user-agent=prometheus/2.35.0-gmp.2 (mode:kubectl)
+        - --export.user-agent-mode=kubectl
         ports:
         - name: prom-metrics
           containerPort: 19090
@@ -776,7 +776,7 @@ spec:
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
-        - --export.user-agent=rule-evaluator/0.5.0 (mode:kubectl)
+        - --export.user-agent-mode=kubectl
         ports:
         - name: r-eval-metrics
           containerPort: 19092

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -157,8 +157,13 @@ type ExporterOpts struct {
 	CredentialsFile string
 	// Disable authentication (for debugging purposes).
 	DisableAuth bool
-	// A user agent string added as a suffix to the regular user agent.
-	UserAgent string
+	// A user agent product string added to the regular user agent.
+	// See: https://www.rfc-editor.org/rfc/rfc7231#section-5.5.3
+	UserAgentProduct string
+	// A string added as a suffix to the regular user agent.
+	UserAgentMode string
+	// UserAgentEnv where calls to GCM API are made.
+	UserAgentEnv string
 
 	// Default monitored resource fields set on exported data.
 	ProjectID string
@@ -227,7 +232,8 @@ func (alwaysLease) OnLeaderChange(f func()) {
 
 func newMetricClient(ctx context.Context, opts ExporterOpts) (*monitoring.MetricClient, error) {
 	// Identity User Agent for all gRPC requests.
-	ua := strings.TrimSpace(fmt.Sprintf("%s/%s %s", ClientName, Version, opts.UserAgent))
+	ua := strings.TrimSpace(fmt.Sprintf("%s/%s %s (env:%s;mode:%s)",
+		ClientName, Version, opts.UserAgentProduct, opts.UserAgentEnv, opts.UserAgentMode))
 
 	clientOpts := []option.ClientOption{
 		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor)),


### PR DESCRIPTION
Update the user agent formatting to insert an environment `env` which is informed by checking the GCE metadata server [attributes](https://cloud.google.com/compute/docs/metadata/default-metadata-values#vm_instance_metadata).