### PR TITLE
use higher limits for operator and rule-evaluator

### DIFF
--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -59,7 +59,7 @@ spec:
           containerPort: 18080
         resources:
           limits:
-            memory: 512M
+            memory: 2G
           requests:
             cpu: 8m
             memory: 32M

--- a/cmd/operator/deploy/operator/11-rule-evaluator.yaml
+++ b/cmd/operator/deploy/operator/11-rule-evaluator.yaml
@@ -101,7 +101,7 @@ spec:
           containerPort: 19092
         resources:
           limits:
-            memory: 256M
+            memory: 1G
           requests:
             cpu: 8m
             memory: 32M

--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -54,7 +54,7 @@ spec:
           containerPort: 9093
         resources:
           limits:
-            memory: 32M
+            memory: 1G
           requests:
             cpu: 8m
             memory: 16M

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -261,7 +261,7 @@ spec:
           containerPort: 18080
         resources:
           limits:
-            memory: 512M
+            memory: 2G
           requests:
             cpu: 8m
             memory: 32M
@@ -787,7 +787,7 @@ spec:
           containerPort: 19092
         resources:
           limits:
-            memory: 256M
+            memory: 1G
           requests:
             cpu: 8m
             memory: 32M

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -86,7 +86,7 @@ spec:
           containerPort: 9093
         resources:
           limits:
-            memory: 32M
+            memory: 1G
           requests:
             cpu: 8m
             memory: 16M


### PR DESCRIPTION
While extremely rare, we have seen cases where memory of these components can bleed up to the limits specified here. 