### PR TITLE
Fix deprecated, missing error and type cast lint checks

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/api/option"
 	apihttp "google.golang.org/api/transport/http"
@@ -74,8 +75,8 @@ func main() {
 
 	metrics := prometheus.NewRegistry()
 	metrics.MustRegister(
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 
 	if *projectID == "" {
@@ -148,7 +149,9 @@ func main() {
 			return server.ListenAndServe()
 		}, func(err error) {
 			ctx, _ = context.WithTimeout(ctx, time.Minute)
-			server.Shutdown(ctx)
+			if err := server.Shutdown(ctx); err != nil {
+				level.Error(logger).Log("msg", "unable to shut down server", "err", err)
+			}
 			cancel()
 		})
 	}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -37,10 +37,6 @@ import (
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator"
 )
 
-func unstableFlagHelp(help string) string {
-	return help + " (Setting this flag voids any guarantees of proper behavior of the operator.)"
-}
-
 func main() {
 	var (
 		defaultProjectID string
@@ -138,7 +134,9 @@ func main() {
 			return server.ListenAndServe()
 		}, func(err error) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			server.Shutdown(ctx)
+			if err := server.Shutdown(ctx); err != nil {
+				logger.Error(err, "unable to shut down server")
+			}
 			cancel()
 		})
 	}

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
@@ -76,8 +77,8 @@ func main() {
 
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 
 	// The rule-evaluator version is identical to the export library version for now, so
@@ -353,7 +354,9 @@ func main() {
 			return server.ListenAndServe()
 		}, func(err error) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			server.Shutdown(ctx)
+			if err := server.Shutdown(ctx); err != nil {
+				level.Error(logger).Log("msg", "unable to shut down server", "err", err)
+			}
 			cancel()
 		})
 	}

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -38,6 +38,7 @@ import (
 	"google.golang.org/api/option"
 	monitoring_pb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 )
 
@@ -245,7 +246,7 @@ func newMetricClient(ctx context.Context, opts ExporterOpts) (*monitoring.Metric
 	if opts.DisableAuth {
 		clientOpts = append(clientOpts,
 			option.WithoutAuthentication(),
-			option.WithGRPCDialOption(grpc.WithInsecure()),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		)
 	}
 	if opts.CredentialsFile != "" {

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -36,6 +36,7 @@ import (
 	monitoredres_pb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoring_pb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 	empty_pb "google.golang.org/protobuf/types/known/emptypb"
 )
@@ -353,7 +354,7 @@ func TestExporter_drainBacklog(t *testing.T) {
 	}
 	metricClient, err := monitoring.NewMetricClient(ctx,
 		option.WithoutAuthentication(),
-		option.WithGRPCDialOption(grpc.WithInsecure()),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		option.WithGRPCDialOption(grpc.WithContextDialer(bufDialer)),
 	)
 	if err != nil {

--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -15,16 +15,10 @@
 package v1alpha1
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-)
-
-var (
-	errInvalidCond = fmt.Errorf("condition needs both 'Type' and 'Status' fields set")
 )
 
 // OperatorConfig defines configuration of the gmp-operator.

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -371,12 +371,6 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := pmon.ScrapeConfigs(projectID, location, cluster)
 		if err != nil {
 			msg := "generating scrape config failed for PodMonitoring endpoint"
-			cond = &monitoringv1.MonitoringCondition{
-				Type:    monitoringv1.ConfigurationCreateSuccess,
-				Status:  corev1.ConditionFalse,
-				Reason:  "ScrapeConfigError",
-				Message: msg,
-			}
 			logger.Error(err, msg, "namespace", pmon.Namespace, "name", pmon.Name)
 			continue
 		}
@@ -410,12 +404,6 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := cmon.ScrapeConfigs(projectID, location, cluster)
 		if err != nil {
 			msg := "generating scrape config failed for PodMonitoring endpoint"
-			cond = &monitoringv1.MonitoringCondition{
-				Type:    monitoringv1.ConfigurationCreateSuccess,
-				Status:  corev1.ConditionFalse,
-				Reason:  "ScrapeConfigError",
-				Message: msg,
-			}
 			logger.Error(err, msg, "namespace", cmon.Namespace, "name", cmon.Name)
 			continue
 		}

--- a/pkg/operator/collection_test.go
+++ b/pkg/operator/collection_test.go
@@ -131,15 +131,19 @@ func TestCollectionStatus(t *testing.T) {
 		Build()
 
 	collectionReconciler := newCollectionReconciler(kubeClient, opts)
-	collectionReconciler.Reconcile(ctx, reconcile.Request{
+	if _, err := collectionReconciler.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: opts.PublicNamespace,
 			Name:      NameOperatorConfig,
 		},
-	})
+	}); err != nil {
+		t.Fatalf("collection reconcile failed: %s", err)
+	}
 
 	var podMonitorings monitoringv1.PodMonitoringList
