### PR TITLE
use Debian 12

### DIFF
--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.20-bookworm AS buildbase
+FROM golang:1.20-bullseye AS buildbase
 WORKDIR /app
 COPY . ./
 
 FROM buildbase as appbase
 RUN CGO_ENABLED=0 go build -mod=vendor -o config-reloader cmd/config-reloader/*.go
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static-debian11:latest
 COPY --from=appbase /app/config-reloader /bin/config-reloader
 ENTRYPOINT ["/bin/config-reloader"]

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM golang:1.20-bookworm AS buildbase
+FROM golang:1.20-bullseye AS buildbase
 
 # Compile the UI assets.
 FROM launcher.gcr.io/google/nodejs as assets
@@ -22,6 +22,6 @@ WORKDIR /app
 COPY --from=assets /app ./
 RUN CGO_ENABLED=0 go build -tags builtinassets -mod=vendor -o frontend ./cmd/frontend/*.go
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static-debian11:latest
 COPY --from=appbase /app/frontend /bin/frontend
 ENTRYPOINT ["/bin/frontend"]

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.20-bookworm AS buildbase
+FROM golang:1.20-bullseye AS buildbase
 WORKDIR /app
 COPY . ./
 
 FROM buildbase as appbase
 RUN CGO_ENABLED=0 go build -mod=vendor -o operator cmd/operator/*.go
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static-debian11:latest
 COPY --from=appbase /app/operator /bin/operator
 ENTRYPOINT ["/bin/operator"]

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.20-bookworm AS buildbase
+FROM golang:1.20-bullseye AS buildbase
 WORKDIR /app
 COPY . ./
 
 FROM buildbase as appbase
 RUN CGO_ENABLED=0 go build -mod=vendor -o rule-evaluator cmd/rule-evaluator/*.go
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static-debian11:latest
 COPY --from=appbase /app/rule-evaluator /bin/rule-evaluator
 ENTRYPOINT ["/bin/rule-evaluator"]

--- a/examples/instrumentation/go-synthetic/Dockerfile
+++ b/examples/instrumentation/go-synthetic/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS buildbase
+FROM golang:1.20-bullseye AS buildbase
 WORKDIR /app
 COPY . ./
 
@@ -6,6 +6,6 @@ FROM buildbase as appbase
 
 RUN CGO_ENABLED=0 go build -o go-synthetic ./examples/instrumentation/go-synthetic/main.go
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static-debian11:latest
 COPY --from=appbase /app/go-synthetic /bin/go-synthetic
 ENTRYPOINT ["/bin/go-synthetic"]

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,6 +1,6 @@
 # deps builds binaries in an isolated environment to avoid
 # funkiness in the hermetic build.
-FROM golang:1.20-bookworm as deps
+FROM golang:1.20-bullseye as deps
 WORKDIR /workspace
 # Have to clone and install this as the go.mod uses replace directives.
 RUN git clone --depth 1 --branch v0.53.1 https://github.com/prometheus-operator/prometheus-operator  \
@@ -10,7 +10,7 @@ RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.12.0
 
 # hermetic is a lite copy of the repo resources used in building
 # testing in a hermetic, idempotent, and reproducable environment.
-FROM golang:1.20-bookworm AS hermetic
+FROM golang:1.20-bullseye AS hermetic
 RUN curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.7/kustomize_v4.5.7_linux_amd64.tar.gz | tar -zx -C /usr/local/bin
 COPY --from=deps /go/bin /go/bin
 ARG RUNCMD='go fmt ./...'
@@ -50,7 +50,7 @@ COPY --from=hermetic /workspace/e2e e2e
 COPY --from=hermetic /workspace/vendor vendor.tmp
 
 ## kindtest image for running tests against kind cluster in hermetic environment.
-FROM golang:1.20-bookworm as buildbase
+FROM golang:1.20-bullseye as buildbase
 FROM google/cloud-sdk:slim as kindtest
 
 WORKDIR /build


### PR DESCRIPTION
Debian 12 is not supported yet.

Change `gcr.io/distroless/static:latest` to `gcr.io/distroless/static-debian11:latest` for consistency with GoogleCloudPlatform/prometheus and GoogleCloudPlatform/alertmanager