### PR TITLE
Updated MongoDB exporter example to use new flag

### DIFF
--- a/examples/mongodb/exporter.yaml
+++ b/examples/mongodb/exporter.yaml
@@ -30,9 +30,10 @@ spec:
     spec:
       containers:
       - name: exporter
-        image: percona/mongodb_exporter:0.20
+        image: percona/mongodb_exporter:0.39
         args:
         - --mongodb.uri=mongodb://user:password@mongodb-service-name:27017
+        - --collect-all
         ports:
         - name: prometheus
           containerPort: 9216


### PR DESCRIPTION
**Changes**
* [Updated the example for the MongoDB exporter to use new flag](https://github.com/GoogleCloudPlatform/prometheus-engine/commit/4c5c85d3cab65f863b6b14d8b022792de33801c0)

**Details**

Based on this [PR](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/pull/592), a newer version of the MongoDB exporter requires a flag for collecting metrics.