-	kubeClient.List(ctx, &podMonitorings)
+	if err := kubeClient.List(ctx, &podMonitorings); err != nil {
+		t.Fatalf("unable to get PodMonitorings: %s", err)
+	}
 	switch amount := len(podMonitorings.Items); amount {
 	case 1:
 		status := podMonitorings.Items[0].Status
@@ -152,7 +156,6 @@ func TestCollectionStatus(t *testing.T) {
 		if diff := cmp.Diff(status, statusOut); diff != "" {
 			t.Fatalf("invalid PodMonitoringStatus: %s", diff)
 		}
-		break
 	default:
 		t.Fatalf("invalid PodMonitorings found: %d", amount)
 	}

--- a/pkg/operator/e2e/context.go
+++ b/pkg/operator/e2e/context.go
@@ -226,6 +226,9 @@ func (tctx *testContext) createBaseResources(ctx context.Context) ([]metav1.Owne
 		return nil, errors.Wrap(err, "read collector YAML")
 	}
 	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(collectorBytes, nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "decode evaluator")
+	}
 	collector := obj.(*appsv1.DaemonSet)
 	collector.Namespace = tctx.namespace
 
@@ -239,6 +242,9 @@ func (tctx *testContext) createBaseResources(ctx context.Context) ([]metav1.Owne
 	}
 
 	obj, _, err = scheme.Codecs.UniversalDeserializer().Decode(evaluatorBytes, nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "decode evaluator")
+	}
 	evaluator := obj.(*appsv1.Deployment)
 	evaluator.Namespace = tctx.namespace
 
