### PR TITLE
Update sample KSM HPA API version

### DIFF
--- a/examples/kube-state-metrics/kube-state-metrics.yaml
+++ b/examples/kube-state-metrics/kube-state-metrics.yaml
@@ -272,9 +272,7 @@ rules:
   - list
   - watch
 ---
-# TODO(pintohutch): bump to autoscaling/v2 when 1.23 is the default in the GKE
-# stable release channel.
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: kube-state-metrics


### PR DESCRIPTION
Remove TODO given that 1.24 is now the default version in stable (https://cloud.google.com/kubernetes-engine/docs/release-notes-stable)

Testing plan: apply this manifest in a cluster, get no errors.