### PR TITLE
Update Debian to latest stable release

### DIFF
--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster AS buildbase
+FROM golang:1.20-bookworm AS buildbase
 WORKDIR /app
 COPY . ./
 

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM golang:1.20-buster AS buildbase
+FROM golang:1.20-bookworm AS buildbase
 
 # Compile the UI assets.
 FROM launcher.gcr.io/google/nodejs as assets

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster AS buildbase
+FROM golang:1.20-bookworm AS buildbase
 WORKDIR /app
 COPY . ./
 

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster AS buildbase
+FROM golang:1.20-bookworm AS buildbase
 WORKDIR /app
 COPY . ./
 

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,6 +1,6 @@
 # deps builds binaries in an isolated environment to avoid
 # funkiness in the hermetic build.
-FROM golang:1.20-buster as deps
+FROM golang:1.20-bookworm as deps
 WORKDIR /workspace
 # Have to clone and install this as the go.mod uses replace directives.
 RUN git clone --depth 1 --branch v0.53.1 https://github.com/prometheus-operator/prometheus-operator  \
@@ -10,7 +10,7 @@ RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.12.0
 
 # hermetic is a lite copy of the repo resources used in building
 # testing in a hermetic, idempotent, and reproducable environment.
-FROM golang:1.20-buster AS hermetic
+FROM golang:1.20-bookworm AS hermetic
 RUN curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.7/kustomize_v4.5.7_linux_amd64.tar.gz | tar -zx -C /usr/local/bin
 COPY --from=deps /go/bin /go/bin
 ARG RUNCMD='go fmt ./...'
@@ -50,7 +50,7 @@ COPY --from=hermetic /workspace/e2e e2e
 COPY --from=hermetic /workspace/vendor vendor.tmp
 
 ## kindtest image for running tests against kind cluster in hermetic environment.
-FROM golang:1.20-buster as buildbase
+FROM golang:1.20-bookworm as buildbase
 FROM google/cloud-sdk:slim as kindtest
 
 WORKDIR /build


### PR DESCRIPTION
Need to update to golang:1.20.7 to fix security vulnerabilities.

golang 1.20-buster supports only until golang 1.20.5, it's also the oldoldstable of debian.

golang 1.20-bookworm is the current stable release. https://wiki.debian.org/DebianReleases