### PR TITLE
Replace deprecated ioutil module usage

### DIFF
--- a/e2e/operator_context_test.go
+++ b/e2e/operator_context_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"strings"
@@ -264,7 +263,7 @@ func (tctx *OperatorContext) createBaseResources(ctx context.Context) ([]metav1.
 	}
 
 	if gcpServiceAccount != "" {
-		b, err := ioutil.ReadFile(gcpServiceAccount)
+		b, err := os.ReadFile(gcpServiceAccount)
 		if err != nil {
 			return nil, fmt.Errorf("read GCP service account file: %w", err)
 		}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -19,8 +19,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -167,7 +167,7 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 		return nil, fmt.Errorf("invalid options: %w", err)
 	}
 	// Create temporary directory to store webhook serving cert files.
-	certDir, err := ioutil.TempDir("", "operator-cert")
+	certDir, err := os.MkdirTemp("", "operator-cert")
 	if err != nil {
 		return nil, fmt.Errorf("create temporary certificate dir: %w", err)
 	}
@@ -482,10 +482,10 @@ func (o *Operator) ensureCerts(ctx context.Context, dir string) ([]byte, error) 
 		return nil, errors.New("Flags key-base64 and cert-base64 must both be set.")
 	}
 	// Create cert/key files.
-	if err := ioutil.WriteFile(filepath.Join(dir, "tls.crt"), crt, 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "tls.crt"), crt, 0666); err != nil {
 		return nil, fmt.Errorf("create cert file: %w", err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, "tls.key"), key, 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "tls.key"), key, 0666); err != nil {
 		return nil, fmt.Errorf("create key file: %w", err)
 	}
 	return caData, nil

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -16,7 +16,6 @@ package operator
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -32,11 +31,11 @@ import (
 )
 
 func readKeyAndCertFiles(dir string, t *testing.T) ([]byte, []byte) {
-	outCert, err := ioutil.ReadFile(path.Join(dir, "tls.crt"))
+	outCert, err := os.ReadFile(path.Join(dir, "tls.crt"))
 	if err != nil {
 		t.Fatalf("error reading from cert file: %v", err)
 	}
-	outKey, err := ioutil.ReadFile(path.Join(dir, "tls.key"))
+	outKey, err := os.ReadFile(path.Join(dir, "tls.key"))
 	if err != nil {
 		t.Fatalf("error reading from key file: %v", err)
 	}
@@ -44,7 +43,7 @@ func readKeyAndCertFiles(dir string, t *testing.T) ([]byte, []byte) {
 }
 
 func TestEnsureCertsExplicit(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_ensure_certs")
+	dir, err := os.MkdirTemp("", "test_ensure_certs")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +126,7 @@ func TestEnsureCertsSelfSigned(t *testing.T) {
 	)
 	t.Cleanup(cancel)
 
-	dir, err := ioutil.TempDir("", "test_ensure_certs")
+	dir, err := os.MkdirTemp("", "test_ensure_certs")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -17,7 +17,7 @@ package ui
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -48,7 +48,7 @@ func Handler(externalURL *url.URL) http.Handler {
 				fmt.Fprintf(w, "Error opening React index.html: %v", err)
 				return
 			}
-			idx, err := ioutil.ReadAll(f)
+			idx, err := io.ReadAll(f)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprintf(w, "Error reading React index.html: %v", err)


### PR DESCRIPTION
This is effectively a no-op. The ioutils package today simply call the os packages. This removes some warnings in the codebase.