### PR TITLE
Fix tag detection on external unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ DOCKER_VOLUME:=$(DOCKER_HOST:unix://%=%)
 IMAGE_REGISTRY?=gcr.io/$(PROJECT_ID)/prometheus-engine
 TAG_NAME?=$(shell date "+gmp-%Y%d%m_%H%M")
 
+# TODO(TheSpiritXIII): Temporary env variables part of `export.go` unit tests.
+export TEST_TAG=true
+
 # Support gsed on OSX (installed via brew), falling back to sed. On Linux
 # systems gsed won't be installed, so will use sed as expected.
 SED ?= $(shell which gsed 2>/dev/null || which sed)
@@ -104,8 +107,9 @@ ifeq ($(NO_DOCKER), 1)
 	go test `go list ./... | grep -v operator/e2e | grep -v export/bench`
 	go test `go list ./... | grep operator/e2e` -args -project-id=${PROJECT_ID} -cluster=${GMP_CLUSTER} -location=${GMP_LOCATION}
 else
+	# TODO(TheSpiritXIII): Temporary env variables part of `export.go` unit tests.
 	$(call docker_build, -f ./hack/Dockerfile --target sync -o . -t gmp/hermetic \
-		--build-arg RUNCMD='GIT_TAG="$(shell git describe --tags --abbrev=0)" ./hack/presubmit.sh test' .)
+		--build-arg RUNCMD='GIT_TAG="$(shell git describe --tags --abbrev=0)" TEST_TAG=true ./hack/presubmit.sh test' .)
 	rm -rf vendor.tmp
 endif
 

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -507,11 +507,14 @@ func Testing() bool {
 // restrictions. While testing, the static version is validated for correctness.
 func Version() (string, error) {
 	if Testing() {
-		// TODO(TheSpiritXIII): After https://github.com/golang/go/issues/50603 just return empty
+		// TODO(TheSpiritXIII): After https://github.com/golang/go/issues/50603 just return an empty
 		// string here. For now, use the opportunity to confirm that the static version is correct.
 		// We manually get the closest git tag if the user is running the unit test locally, but
 		// fallback to the GIT_TAG environment variable in case the user is running the test via
 		// Docker (like `make test` does by default).
+		if testTag, found := os.LookupEnv("TEST_TAG"); !found || testTag == "false" {
+			return mainModuleVersion, nil
+		}
 		cmd := exec.Command("git", "describe", "--tags", "--abbrev=0")
 		var stdout bytes.Buffer
 		cmd.Stdout = &stdout


### PR DESCRIPTION
PR #481 missed a case where an external application was running unit tests.