### PR TITLE
add init container to prom example

### DIFF
--- a/examples/prometheus.yaml
+++ b/examples/prometheus.yaml
@@ -93,6 +93,19 @@ spec:
                 operator: In
                 values:
                 - linux
+      initContainers:
+      - name: config-init
+        image: gke.gcr.io/gke-distroless/bash:20220419
+        command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
+        volumeMounts:
+        - name: config-out
+          mountPath: /prometheus/config_out
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
       containers:
       - name: prometheus
         image: gke.gcr.io/prometheus-engine/prometheus:v2.35.0-gmp.2-gke.0


### PR DESCRIPTION
Since the `config-reloader` logic was [changed](https://github.com/GoogleCloudPlatform/prometheus-engine/commit/edba0b43a3c502fb670a78e2adf0343e8abffd53) to return an error if there was a connection issue with the `ready-url`, the pod is never able to start.

`prometheus` is looking for the [config file output](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/c50410e403ce13bfd248f5d0d950988e858797f2/examples/prometheus.yaml#L100) from the `config-reloader` before returning a 200 on `/-/ready`, but since the `config-reloader` is exiting before its main routine, the file is never generated. So it's stuck in a broken loop.

The init container priming the pod with a [blank config](https://github.com/GoogleCloudPlatform/prometheus-engine/pull/422/commits/0487f2343ad9064b50ffa7c61ccf531bc070936a#diff-f5609820b8572f20b3b31a413009e43ea58ad42e14bc07a98d27d007324204f5R99) breaks this cycle to allow the pod to start successfully.