### PR TITLE
Update the RabbitMQ sample PodMonitoring manifest

### DIFF
--- a/examples/rabbitmq/pod-monitoring.yaml
+++ b/examples/rabbitmq/pod-monitoring.yaml
@@ -27,4 +27,7 @@ spec:
     path: /metrics
   selector:
     matchLabels:
+      # If RabbitMQ is installed via the operator, use this label selector
       app.kubernetes.io/component: rabbitmq
+      # If installing RabbitMQ via GCP click-to-deploy, use this instead
+      # app.kubernetes.io/component: rabbitmq-server


### PR DESCRIPTION
There are two common ways to install RabbitMQ which result in pods with different label selectors. Acknowledge both options in the example.

This manifest is embedded in https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/rabbitmq#exporter-podmonitoring which also includes a paragraph reminder to check this against the labels on the RabbitMQ pods.