### PR TITLE
Update Grafana version

### DIFF
--- a/examples/grafana.yaml
+++ b/examples/grafana.yaml
@@ -42,7 +42,7 @@ spec:
                 - linux
       containers:
       - name: grafana
-        image: grafana/grafana:8.3.4
+        image: grafana/grafana:9.4.7
         ports:
         - name: web
           containerPort: 3000


### PR DESCRIPTION
We have tested GMP with 9.4.7 and all is well. Upgrading from 8.4.x to 9.4.7 can break GMP as Grafana added a setting for "Prometheus version" which changes autocomplete behavior if version is set too low. Better to default to a version which has that from the beginning.