### PR TITLE
add replicaset and specific job metric to support sample dashboards

### DIFF
--- a/examples/kube-state-metrics/kube-state-metrics.yaml
+++ b/examples/kube-state-metrics/kube-state-metrics.yaml
@@ -318,7 +318,7 @@ spec:
     interval: 30s
     metricRelabeling:
     - action: keep
-      regex: kube_(daemonset|deployment|pod|namespace|node|statefulset|persistentvolume|horizontalpodautoscaler)_.+
+      regex: kube_(daemonset|deployment|replicaset|pod|namespace|node|statefulset|persistentvolume|horizontalpodautoscaler|job_created)(_.+)?
       sourceLabels: [__name__]
   targetLabels:
     metadata: [] # explicitly empty so the metric labels are respected

--- a/examples/kube-state-metrics/kube-state-metrics.yaml
+++ b/examples/kube-state-metrics/kube-state-metrics.yaml
@@ -318,6 +318,9 @@ spec:
     interval: 30s
     metricRelabeling:
     - action: keep
+      # Curated subset of metrics to reduce costs while populating default set of sample dashboards at
+      # https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/tree/master/dashboards/kubernetes
+      # Change this regex to fit your needs for which objects you want to monitor    
       regex: kube_(daemonset|deployment|replicaset|pod|namespace|node|statefulset|persistentvolume|horizontalpodautoscaler|job_created)(_.+)?
       sourceLabels: [__name__]
   targetLabels:


### PR DESCRIPTION
To support sample dashboard content:

`replicaset`  - [Kubernetes Infrastructure Promtheus Overview
](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/blob/master/dashboards/kubernetes/k8s-overview-prometheus.json)

`job_created` - [Kubernetes Pod Prometheus Overview
](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/blob/master/dashboards/kubernetes/k8s-pod-prometheus.json)