### PR TITLE
Add ability to run individual tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,14 +143,14 @@ ifeq ($(NO_DOCKER), 1)
 	kubectl apply -f manifests/setup.yaml
 	kubectl apply -f cmd/operator/deploy/operator/01-priority-class.yaml
 	kubectl apply -f cmd/operator/deploy/operator/03-role.yaml
-	go test `go list ./... | grep e2e` -args -project-id=${PROJECT_ID} -cluster=${GMP_CLUSTER} -location=${GMP_LOCATION}
+	go test -v "./e2e/..." -run "$(or $(TEST_RUN), .)" -args -project-id="$(PROJECT_ID)" -cluster="$(GMP_CLUSTER)" -location="$(GMP_LOCATION)" $(TEST_ARGS)
 else
 	@echo ">> building kindtest image"
 	$(call docker_build, -f hack/Dockerfile --target kindtest -t gmp/kindtest .)
 	@echo ">> running container"
 # We lose some isolation by sharing the host network with the kind containers.
 # However, we avoid a gcloud-shell "Dockerception" and save on build times.
-	docker run --network host --rm -v $(DOCKER_VOLUME):/var/run/docker.sock gmp/kindtest ./hack/kind-test.sh
+	docker run --env TEST_RUN="$(TEST_RUN)" --env TEST_ARGS="$(TEST_ARGS)" --network host --rm -v $(DOCKER_VOLUME):/var/run/docker.sock gmp/kindtest ./hack/kind-test.sh
 endif
 
 .PHONY: presubmit

--- a/README.md
+++ b/README.md
@@ -103,12 +103,22 @@ To run unit tests from docker container run `make test`
 Running `make e2e` will run e2e tests against Kubernetes cluster:
   * By default, it run in hermetic docker container, downloads kind, recreates
 a single node kind cluster and runs [e2e](./e2e) tests against it.
+  * To run a single test, use the `TEST_RUN` environment variable. For example, to run all collector tests, pass `TEST_RUN=TestCollector`:
+  ```bash
+  TEST_RUN=TestCollector make e2e
+  ```
+  * To pass args to the test, use the `TEST_ARGS` environment variable. For example, to add `-skip-gcm`, pass `TEST_ARGS=-skip-gcm`:
+  ```bash
+  NO_DOCKER=1 TEST_ARGS=-skip-gcm make e2e
+  ```
   * If `NO_DOCKER=1` is set, end-to-end tests will be run against the current
     kubectl context. It is assumed the cluster has access to the GCM API.
     Ensure `GMP_CLUSTER` and `GMP_LOCATION` are set, e.g.
   ```bash
   NO_DOCKER=1 GMP_CLUSTER=<my-cluster> GMP_LOCATION=<cluster-location> make e2e
   ```
+
+##### Debugging
 
 In docker mode, to run a single test or debug a cluster during or after failed
 test, you can try entering shell of the `kindtest` container. Before doing so, 
@@ -140,8 +150,8 @@ go test -v ./e2e -run "TestAlertmanagerDefault" -args -project-id=test-proj -clu
 Each test case is creating a separate set of namespaces e.g.
 `gmp-test-testalertmanagerdefault-20230714-120756` and
 `gmp-test-testalertmanagerdefault-20230714-120756-pub`, so to debug tests you
-have to ensure those namespaces are not cleaned. You can also provide time.Sleep in
-the place you want debug in.
+have to ensure those namespaces are not cleaned. You can also provide
+`time.Sleep` in the place you want debug in.
 
 ##### Benchmarking
 

--- a/hack/kind-test.sh
+++ b/hack/kind-test.sh
@@ -28,15 +28,15 @@ kind create cluster
 
 # Need to ensure namespace is deployed first explicitly.
 echo ">>> deploying static resources"
-kubectl --context kind-kind apply -f ${REPO_ROOT}/manifests/setup.yaml
+kubectl --context kind-kind apply -f "${REPO_ROOT}/manifests/setup.yaml"
 
 # TODO(pintohutch): find a way to incorporate webhooks back into our kind tests.
 # This is a workaround for now.
 for m in `ls -d ${REPO_ROOT}/cmd/operator/deploy/operator/* | grep -v webhook`
 do
-  kubectl --context kind-kind apply -f $m
+  kubectl --context kind-kind apply -f "${m}"
 done
-kubectl --context kind-kind apply -f ${REPO_ROOT}/manifests/rule-evaluator.yaml
+kubectl --context kind-kind apply -f "${REPO_ROOT}/manifests/rule-evaluator.yaml"
 
 echo ">>> executing gmp e2e tests"
-go test -v ${REPO_ROOT}/e2e -args -project-id=test-proj -cluster=test-cluster -location=test-loc -skip-gcm
+go test -v "${REPO_ROOT}/e2e" -run "${TEST_RUN:-.}" -args -project-id=test-proj -cluster=test-cluster -location=test-loc -skip-gcm ${TEST_ARGS}


### PR DESCRIPTION
Provides a uniform way of running a single test via our Makefile, no matter what other environment variables are used.