### PR TITLE
fix issue with non-RFC 6890

### DIFF
--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -67,7 +67,6 @@ spec:
         - --storage.path=/alertmanager-data
         - --cluster.listen-address=[$(POD_IP)]:9094
         - --web.listen-address=:9093
-        - --web.route-prefix=/
         ports:
         - name: alertmanager
           containerPort: 9093

--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -65,9 +65,18 @@ spec:
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data
+        - --cluster.listen-address=[$(POD_IP)]:9094
+        - --web.listen-address=:9093
+        - --web.route-prefix=/
         ports:
         - name: alertmanager
           containerPort: 9093
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         resources:
           limits:
             memory: 1G

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -918,7 +918,6 @@ spec:
         - --storage.path=/alertmanager-data
         - --cluster.listen-address=[$(POD_IP)]:9094
         - --web.listen-address=:9093
-        - --web.route-prefix=/
         ports:
         - name: alertmanager
           containerPort: 9093

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -916,9 +916,18 @@ spec:
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data
+        - --cluster.listen-address=[$(POD_IP)]:9094
+        - --web.listen-address=:9093
+        - --web.route-prefix=/
         ports:
         - name: alertmanager
           containerPort: 9093
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         resources:
           limits:
             memory: 1G


### PR DESCRIPTION
In rare cases, the alertmanager pod can end up on a IP that is not a part of [RFC 6890](https://www.rfc-editor.org/rfc/rfc6890.html), which can cause error messages like:
```
ts=2022-12-10T13:01:12.632Z caller=main.go:263 level=error msg="unable to initialize gossip mesh" err="create memberlist: Failed to get final advertise address: No private IP address found, and explicit IP not provided"
```
The [recommended fix](https://github.com/prometheus/alertmanager/blob/99a464c914ce265e9db2d64036c9785eb09f6a5e/README.md#high-availability) is to specify the `--cluster.advertise-address` flag. However, if the `--cluster.listen-address` is specified, [it is used](https://github.com/GoogleCloudPlatform/alertmanager/blob/v0.24.0-gmp.0/cluster/cluster.go#L175-L188) as the default.

This also mimics behavior in [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator/blob/f05c64c74df03ae4f78e547b8d1b52f1439d8549/pkg/alertmanager/statefulset.go#L243-L247).