### PR TITLE
fix cluster label auto-populate in GCE

### DIFF
--- a/pkg/export/setup/setup.go
+++ b/pkg/export/setup/setup.go
@@ -96,8 +96,8 @@ func FromFlags(a *kingpin.Application, userAgentProduct string) func(log.Logger,
 	if metadata.OnGCE() {
 		env = UAEnvGCE
 		opts.ProjectID, _ = metadata.ProjectID()
-		cluster, _ := metadata.InstanceAttributeValue("cluster-name")
-		if cluster != "" {
+		opts.Cluster, _ = metadata.InstanceAttributeValue("cluster-name")
+		if opts.Cluster != "" {
 			env = UAEnvGKE
 		}
 		// These attributes are set for GKE nodes. For the location, we first check


### PR DESCRIPTION
I previously removed the auto-populated default in GCE in https://github.com/GoogleCloudPlatform/prometheus-engine/commit/f2a1b010e37b7bf48b5f300e18f33df0d41e7277#diff-5b0aad29927670f209bb47d27f555506630c61d4c7c1c3fa8130bd99e9d5fe2aR97, causing the `cluster` label to not be auto-populated in GCE/GKE in ingested metrics to GMP.

This is the fix.