### PR TITLE
Set default interval for ScrapeEndpoint

### DIFF
--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -90,7 +90,9 @@ spec:
                       x-kubernetes-int-or-string: true
                     interval:
                       type: string
+                      default: 1m
                       description: Interval at which to scrape metrics. Must be a valid Prometheus duration.
+                      pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                     metricRelabeling:
                       type: array
                       description: Relabeling rules for metrics scraped from this endpoint. Relabeling rules that override protected target labels (project_id, location, cluster, namespace, job, instance, or __address__) are not permitted. The labelmap action is not permitted in general.

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -90,7 +90,9 @@ spec:
                       x-kubernetes-int-or-string: true
                     interval:
                       type: string
+                      default: 1m
                       description: Interval at which to scrape metrics. Must be a valid Prometheus duration.
+                      pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                     metricRelabeling:
                       type: array
                       description: Relabeling rules for metrics scraped from this endpoint. Relabeling rules that override protected target labels (project_id, location, cluster, namespace, job, instance, or __address__) are not permitted. The labelmap action is not permitted in general.

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -92,7 +92,9 @@ spec:
                       x-kubernetes-int-or-string: true
                     interval:
                       type: string
+                      default: 1m
                       description: Interval at which to scrape metrics. Must be a valid Prometheus duration.
+                      pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                     metricRelabeling:
                       type: array
                       description: Relabeling rules for metrics scraped from this endpoint. Relabeling rules that override protected target labels (project_id, location, cluster, namespace, job, instance, or __address__) are not permitted. The labelmap action is not permitted in general.
@@ -1470,7 +1472,9 @@ spec:
                       x-kubernetes-int-or-string: true
                     interval:
                       type: string
+                      default: 1m
                       description: Interval at which to scrape metrics. Must be a valid Prometheus duration.
+                      pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                     metricRelabeling:
                       type: array
                       description: Relabeling rules for metrics scraped from this endpoint. Relabeling rules that override protected target labels (project_id, location, cluster, namespace, job, instance, or __address__) are not permitted. The labelmap action is not permitted in general.

--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -988,6 +988,8 @@ type ScrapeEndpoint struct {
 	// Proxy URL to scrape through. Encoded passwords are not supported.
 	ProxyURL string `json:"proxyUrl,omitempty"`
 	// Interval at which to scrape metrics. Must be a valid Prometheus duration.
+	// +kubebuilder:validation:Pattern="^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$"
+	// +kubebuilder:default="1m"
 	Interval string `json:"interval,omitempty"`
 	// Timeout for metrics scrapes. Must be a valid Prometheus duration.
 	// Must not be larger then the scrape interval.


### PR DESCRIPTION
Fix #491

Also adding validation for the field, based on the [regex provided in the Prometheus duration spec](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file).