### PR TITLE
Target status e2e test

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,31 +24,70 @@ For the fully Prometheus-compatible binary that writes ingested data into GMP/GC
 see [GoogleCloudPlatform/prometheus](https://github.com/GoogleCloudPlatform/prometheus).
 
 ## Build
-Run `make help` shows a list of candidate targets with documentation.
+To build and deploy everything to your GKE cluster, connect to your GKE cluster and run:
 
-Any go application in `./cmd/` with an associated `main.go`, e.g. `./cmd/operator/main.go`
-is a candidate for build by running:
 ```bash
-make operator
+DOCKER_PUSH=1 make bin
+kubectl apply -f manifests/setup.yaml
+kubectl apply -f manifests/operator.yaml
 ```
 
-- Running `make bin` will generate all the go binaries.
-  - Setting `NO_DOCKER=1` here will build all the binaries natively on the host machine.
-- Running `make test` will run unit and e2e tests.
-  - If `NO_DOCKER=1` is set, end-to-end tests will be run against the current
-  kubectl context. It is assumed the cluster has access to the GCM API.
-  Ensure `GMP_CLUSTER` and `GMP_LOCATION` are set, e.g.
-  ```bash
-  NO_DOCKER=1 GMP_CLUSTER=<my-cluster> GMP_LOCATION=<cluster-location> make test
-  ```
-- Running `make presubmit` will run various checks on the repo to ensure it is
-ready to submit a pull request. This includes testing, formatting,
-and regenerating files in-place.
-  - Setting `DRY_RUN=1` won't regenerate any files but will return a
-  non-zero exit code if the current changes differ from what would be. This
-  can be useful in running in CI workflows.
+The Kubernetes configurations under `manifests/` will be updated with the new Docker image after
+each build.
 
-### Dependencies
+To build a single application, you can use `make` with the application name. Any Go application in
+[`cmd/`](cmd/) with an associated `main.go`, e.g. `./cmd/operator/main.go` is a candidate for build:
+
+```bash
+DOCKER_PUSH=1 make operator
+```
+
+Setting `NO_DOCKER=1` in front of `make` will simply build a binary without tagging it. If you want
+to run binaries locally, do not apply the manifests YAML configurations otherwise you may have two
+instances of the binary running -- the one you run locally and the one from the Kubernetes
+`Deployment` configuration.
+
+For a list of candidate targets with documentation, run:
+
+```bash
+make help
+```
+
+## Unit Tests
+To run unit tests:
+
+```bash
+make test
+```
+
+If `NO_DOCKER=1` is set, end-to-end tests will be run against the current Kubernetes context. It is
+assumed the cluster has access to the GCM API. Ensure `GMP_CLUSTER` and `GMP_LOCATION` are set, e.g.
+
+```bash
+NO_DOCKER=1 GMP_CLUSTER=<my-cluster> GMP_LOCATION=<cluster-location> make test
+```
+
+## Integration Tests
+To run end-to-end tests against a `kind` cluster:
+
+```bash
+make kindtest
+```
+
+See the [operator README](./pkg/operator/README.md) for instructions on running the end-to-end test
+on your own cluster.
+
+## Contributing
+To run various checks on the repo to ensure your changes are ready to submit a pull request, run:
+
+```bash
+make presubmit
+```
+
+This includes testing, formatting, and regenerating files in-place. Setting `DRY_RUN=1` won't
+regenerate any files but will return a non-zero exit code if the current changes differ from what
+would be. This can be useful in running in CI workflows.
+
 In order to best develop and contribute to this repository, the following dependencies are
 recommended:
 1. [`go`](https://golang.org/doc/install)

--- a/pkg/operator/README.md
+++ b/pkg/operator/README.md
@@ -4,17 +4,24 @@ See the [binary documentation](../../cmd/operator/README.md) for deployment inst
 
 ## Testing
 
-The operator has an end-to-end test suite to run functional tests against a real
-Kubernetes cluster.
+The operator has an end-to-end test suite to run functional tests against a real Kubernetes cluster.
 
-To run the tests a kubeconfig pointing to a GKE cluster is required. This is generally
-already taken care of while setting up a GKE cluster
+To run the tests a kubeconfig pointing to a GKE cluster is required. This is generally already taken
+care of while setting up a GKE cluster
 ([instructions](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-zonal-cluster)).
 Use `kubectl config {current,set}-context` to verify or change which cluster the tests will
 execute against.
 
-The test expects various resources, which are part of deploying the operator, to be installed
-in the cluster:
+The easiest way to run end-to-end tests is to deploy all the operator yourself and connect to that
+cluster by passing `--local-operator` to your test:
+
+```bash
+go test ./e2e/ --local-operator \
+    --project-id=$PROJECT_ID --cluster=$CLUSTER_NAME --location=$LOCATION
+```
+
+To run the test with a test-deployed operator, the test expects various resources, which are part of
+deploying the operator, to be installed in the cluster:
 
 ```bash
 kubectl apply -f ../../cmd/operator/deploy/crds/


### PR DESCRIPTION
This PR builds on top of #386

Due to the nature of `kind` tests running the operator within the test itself, target status cannot be done without port forwarding so for non-local operators, the tests were disabled.