### PR TITLE
Update kube-state-metrics.yaml ClusterPodMonitoring object to include…

### DIFF
--- a/examples/kube-state-metrics/kube-state-metrics.yaml
+++ b/examples/kube-state-metrics/kube-state-metrics.yaml
@@ -318,7 +318,7 @@ spec:
     interval: 30s
     metricRelabeling:
     - action: keep
-      regex: kube_(daemonset|deployment|pod|namespace|node|statefulset|persistentvolumes)_.+
+      regex: kube_(daemonset|deployment|pod|namespace|node|statefulset|persistentvolume)_.+
       sourceLabels: [__name__]
   targetLabels:
     metadata: [] # explicitly empty so the metric labels are respected

--- a/examples/kube-state-metrics/kube-state-metrics.yaml
+++ b/examples/kube-state-metrics/kube-state-metrics.yaml
@@ -318,7 +318,7 @@ spec:
     interval: 30s
     metricRelabeling:
     - action: keep
-      regex: kube_(daemonset|deployment|pod|namespace|node|statefulset)_.+
+      regex: kube_(daemonset|deployment|pod|namespace|node|statefulset|persistentvolumes)_.+
       sourceLabels: [__name__]
   targetLabels:
     metadata: [] # explicitly empty so the metric labels are respected

--- a/examples/kube-state-metrics/kube-state-metrics.yaml
+++ b/examples/kube-state-metrics/kube-state-metrics.yaml
@@ -318,7 +318,7 @@ spec:
     interval: 30s
     metricRelabeling:
     - action: keep
-      regex: kube_(daemonset|deployment|pod|namespace|node|statefulset|persistentvolume)_.+
+      regex: kube_(daemonset|deployment|pod|namespace|node|statefulset|persistentvolume|horizontalpodautoscaler)_.+
       sourceLabels: [__name__]
   targetLabels:
     metadata: [] # explicitly empty so the metric labels are respected


### PR DESCRIPTION
… persistentvolumes

Currently ClusterPodMonitoring regex drops PersistentVolumes, this will now include this object type and prevent it from being dropped.

Essentially this also fixes empty GMP PV/HPA dashboards.