### PR TITLE
Add auto-assign to issues and PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,18 @@
+name: Issue assignment
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Auto-assign issue
+      uses: pozil/auto-assign-issue@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        assignees: ${{ secrets.DEFAULT_ISSUE_ASSIGNEE }}
+        abortIfPreviousAssignees: true


### PR DESCRIPTION
Automatically assigns the team on a rotation basis. An internal script updates the repository's secret with the value of the week's user: https://github.com/GoogleCloudPlatform/prometheus-engine/settings/secrets/actions