### PR TITLE
Update TLS config to match Prometheus settings

### DIFF
--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -150,6 +150,12 @@ spec:
                         insecureSkipVerify:
                           type: boolean
                           description: Disable target certificate validation.
+                        maxVersion:
+                          type: string
+                          description: 'Maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
+                        minVersion:
+                          type: string
+                          description: 'Minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
                         serverName:
                           type: string
                           description: Used to verify the hostname for the targets.

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_operatorconfigs.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_operatorconfigs.yaml
@@ -291,6 +291,12 @@ spec:
                               required:
                               - key
                               x-kubernetes-map-type: atomic
+                            maxVersion:
+                              type: string
+                              description: 'Maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
+                            minVersion:
+                              type: string
+                              description: 'Minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
                             serverName:
                               type: string
                               description: Used to verify the hostname for the targets.

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -150,6 +150,12 @@ spec:
                         insecureSkipVerify:
                           type: boolean
                           description: Disable target certificate validation.
+                        maxVersion:
+                          type: string
+                          description: 'Maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
+                        minVersion:
+                          type: string
+                          description: 'Minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
                         serverName:
                           type: string
                           description: Used to verify the hostname for the targets.

--- a/doc/api.md
+++ b/doc/api.md
@@ -633,6 +633,8 @@ TLS specifies TLS configuration parameters from Kubernetes resources.
 | ----- | ----------- | ------ | -------- |
 | serverName | Used to verify the hostname for the targets. | string | false |
 | insecureSkipVerify | Disable target certificate validation. | bool | false |
+| minVersion | Minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config. | string | false |
+| maxVersion | Maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config. | string | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -650,6 +652,8 @@ TLSConfig specifies TLS configuration parameters from Kubernetes resources.
 | keySecret | Secret containing the client key file for the targets. | *[v1.SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core) | false |
 | serverName | Used to verify the hostname for the targets. | string | false |
 | insecureSkipVerify | Disable target certificate validation. | bool | false |
+| minVersion | Minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config. | string | false |
+| maxVersion | Maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config. | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -152,6 +152,12 @@ spec:
                         insecureSkipVerify:
                           type: boolean
                           description: Disable target certificate validation.
+                        maxVersion:
+                          type: string
+                          description: 'Maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
+                        minVersion:
+                          type: string
+                          description: 'Minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
                         serverName:
                           type: string
                           description: Used to verify the hostname for the targets.
@@ -1137,6 +1143,12 @@ spec:
                               required:
                               - key
                               x-kubernetes-map-type: atomic
+                            maxVersion:
+                              type: string
+                              description: 'Maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
+                            minVersion:
+                              type: string
+                              description: 'Minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
                             serverName:
                               type: string
                               description: Used to verify the hostname for the targets.
@@ -1552,6 +1564,12 @@ spec:
                         insecureSkipVerify:
                           type: boolean
                           description: Disable target certificate validation.
+                        maxVersion:
+                          type: string
+                          description: 'Maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
+                        minVersion:
+                          type: string
+                          description: 'Minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3). If unset, Prometheus will use Go default minimum version, which is TLS 1.2. See MinVersion in https://pkg.go.dev/crypto/tls#Config.'
                         serverName:
                           type: string
                           description: Used to verify the hostname for the targets.

--- a/pkg/operator/apis/monitoring/v1/http.go
+++ b/pkg/operator/apis/monitoring/v1/http.go
@@ -1,12 +1,39 @@
 package v1
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/prometheus/common/config"
 )
 
-func (c *TLS) ToPrometheusConfig() *config.TLSConfig {
+func TLSVersionFromString(s string) (config.TLSVersion, error) {
+	if s == "" {
+		return 0, nil
+	}
+	if v, ok := config.TLSVersions[s]; ok {
+		return v, nil
+	}
+	return 0, fmt.Errorf("unknown TLS version: %s", s)
+}
+
+func (c *TLS) ToPrometheusConfig() (*config.TLSConfig, error) {
+	var errs []error
+	minVersion, err := TLSVersionFromString(c.MinVersion)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("unable to convert TLS min version: %w", err))
+	}
+	maxVersion, err := TLSVersionFromString(c.MaxVersion)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("unable to convert TLS min version: %w", err))
+	}
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
 	return &config.TLSConfig{
 		InsecureSkipVerify: c.InsecureSkipVerify,
 		ServerName:         c.ServerName,
-	}
+		MinVersion:         minVersion,
+		MaxVersion:         maxVersion,
+	}, nil
 }

--- a/pkg/operator/apis/monitoring/v1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1/types_test.go
@@ -280,6 +280,35 @@ func TestValidatePodMonitoringCommon(t *testing.T) {
 			tls: TargetLabels{
 				Metadata: stringSlicePtr(),
 			},
+		}, {
+			desc: "TLS setting invalid",
+			eps: []ScrapeEndpoint{
+				{
+					Port:     intstr.FromString("web"),
+					Interval: "10s",
+					HTTPClientConfig: HTTPClientConfig{
+						TLS: &TLS{
+							MinVersion: "TLS09",
+						},
+					},
+				},
+			},
+			fail:        true,
+			errContains: `unknown TLS version`,
+		}, {
+			desc: "TLS setting valid",
+			eps: []ScrapeEndpoint{
+				{
+					Port:     intstr.FromString("web"),
+					Interval: "10s",
+					HTTPClientConfig: HTTPClientConfig{
+						TLS: &TLS{
+							MinVersion: "TLS13",
+						},
+					},
+				},
+			},
+			errContains: `unknown TLS version`,
 		},
 	}
 

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -519,9 +519,20 @@ func (r *operatorConfigReconciler) makeAlertmanagerConfigs(ctx context.Context, 
 		}
 		// TLS config.
 		if am.TLS != nil {
+			minVersion, err := monitoringv1.TLSVersionFromString(am.TLS.MinVersion)
+			if err != nil {
+				return nil, nil, fmt.Errorf("unable to convert TLS min version: %w", err)
+			}
+			maxVersion, err := monitoringv1.TLSVersionFromString(am.TLS.MaxVersion)
+			if err != nil {
+				return nil, nil, fmt.Errorf("unable to convert TLS min version: %w", err)
+			}
+
 			tlsCfg := promcommonconfig.TLSConfig{
 				InsecureSkipVerify: am.TLS.InsecureSkipVerify,
 				ServerName:         am.TLS.ServerName,
+				MinVersion:         minVersion,
+				MaxVersion:         maxVersion,
 			}
 
 			if am.TLS.CA != nil {


### PR DESCRIPTION
Adds min and max TLS version settings to match what Prometheus offers: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config

These were not there originally largely due to our Prometheus at the time (2.35) not offering them.