### PR TITLE
Adjust rule-evaluator memory limits

### DIFF
--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -54,7 +54,7 @@ spec:
           containerPort: 9093
         resources:
           limits:
-            memory: 1G
+            memory: 32M
           requests:
             cpu: 8m
             memory: 16M
@@ -83,7 +83,7 @@ spec:
           containerPort: 9092
         resources:
           limits:
-            memory: 256M
+            memory: 1G
           requests:
             cpu: 8m
             memory: 32M

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -86,7 +86,7 @@ spec:
           containerPort: 9093
         resources:
           limits:
-            memory: 1G
+            memory: 32M
           requests:
             cpu: 8m
             memory: 16M
@@ -115,7 +115,7 @@ spec:
           containerPort: 9092
         resources:
           limits:
-            memory: 256M
+            memory: 1G
           requests:
             cpu: 8m
             memory: 32M


### PR DESCRIPTION
Increase evaluator memory limit to 1G
reset config-reloader to 32M from 1G