### PR TITLE
Use static target for managed Alertmanager

### DIFF
--- a/pkg/operator/e2e/main_test.go
+++ b/pkg/operator/e2e/main_test.go
@@ -316,6 +316,14 @@ func testRuleEvaluatorConfig(ctx context.Context, t *testContext) {
         external_key: external_val
 alerting:
     alertmanagers:
+        - follow_redirects: true
+          enable_http2: true
+          scheme: http
+          timeout: 10s
+          api_version: v2
+          static_configs:
+            - targets:
+                - alertmanager.{namespace}.svc.cluster.local:9093
         - authorization:
             type: Bearer
             credentials_file: /etc/secrets/secret_{pubNamespace}_alertmanager-authorization_token
@@ -337,29 +345,6 @@ alerting:
               regex: (.+):\d+
               target_label: __address__
               replacement: $1:19093
-              action: replace
-          kubernetes_sd_configs:
-            - role: endpoints
-              kubeconfig_file: ""
-              follow_redirects: true
-              enable_http2: true
-              namespaces:
-                own_namespace: false
-                names:
-                    - {namespace}
-        - follow_redirects: true
-          enable_http2: true
-          scheme: http
-          timeout: 10s
-          api_version: v2
-          relabel_configs:
-            - source_labels: [__meta_kubernetes_endpoints_name]
-              regex: alertmanager
-              action: keep
-            - source_labels: [__address__]
-              regex: (.+):\d+
-              target_label: __address__
-              replacement: $1:9093
               action: replace
           kubernetes_sd_configs:
             - role: endpoints

--- a/pkg/operator/e2e/main_test.go
+++ b/pkg/operator/e2e/main_test.go
@@ -323,7 +323,7 @@ alerting:
           api_version: v2
           static_configs:
             - targets:
-                - alertmanager.{namespace}.svc.cluster.local:9093
+                - alertmanager.{namespace}:9093
         - authorization:
             type: Bearer
             credentials_file: /etc/secrets/secret_{pubNamespace}_alertmanager-authorization_token

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -464,7 +464,7 @@ func (r *operatorConfigReconciler) makeAlertmanagerConfigs(ctx context.Context, 
 		if ports := amSvc.Spec.Ports; len(ports) > 0 {
 			// Assume first port on service is the correct endpoint.
 			port := ports[0].Port
-			svcDNSName := fmt.Sprintf("%s.%s.svc.cluster.local:%d", amSvc.Name, amSvc.Namespace, port)
+			svcDNSName := fmt.Sprintf("%s.%s:%d", amSvc.Name, amSvc.Namespace, port)
 			cfg := promconfig.DefaultAlertmanagerConfig
 			cfg.ServiceDiscoveryConfigs = discovery.Configs{
 				discovery.StaticConfig{


### PR DESCRIPTION
Since the managed Alertmanager service is known, we can rely on [K8s DNS resolution](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#services) of services to configure a static target to route alerts to.

This is an expected improvement over relying on K8s SD as it reduces the watch load in OOTB deployments.