### PR TITLE
Use JSON logger for GMP components

### DIFF
--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	flag.Parse()
 
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
 

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -68,7 +68,7 @@ var (
 func main() {
 	flag.Parse()
 
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
 

--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -68,6 +68,7 @@ spec:
         - --storage.path=/alertmanager-data
         - --cluster.listen-address=[$(POD_IP)]:9094
         - --web.listen-address=:9093
+        - --log.format=json
         ports:
         - name: alertmanager
           containerPort: 9093

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -61,7 +61,7 @@ import (
 const projectIDVar = "PROJECT_ID"
 
 func main() {
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
 

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -921,6 +921,7 @@ spec:
         - --storage.path=/alertmanager-data
         - --cluster.listen-address=[$(POD_IP)]:9094
         - --web.listen-address=:9093
+        - --log.format=json
         ports:
         - name: alertmanager
           containerPort: 9093

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -306,7 +306,7 @@ func TestExporter_wrapMetadata(t *testing.T) {
 		},
 	}
 
-	e, err := New(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true})
+	e, err := New(log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,7 +360,7 @@ func TestExporter_drainBacklog(t *testing.T) {
 		t.Fatalf("Creating metric client failed: %s", err)
 	}
 
-	e, err := New(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true})
+	e, err := New(log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true})
 	if err != nil {
 		t.Fatalf("Creating Exporter failed: %s", err)
 	}


### PR DESCRIPTION
Similar to https://github.com/GoogleCloudPlatform/prometheus-engine/pull/517. JSON logs are needed for GKE to display logs correctly. 

The following components were modified to use the JSON logger:
1. alertmanager
2. rule-evaluator
3. config-reloader
4. frontend

Tested with @TheSpiritXIII and confirmed working in GKE.

Tested in a clean GKE cluster without GMP enabled using: 
```
DOCKER_PUSH=1 make operator
DOCKER_PUSH=1 make rule-evaluator
DOCKER_PUSH=1 make config-reloader
DOCKER_PUSH=1 make frontend

kubectl apply -f manifests/setup.yaml 
kubectl apply -f manifests/operator.yaml 
kubectl apply -n gmp-system -f examples/frontend.yaml 

// Verify log levels in each component are appearing correctly.
```

pkg/export/export_test.go was updated to match the logger used in the collector that was updated in https://github.com/GoogleCloudPlatform/prometheus-engine/pull/517