@@ -256,23 +262,20 @@ func (tctx *testContext) createBaseResources(ctx context.Context) ([]metav1.Owne
 		if err != nil {
 			return nil, errors.Wrap(err, "deserializing alertmanager manifest")
 		}
-		switch obj.(type) {
+		switch obj := obj.(type) {
 		case *appsv1.StatefulSet:
-			alertmanager := obj.(*appsv1.StatefulSet)
-			alertmanager.Namespace = tctx.namespace
-			if _, err := tctx.kubeClient.AppsV1().StatefulSets(tctx.namespace).Create(ctx, alertmanager, metav1.CreateOptions{}); err != nil {
+			obj.Namespace = tctx.namespace
+			if _, err := tctx.kubeClient.AppsV1().StatefulSets(tctx.namespace).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
 				return nil, errors.Wrap(err, "create alertmanager statefulset")
 			}
 		case *corev1.Secret:
-			amSecret := obj.(*corev1.Secret)
-			amSecret.Namespace = tctx.namespace
-			if _, err := tctx.kubeClient.CoreV1().Secrets(tctx.namespace).Create(ctx, amSecret, metav1.CreateOptions{}); err != nil {
+			obj.Namespace = tctx.namespace
+			if _, err := tctx.kubeClient.CoreV1().Secrets(tctx.namespace).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
 				return nil, errors.Wrap(err, "create alertmanager secret")
 			}
 		case *corev1.Service:
-			amSvc := obj.(*corev1.Service)
-			amSvc.Namespace = tctx.namespace
-			if _, err := tctx.kubeClient.CoreV1().Services(tctx.namespace).Create(ctx, amSvc, metav1.CreateOptions{}); err != nil {
+			obj.Namespace = tctx.namespace
+			if _, err := tctx.kubeClient.CoreV1().Services(tctx.namespace).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
 				return nil, errors.Wrap(err, "create alertmanager service")
 			}
 		}

--- a/pkg/operator/e2e/main_test.go
+++ b/pkg/operator/e2e/main_test.go
@@ -165,7 +165,7 @@ route:
 	spec := &monitoringv1.ManagedAlertmanagerSpec{
 		ConfigSecret: &v1.SecretKeySelector{
 			LocalObjectReference: v1.LocalObjectReference{
-				"my-secret-name",
+				Name: "my-secret-name",
 			},
 			Key: "my-secret-key",
 		},

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -78,8 +78,6 @@ const (
 	RuleEvaluatorAppName = "managed-prometheus-rule-evaluator"
 	AlertmanagerAppName  = "managed-prometheus-alertmanager"
 
-	// How often to poll the targets.
-	targetPollInterval = 10 * time.Second
 	// The level of concurrency to use to fetch all targets.
 	defaultTargetPollConcurrency = 4
 )

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -394,7 +394,9 @@ func (o *Operator) Run(ctx context.Context, registry prometheus.Registerer) erro
 	o.logger.Info("starting GMP operator")
 
 	go func() {
-		o.managedNamespacesCache.Start(ctx)
+		if err := o.managedNamespacesCache.Start(ctx); err != nil {
+			o.logger.Error(err, "unable to start managed namespaces cache")
+		}
 	}()
 	return o.manager.Start(ctx)
 }

--- a/pkg/operator/target_status.go
+++ b/pkg/operator/target_status.go
@@ -113,12 +113,14 @@ func setupTargetStatusPoller(op *Operator, registry prometheus.Registerer) error
 	}
 
 	// Start the controller only once.
-	op.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
+	if err := op.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		reconciler.ch <- event.GenericEvent{
 			Object: &appsv1.DaemonSet{},
 		}
 		return nil
-	}))
+	})); err != nil {
+		return errors.Wrap(err, "unable to start target status controller")
+	}
 
 	return nil
 }
@@ -211,7 +213,7 @@ func fetchTargets(ctx context.Context, logger logr.Logger, opts Options, getTarg
 				// Fetch operation is blocking.
 				target, err := getTarget(ctx, logger, prometheusPod.port, prometheusPod.pod)
 				if err != nil {
-					logger.Error(err, "failed to fetch target")
+					logger.Error(err, "failed to fetch target", "pod", prometheusPod.pod.GetName())
 				}
 				// nil represents being unable to reach a target.
 				targetCh <- target
@@ -362,6 +364,9 @@ func getPrometheusPods(ctx context.Context, kubeClient client.Client, opts Optio
 }
 
 func getTarget(ctx context.Context, logger logr.Logger, port int32, pod *corev1.Pod) (*prometheusv1.TargetsResult, error) {
+	if pod.Status.PodIP == "" {
+		return nil, errors.New("pod does not have IP allocated")
+	}
 	podUrl := fmt.Sprintf("http://%s:%d", pod.Status.PodIP, port)
 	client, err := api.NewClient(api.Config{
 		Address: podUrl,

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -39,10 +39,12 @@ func TestScope(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("Unexpected input errors: %s", errs)
 	}
-	err := Scope(groups, map[string]string{
+	if err := Scope(groups, map[string]string{
 		"l1": "v1",
 		"l2": "v2",
-	})
+	}); err != nil {
+		t.Fatalf("Unable to set scope: %s", err)
+	}
 	want := `groups:
     - name: test
       rules:

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -57,7 +57,9 @@ func Handler(externalURL *url.URL) http.Handler {
 			idx = bytes.ReplaceAll(idx, []byte("CONSOLES_LINK_PLACEHOLDER"), []byte(""))
 			idx = bytes.ReplaceAll(idx, []byte("TITLE_PLACEHOLDER"), []byte("Google Cloud Managed Service for Prometheus"))
 
-			w.Write(idx)
+			if _, err := w.Write(idx); err != nil {
+				fmt.Fprintf(w, "Error writing bytes: %s", err)
+			}
 		})
 	}
 


### PR DESCRIPTION
This fixes all lints warnings in the operator package and a few in other packages.