### PR TITLE
Fix rule-evaluator init container

### DIFF
--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -28,19 +28,21 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
     spec:
+      serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
       initContainers:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:20220419
-        command: ['/bin/bash', '-c', 'touch /etc/config/config.yaml']
+        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
         volumeMounts:
-        - name: config
-          mountPath: /etc/config
+        - name: config-out
+          mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.5.0-gke.0
         args:
-        - --config-file=/etc/config/config.yaml
+        - --config-file=/prometheus/config/config.yaml
+        - --config-file-output=/prometheus/config_out/config.yaml
         - --watched-dir=/etc/rules
         - --reload-url=http://localhost:9092/-/reload
         - --ready-url=http://localhost:9092/-/ready
@@ -58,7 +60,9 @@ spec:
         volumeMounts:
         - name: config
           readOnly: true
-          mountPath: /etc/config
+          mountPath: /prometheus/config
+        - name: config-out
+          mountPath: /prometheus/config_out
         - name: rules
           readOnly: true
           mountPath: /etc/rules
@@ -71,7 +75,7 @@ spec:
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.5.0-gke.0
         args:
-        - "--config.file=/etc/config/config.yaml"
+        - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"
         ports:
         - name: r-eval-metrics
@@ -83,9 +87,9 @@ spec:
             cpu: 100m
             memory: 200M
         volumeMounts:
-        - name: config
+        - name: config-out
           readOnly: true
-          mountPath: /etc/config
+          mountPath: /prometheus/config_out
         - name: rules
           readOnly: true
           mountPath: /etc/rules
@@ -109,6 +113,8 @@ spec:
       - name: config
         configMap:
           name: rule-evaluator
+      - name: config-out
+        emptyDir: {}
       - name: rules
         configMap:
           name: rules

--- a/cmd/operator/deploy/rule-evaluator/02-service-account.yaml
+++ b/cmd/operator/deploy/rule-evaluator/02-service-account.yaml
@@ -1,0 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rule-evaluator

--- a/cmd/operator/deploy/rule-evaluator/03-role.yaml
+++ b/cmd/operator/deploy/rule-evaluator/03-role.yaml
@@ -1,0 +1,33 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rule-evaluator
+rules:
+- resources:
+  - endpoints
+  - nodes
+  - nodes/metrics
+  - pods
+  - services
+  apiGroups: [""]
+  verbs: ["get", "list", "watch"]
+- resources:
+  - configmaps
+  apiGroups: [""]
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/cmd/operator/deploy/rule-evaluator/04-rolebinding.yaml
+++ b/cmd/operator/deploy/rule-evaluator/04-rolebinding.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rule-evaluator
+roleRef:
+  name: rule-evaluator
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- name: rule-evaluator
+  namespace: default
+  kind: ServiceAccount

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -60,19 +60,21 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
     spec:
+      serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
       initContainers:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:20220419
-        command: ['/bin/bash', '-c', 'touch /etc/config/config.yaml']
+        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
         volumeMounts:
-        - name: config
-          mountPath: /etc/config
+        - name: config-out
+          mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.5.0-gke.0
         args:
-        - --config-file=/etc/config/config.yaml
+        - --config-file=/prometheus/config/config.yaml
+        - --config-file-output=/prometheus/config_out/config.yaml
         - --watched-dir=/etc/rules
         - --reload-url=http://localhost:9092/-/reload
         - --ready-url=http://localhost:9092/-/ready
@@ -90,7 +92,9 @@ spec:
         volumeMounts:
         - name: config
           readOnly: true
-          mountPath: /etc/config
+          mountPath: /prometheus/config
+        - name: config-out
+          mountPath: /prometheus/config_out
         - name: rules
           readOnly: true
           mountPath: /etc/rules
@@ -103,7 +107,7 @@ spec:
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.5.0-gke.0
         args:
-        - "--config.file=/etc/config/config.yaml"
+        - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"
         ports:
         - name: r-eval-metrics
@@ -115,9 +119,9 @@ spec:
             cpu: 100m
             memory: 200M
         volumeMounts:
-        - name: config
+        - name: config-out
           readOnly: true
-          mountPath: /etc/config
+          mountPath: /prometheus/config_out
         - name: rules
           readOnly: true
           mountPath: /etc/rules
@@ -141,6 +145,8 @@ spec:
       - name: config
         configMap:
           name: rule-evaluator
+      - name: config-out
+        emptyDir: {}
       - name: rules
         configMap:
           name: rules
@@ -176,3 +182,41 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 1000
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rule-evaluator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rule-evaluator
+rules:
+- resources:
+  - endpoints
+  - nodes
+  - nodes/metrics
+  - pods
+  - services
+  apiGroups: [""]
+  verbs: ["get", "list", "watch"]
+- resources:
+  - configmaps
+  apiGroups: [""]
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rule-evaluator
+roleRef:
+  name: rule-evaluator
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- name: rule-evaluator
+  namespace: default
+  kind: ServiceAccount


### PR DESCRIPTION
When we [removed](https://github.com/GoogleCloudPlatform/prometheus-engine/commit/0c2fcf209332a542e4af5326c413d2eb179f0984) the init container's root permissions, we also removed its ability to touch a file in `/etc/config/config.yaml`. This fixes that, and also makes it consistent with the managed-collection's [rule-evaluator](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/bcabe942c4bf2826a728f2d72baeafad437609ed/cmd/operator/deploy/operator/11-rule-evaluator.yaml#L41-L47).

Let's also add a rule-evaluator role and service account to allow k8s service discovery of alertmanagers, as was originally proposed in #367.