### PR TITLE
PostgreSQL Exporter: Update YAML snippet

### DIFF
--- a/examples/postgresql/exporter.yaml.snippet
+++ b/examples/postgresql/exporter.yaml.snippet
@@ -27,7 +27,7 @@ spec:
 +       app.kubernetes.io/name: postgresql
     spec:
       containers:
-      - image: postgres:14.0
+      - image: postgres:15.3
         name: postgresql
         env:
         - name: POSTGRES_USER
@@ -37,7 +37,9 @@ spec:
         - name: POSTGRES_DB
           value: dev
 +     - name: exporter
-+       image: quay.io/prometheuscommunity/postgres-exporter:v0.11.1
++       image: quay.io/prometheuscommunity/postgres-exporter:v0.14.0
++       args:
++         - --collector.stat_statements
 +       env:
 +       - name: DATA_SOURCE_NAME
 +         value: postgresql://root:password@localhost:5432/dev?sslmode=disable


### PR DESCRIPTION
## Changes
* [updated yaml snippet based on new exporter release](https://github.com/GoogleCloudPlatform/prometheus-engine/commit/a6a02e34b284b297b77900a8219549fb745d0b60)

## Details
Version `0.14.0` of the postgresql exporter has been released. There was an issue resolved regarding certain collectors not starting when the PostgreSQL database was not started completely. Also, there's a new flag/argument to include in the deployment to collect certain metrics.