### PR TITLE
Use JSON logger for the collector

### DIFF
--- a/cmd/operator/deploy/operator/10-collector.yaml
+++ b/cmd/operator/deploy/operator/10-collector.yaml
@@ -107,6 +107,8 @@ spec:
         - --web.enable-lifecycle
         - --web.route-prefix=/
         - --export.user-agent-mode=kubectl
+        # JSON log format is needed for GKE to display log levels correctly.
+        - --log.format=json
         ports:
         - name: prom-metrics
           containerPort: 19090

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -613,6 +613,8 @@ spec:
         - --web.enable-lifecycle
         - --web.route-prefix=/
         - --export.user-agent-mode=kubectl
+        # JSON log format is needed for GKE to display log levels correctly.
+        - --log.format=json
         ports:
         - name: prom-metrics
           containerPort: 19090


### PR DESCRIPTION
All of the collector logs(INFO,DEBUG,etc) were showing up as ERRORs.

![image](https://github.com/GoogleCloudPlatform/prometheus-engine/assets/89922129/d7d59f7e-a7ae-4e69-8c46-c51030c18481)

This's because GKE needs structured
logs(https://cloud.google.com/stackdriver/docs/solutions/gke/managing-logs#best_practices) to show log level correctly.

By using the JSON logger error levels will be displayed correctly.

Confirmed working in
https://github.com/GoogleCloudPlatform/prometheus/pull/74