### PR TITLE
Update kind used in kindtest target

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -58,7 +58,7 @@ COPY --from=buildbase /usr/local/go /usr/local
 RUN apt-get install kubectl
 
 # Install kind.
-RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
 RUN install -o root -g root -m 0755 kind /usr/local/bin/kind \
   && rm kind
 


### PR DESCRIPTION
Update from v0.11.1 to v0.20.1. This resolves a bug on my local development environment where kind cluster fails to create.