### PR TITLE
Include Endpoint index in job_name (#479)

### DIFF
--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -244,6 +244,10 @@ func (p *PodMonitoring) GetKey() string {
 	return fmt.Sprintf("PodMonitoring/%s/%s", p.Namespace, p.Name)
 }
 
+func (p *PodMonitoring) GetEndpointKey(index int) string {
+	return fmt.Sprintf("%s/%s/%d", p.GetKey(), &p.Spec.Endpoints[index].Port, index)
+}
+
 func (p *PodMonitoring) GetStatus() *PodMonitoringStatus {
 	return &p.Status
 }
@@ -277,6 +281,10 @@ type ClusterPodMonitoring struct {
 
 func (p *ClusterPodMonitoring) GetKey() string {
 	return fmt.Sprintf("ClusterPodMonitoring/%s", p.Name)
+}
+
+func (p *ClusterPodMonitoring) GetEndpointKey(index int) string {
+	return fmt.Sprintf("%s/%s/%d", p.GetKey(), &p.Spec.Endpoints[index].Port, index)
 }
 
 func (p *ClusterPodMonitoring) GetStatus() *PodMonitoringStatus {
@@ -452,7 +460,7 @@ func (pm *PodMonitoring) endpointScrapeConfig(index int, projectID, location, cl
 	})
 
 	return endpointScrapeConfig(
-		pm.GetKey(),
+		pm.GetEndpointKey(index),
 		projectID, location, cluster,
 		pm.Spec.Endpoints[index],
 		relabelCfgs,
@@ -698,7 +706,7 @@ func endpointScrapeConfig(id, projectID, location, cluster string, ep ScrapeEndp
 	scrapeCfg := &promconfig.ScrapeConfig{
 		// Generate a job name to make it easy to track what generated the scrape configuration.
 		// The actual job label attached to its metrics is overwritten via relabeling.
-		JobName:                 fmt.Sprintf("%s/%s", id, &ep.Port),
+		JobName:                 id,
 		ServiceDiscoveryConfigs: discoveryCfgs,
 		MetricsPath:             metricsPath,
 		Scheme:                  ep.Scheme,
@@ -793,7 +801,7 @@ func (cm *ClusterPodMonitoring) endpointScrapeConfig(index int, projectID, locat
 	})
 
 	return endpointScrapeConfig(
-		cm.GetKey(),
+		cm.GetEndpointKey(index),
 		projectID, location, cluster,
 		cm.Spec.Endpoints[index],
 		relabelCfgs,

--- a/pkg/operator/apis/monitoring/v1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1/types_test.go
@@ -584,7 +584,7 @@ func TestPodMonitoring_ScrapeConfig(t *testing.T) {
 		got = append(got, string(b))
 	}
 	want := []string{
-		`job_name: PodMonitoring/ns1/name1/web
+		`job_name: PodMonitoring/ns1/name1/web/0
 honor_timestamps: false
 scrape_interval: 10s
 scrape_timeout: 10s
@@ -658,7 +658,7 @@ kubernetes_sd_configs:
   - role: pod
     field: spec.nodeName=$(NODE_NAME)
 `,
-		`job_name: PodMonitoring/ns1/name1/8080
+		`job_name: PodMonitoring/ns1/name1/8080/1
 honor_timestamps: false
 scrape_interval: 10s
 scrape_timeout: 5s
@@ -796,7 +796,7 @@ func TestClusterPodMonitoring_ScrapeConfig(t *testing.T) {
 		got = append(got, string(b))
 	}
 	want := []string{
-		`job_name: ClusterPodMonitoring/name1/web
+		`job_name: ClusterPodMonitoring/name1/web/0
 honor_timestamps: false
 scrape_interval: 10s
 scrape_timeout: 10s
@@ -865,7 +865,7 @@ kubernetes_sd_configs:
   - role: pod
     field: spec.nodeName=$(NODE_NAME)
 `,
-		`job_name: ClusterPodMonitoring/name1/8080
+		`job_name: ClusterPodMonitoring/name1/8080/1
 honor_timestamps: false
 scrape_interval: 10s
 scrape_timeout: 5s


### PR DESCRIPTION
This fixes the issue described in #479.

### Summary

- A ServiceMonitor resource from the monitoring.coreos.com/v1 API can contain multiple endpoints with the same port name but different paths in its spec.
- Scraping job names generated from ServiceMonitor resource contain endpoint indexes (e.g. `ServiceMonitor/ns1/name1/0`, `ServiceMonitor/ns1/name1/1`, see the [implementation](https://github.com/prometheus-operator/prometheus-operator/blob/b5327e7e66e818b8b924332191d4888d45d270e4/pkg/prometheus/promcfg.go#L1075)).
- A PodMonitoring resource from the monitoring.googleapis.com/v1 API can contain multiple endpoints with the same port name but different paths in its spec.
- Scraping job names generated from PodMonitoring resource *does not* contain endpoint indexes (e.g. `PodMonitoring/ns1/name1/http`, `PodMonitoring/ns1/name1/http`, see the [implementation](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/b353ebdee8236c5daa7c6cc93d0d23c0d3c1cd13/pkg/operator/apis/monitoring/v1/types.go#L244)). This way job names get duplicated.
- Prometheus does not allow duplicated job names in a scraping configuration.

This PR includes endpoint indexes into job names to fix the issue. However, the resulting job names' format differs from the upstream format (which does not include a port name):

```diff
- ServiceMonitor/ns1/name1/0
+ PodMonitoring/ns1/name1/http/0
```

I'm not entirely sure if the format should match the upstream or not.