### PR TITLE
Bump images to 0.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,10 @@ presubmit:   ## Run all checks and tests before submitting a change
              ##
 presubmit: regen bin test kindtest
 
-CURRENT_TAG = v0.6.3-gke.0
+CURRENT_TAG = v0.7.1-gke.0
 CURRENT_PROM_TAG = v2.35.0-gmp.5-gke.0
 CURRENT_AM_TAG = v0.24.0-gmp.3-gke.1
-LABEL_API_VERSION = 0.6.3
+LABEL_API_VERSION = 0.7.1
 FILES_TO_UPDATE = $(shell find . -type f -name "*.yaml" ! -name "kube-state-metrics.yaml" ! -name "node-exporter.yaml")
 updateversions: $(SED)
 	@echo ">> Updating prometheus-engine images in manifests to $(CURRENT_TAG)"

--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -36,14 +36,14 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.6.3
+        app.kubernetes.io/version: 0.7.1
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/operator:v0.7.1-gke.0
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"

--- a/cmd/operator/deploy/operator/10-collector.yaml
+++ b/cmd/operator/deploy/operator/10-collector.yaml
@@ -28,7 +28,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.6.3
+        app.kubernetes.io/version: 0.7.1
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -53,7 +53,7 @@ spec:
           privileged: false
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.7.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml

--- a/cmd/operator/deploy/operator/11-rule-evaluator.yaml
+++ b/cmd/operator/deploy/operator/11-rule-evaluator.yaml
@@ -29,7 +29,7 @@ spec:
       labels:
         app: managed-prometheus-rule-evaluator
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.6.3
+        app.kubernetes.io/version: 0.7.1
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -54,7 +54,7 @@ spec:
           privileged: false
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.7.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -91,7 +91,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.7.1-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092

--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -41,7 +41,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.6.3
+        app.kubernetes.io/version: 0.7.1
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
@@ -96,7 +96,7 @@ spec:
             - all
           privileged: false
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.7.1-gke.0
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.6.3
+        app.kubernetes.io/version: 0.7.1
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
@@ -40,7 +40,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.7.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -74,7 +74,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.7.1-gke.0
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"

--- a/examples/prometheus.yaml
+++ b/examples/prometheus.yaml
@@ -134,7 +134,7 @@ spec:
         - name: prometheus-db
           mountPath: /prometheus/data
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.7.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -238,14 +238,14 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.6.3
+        app.kubernetes.io/version: 0.7.1
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/operator:v0.7.1-gke.0
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"
@@ -534,7 +534,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.6.3
+        app.kubernetes.io/version: 0.7.1
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -559,7 +559,7 @@ spec:
           privileged: false
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.7.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -715,7 +715,7 @@ spec:
       labels:
         app: managed-prometheus-rule-evaluator
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.6.3
+        app.kubernetes.io/version: 0.7.1
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -740,7 +740,7 @@ spec:
           privileged: false
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.7.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -777,7 +777,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.7.1-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
@@ -892,7 +892,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.6.3
+        app.kubernetes.io/version: 0.7.1
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
@@ -947,7 +947,7 @@ spec:
             - all
           privileged: false
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.7.1-gke.0
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -59,7 +59,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.6.3
+        app.kubernetes.io/version: 0.7.1
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
@@ -72,7 +72,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.7.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -106,7 +106,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.6.3-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.7.1-gke.0
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"


### PR DESCRIPTION
To prepare for the 0.7.1 release.

After this, we will update the release-0.7 branch by cherry-picking everything from 0.7.1 including this commit.