### PR TITLE
tolerate ready-url errors and retry

### DIFF
--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -87,9 +87,10 @@ func main() {
 				os.Exit(0)
 			case <-ticker.C:
 				resp, err := http.DefaultClient.Do(req)
+				// Log but tolerate the error here as a "connection refused"
+				// error from Prometheus is a retryable event during startup.
 				if err != nil {
 					level.Error(logger).Log("msg", "polling ready-url", "err", err)
-					os.Exit(1)
 				}
 				if resp.StatusCode == http.StatusOK {
 					level.Info(logger).Log("msg", "ready-url is healthy")

--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -90,7 +90,7 @@ func main() {
 				// Log but tolerate the error here as a "connection refused"
 				// error from Prometheus is a retryable event during startup.
 				if err != nil {
-					level.Error(logger).Log("msg", "polling ready-url", "err", err)
+					level.Error(logger).Log("msg", "polling ready-url", "status", resp.StatusCode, "err", err)
 				}
 				if resp.StatusCode == http.StatusOK {
 					level.Info(logger).Log("msg", "ready-url is healthy")


### PR DESCRIPTION
Tolerate http request errors when calling the ready url.

During start-up, Prometheus could refuse connections, resulting in the returned error here. This should be tolerated and retried to mitigate container restarts.

Fixes #472 