### PR TITLE
examples: cert-manager podmonitoring manifest

### DIFF
--- a/examples/cert-manager/README.md
+++ b/examples/cert-manager/README.md
@@ -1,0 +1,1 @@
+# Cert-Manager sample manifests

--- a/examples/cert-manager/pod-monitoring.yaml
+++ b/examples/cert-manager/pod-monitoring.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: cert-manager
+  labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  endpoints:
+  - port: http-metrics
+    interval: 30s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager


### PR DESCRIPTION
Add an example for the basic cert-manager podmonitoring manifest to scrape the cert-manager metrics 
