### PR TITLE
Use subtest labels for cleanup

### DIFF
--- a/e2e/alertmanager_test.go
+++ b/e2e/alertmanager_test.go
@@ -40,7 +40,10 @@ route:
   receiver: "foobar"
 `
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: operator.AlertmanagerPublicSecretName},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   operator.AlertmanagerPublicSecretName,
+			Labels: tctx.getSubTestLabels(),
+		},
 		Data: map[string][]byte{
 			operator.AlertmanagerPublicSecretKey: []byte(alertmanagerConfig),
 		},
@@ -67,7 +70,10 @@ route:
 		},
 	}
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-secret-name"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "my-secret-name",
+			Labels: tctx.getSubTestLabels(),
+		},
 		Data: map[string][]byte{
 			"my-secret-key": []byte(alertmanagerConfig),
 		},
@@ -80,7 +86,8 @@ func testCreateAlertmanagerSecrets(ctx context.Context, t *OperatorContext, cert
 	secrets := []*corev1.Secret{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "alertmanager-authorization",
+				Name:   "alertmanager-authorization",
+				Labels: t.getSubTestLabels(),
 			},
 			Data: map[string][]byte{
 				"token": []byte("auth-bearer-password"),
@@ -88,7 +95,8 @@ func testCreateAlertmanagerSecrets(ctx context.Context, t *OperatorContext, cert
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "alertmanager-tls",
+				Name:   "alertmanager-tls",
+				Labels: t.getSubTestLabels(),
 			},
 			Data: map[string][]byte{
 				"cert": cert,
@@ -108,7 +116,8 @@ func testAlertmanagerDeployed(spec *monitoringv1.ManagedAlertmanagerSpec) func(c
 	return func(ctx context.Context, t *OperatorContext) {
 		opCfg := &monitoringv1.OperatorConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: operator.NameOperatorConfig,
+				Name:   operator.NameOperatorConfig,
+				Labels: t.getSubTestLabels(),
 			},
 			Collection: monitoringv1.CollectionSpec{
 				ExternalLabels: map[string]string{

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -57,7 +57,8 @@ func testCollectorDeployed(ctx context.Context, t *OperatorContext) {
 	// Create initial OperatorConfig to trigger deployment of resources.
 	opCfg := &monitoringv1.OperatorConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: operator.NameOperatorConfig,
+			Name:   operator.NameOperatorConfig,
+			Labels: t.getSubTestLabels(),
 		},
 		Collection: monitoringv1.CollectionSpec{
 			ExternalLabels: map[string]string{
@@ -165,7 +166,8 @@ func testCollectorSelfPodMonitoring(ctx context.Context, t *OperatorContext) {
 	// should show up in Cloud Monitoring shortly after.
 	podmon := &monitoringv1.PodMonitoring{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "collector-podmon",
+			Name:   "collector-podmon",
+			Labels: t.getSubTestLabels(),
 		},
 		Spec: monitoringv1.PodMonitoringSpec{
 			Selector: metav1.LabelSelector{
@@ -232,8 +234,8 @@ func testCollectorSelfClusterPodMonitoring(ctx context.Context, t *OperatorConte
 	// should show up in Cloud Monitoring shortly after.
 	podmon := &monitoringv1.ClusterPodMonitoring{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "collector-cmon",
-			OwnerReferences: t.ownerReferences,
+			Name:   "collector-cmon",
+			Labels: t.getSubTestLabels(),
 		},
 		Spec: monitoringv1.ClusterPodMonitoringSpec{
 			Selector: metav1.LabelSelector{

--- a/e2e/operator_context_test.go
+++ b/e2e/operator_context_test.go
@@ -20,6 +20,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -34,11 +35,17 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator"
@@ -49,6 +56,8 @@ const (
 	collectorManifest    = "../cmd/operator/deploy/operator/10-collector.yaml"
 	ruleEvalManifest     = "../cmd/operator/deploy/operator/11-rule-evaluator.yaml"
 	alertmanagerManifest = "../cmd/operator/deploy/operator/12-alertmanager.yaml"
+
+	testLabel = "monitoring.googleapis.com/prometheus-test"
 )
 
 var (
@@ -98,7 +107,7 @@ func TestMain(m *testing.M) {
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 
 	<-term
-	if err := cleanupAllNamespaces(context.Background()); err != nil {
+	if err := cleanupResources(context.Background(), kubeconfig, ""); err != nil {
 		fmt.Fprintln(os.Stderr, "Cleaning up namespaces failed:", err)
 		os.Exit(1)
 	}
@@ -117,9 +126,6 @@ type OperatorContext struct {
 	*testing.T
 
 	namespace, pubNamespace string
-	// A list of owner references that can be attached to non-namespaced
-	// test resources so that they'll get cleaned up on teardown.
-	ownerReferences []metav1.OwnerReference
 
 	kubeClient     kubernetes.Interface
 	operatorClient clientset.Interface
@@ -149,13 +155,14 @@ func newOperatorContext(t *testing.T) *OperatorContext {
 		kubeClient:     kubeClient,
 		operatorClient: operatorClient,
 	}
-	// The testing package runs cleanup on a best-effort basis. Thus we have a fallback
-	// cleanup of namespaces in TestMain.
-	t.Cleanup(cancel)
-	t.Cleanup(func() { tctx.cleanupNamespaces() })
+	t.Cleanup(func() {
+		if err := cleanupResources(ctx, kubeconfig, tctx.getSubTestLabelValue()); err != nil {
+			t.Fatalf("unable to cleanup resources: %s", err)
+		}
+		cancel()
+	})
 
-	tctx.ownerReferences, err = tctx.createBaseResources(context.TODO())
-	if err != nil {
+	if err := tctx.createBaseResources(ctx); err != nil {
 		t.Fatalf("create test namespace: %s", err)
 	}
 
@@ -181,56 +188,52 @@ func newOperatorContext(t *testing.T) *OperatorContext {
 	return tctx
 }
 
+func (tctx *OperatorContext) getSubTestLabelValue() string {
+	return strings.ReplaceAll(tctx.T.Name(), "/", ".")
+}
+
+func (tctx *OperatorContext) getSubTestLabels() map[string]string {
+	return map[string]string{
+		testLabel: tctx.getSubTestLabelValue(),
+	}
+}
+
 // createBaseResources creates resources the operator requires to exist already.
 // These are resources which don't depend on runtime state and can thus be deployed
 // statically, allowing to run the operator without critical write permissions.
-func (tctx *OperatorContext) createBaseResources(ctx context.Context) ([]metav1.OwnerReference, error) {
+func (tctx *OperatorContext) createBaseResources(ctx context.Context) error {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: tctx.namespace,
-			// Apply a consistent label to make it easy manually cleanup in case
-			// something went wrong with the test cleanup.
-			Labels: map[string]string{
-				"gmp-operator-test": "true",
-			},
+			Name:   tctx.namespace,
+			Labels: tctx.getSubTestLabels(),
 		},
 	}
 	pns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: tctx.pubNamespace,
-			// Apply a consistent label to make it easy manually cleanup in case
-			// something went wrong with the test cleanup.
-			Labels: map[string]string{
-				"gmp-operator-test": "true",
-			},
+			Name:   tctx.pubNamespace,
+			Labels: tctx.getSubTestLabels(),
 		},
 	}
 	// This will also fail is the namespace already exists, thereby detecting if a previous
 	// test run wasn't cleaned up correctly.
 	ns, err := tctx.kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("create namespace %q: %w", ns, err)
+		return fmt.Errorf("create namespace %q: %w", ns, err)
 	}
 	_, err = tctx.kubeClient.CoreV1().Namespaces().Create(ctx, pns, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("create namespace %q: %w", pns, err)
-	}
-
-	ors := []metav1.OwnerReference{
-		{
-			APIVersion: "v1",
-			Kind:       "Namespace",
-			Name:       ns.Name,
-			UID:        ns.UID,
-		},
+		return fmt.Errorf("create namespace %q: %w", pns, err)
 	}
 
 	svcAccount := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{Name: operator.NameCollector},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   operator.NameCollector,
+			Labels: tctx.getSubTestLabels(),
+		},
 	}
 	_, err = tctx.kubeClient.CoreV1().ServiceAccounts(tctx.namespace).Create(ctx, svcAccount, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("create collector service account: %w", err)
+		return fmt.Errorf("create collector service account: %w", err)
 	}
 
 	// The cluster role expected to exist already.
@@ -238,10 +241,8 @@ func (tctx *OperatorContext) createBaseResources(ctx context.Context) ([]metav1.
 
 	roleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterRoleName + ":" + tctx.namespace,
-			// Tie to the namespace so the binding gets deleted alongside it, even though
-			// it's an cluster-wide resource.
-			OwnerReferences: ors,
+			Name:   clusterRoleName + ":" + tctx.namespace,
+			Labels: tctx.getSubTestLabels(),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -259,17 +260,18 @@ func (tctx *OperatorContext) createBaseResources(ctx context.Context) ([]metav1.
 	}
 	_, err = tctx.kubeClient.RbacV1().ClusterRoleBindings().Create(ctx, roleBinding, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("create cluster role binding: %w", err)
+		return fmt.Errorf("create cluster role binding: %w", err)
 	}
 
 	if gcpServiceAccount != "" {
 		b, err := os.ReadFile(gcpServiceAccount)
 		if err != nil {
-			return nil, fmt.Errorf("read GCP service account file: %w", err)
+			return fmt.Errorf("read GCP service account file: %w", err)
 		}
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "user-gcp-service-account",
+				Name:   "user-gcp-service-account",
+				Labels: tctx.getSubTestLabels(),
 			},
 			Data: map[string][]byte{
 				"key.json": b,
@@ -277,83 +279,102 @@ func (tctx *OperatorContext) createBaseResources(ctx context.Context) ([]metav1.
 		}
 		_, err = tctx.kubeClient.CoreV1().Secrets(tctx.pubNamespace).Create(ctx, secret, metav1.CreateOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("create GCP service account secret: %w", err)
+			return fmt.Errorf("create GCP service account secret: %w", err)
 		}
 	}
 
 	// Load workloads from YAML files and update the namespace to the test namespace.
 	collectorBytes, err := os.ReadFile(collectorManifest)
 	if err != nil {
-		return nil, fmt.Errorf("read collector YAML: %w", err)
+		return fmt.Errorf("read collector YAML: %w", err)
 	}
 	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(collectorBytes, nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("decode collector: %w", err)
+		return fmt.Errorf("decode collector: %w", err)
 	}
 	collector := obj.(*appsv1.DaemonSet)
 	collector.Namespace = tctx.namespace
+	if collector.Labels == nil {
+		collector.Labels = map[string]string{}
+	}
+	for k, v := range tctx.getSubTestLabels() {
+		collector.Labels[k] = v
+	}
 
 	_, err = tctx.kubeClient.AppsV1().DaemonSets(tctx.namespace).Create(ctx, collector, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("create collector DaemonSet: %w", err)
+		return fmt.Errorf("create collector DaemonSet: %w", err)
 	}
 	evaluatorBytes, err := os.ReadFile(ruleEvalManifest)
 	if err != nil {
-		return nil, fmt.Errorf("read rule-evaluator YAML: %w", err)
+		return fmt.Errorf("read rule-evaluator YAML: %w", err)
 	}
 
 	obj, _, err = scheme.Codecs.UniversalDeserializer().Decode(evaluatorBytes, nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("decode evaluator: %w", err)
+		return fmt.Errorf("decode evaluator: %w", err)
 	}
 	evaluator := obj.(*appsv1.Deployment)
 	evaluator.Namespace = tctx.namespace
+	if evaluator.Labels == nil {
+		evaluator.Labels = map[string]string{}
+	}
+	for k, v := range tctx.getSubTestLabels() {
+		evaluator.Labels[k] = v
+	}
 
 	_, err = tctx.kubeClient.AppsV1().Deployments(tctx.namespace).Create(ctx, evaluator, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("create rule-evaluator Deployment: %w", err)
+		return fmt.Errorf("create rule-evaluator Deployment: %w", err)
 	}
 
 	alertmanagerBytes, err := os.ReadFile(alertmanagerManifest)
 	if err != nil {
-		return nil, fmt.Errorf("read alertmanager YAML: %w", err)
+		return fmt.Errorf("read alertmanager YAML: %w", err)
 	}
 	for _, doc := range strings.Split(string(alertmanagerBytes), "---") {
 		obj, _, err = scheme.Codecs.UniversalDeserializer().Decode([]byte(doc), nil, nil)
 		if err != nil {
-			return nil, fmt.Errorf("deserializing alertmanager manifest: %w", err)
+			return fmt.Errorf("deserializing alertmanager manifest: %w", err)
 		}
 		switch obj := obj.(type) {
 		case *appsv1.StatefulSet:
 			obj.Namespace = tctx.namespace
+			if obj.Labels == nil {
+				obj.Labels = map[string]string{}
+			}
+			for k, v := range tctx.getSubTestLabels() {
+				obj.Labels[k] = v
+			}
 			if _, err := tctx.kubeClient.AppsV1().StatefulSets(tctx.namespace).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
-				return nil, fmt.Errorf("create alertmanager statefulset: %w", err)
+				return fmt.Errorf("create alertmanager statefulset: %w", err)
 			}
 		case *corev1.Secret:
 			obj.Namespace = tctx.namespace
+			if obj.Labels == nil {
+				obj.Labels = map[string]string{}
+			}
+			for k, v := range tctx.getSubTestLabels() {
+				obj.Labels[k] = v
+			}
 			if _, err := tctx.kubeClient.CoreV1().Secrets(tctx.namespace).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
-				return nil, fmt.Errorf("create alertmanager secret: %w", err)
+				return fmt.Errorf("create alertmanager secret: %w", err)
 			}
 		case *corev1.Service:
 			obj.Namespace = tctx.namespace
+			if obj.Labels == nil {
+				obj.Labels = map[string]string{}
+			}
+			for k, v := range tctx.getSubTestLabels() {
+				obj.Labels[k] = v
+			}
 			if _, err := tctx.kubeClient.CoreV1().Services(tctx.namespace).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
-				return nil, fmt.Errorf("create alertmanager service: %w", err)
+				return fmt.Errorf("create alertmanager service: %w", err)
 			}
 		}
 	}
 
-	return ors, nil
-}
-
-func (tctx *OperatorContext) cleanupNamespaces() {
-	err := tctx.kubeClient.CoreV1().Namespaces().Delete(context.TODO(), tctx.namespace, metav1.DeleteOptions{})
-	if err != nil {
-		tctx.Errorf("cleanup namespace %q: %s", tctx.namespace, err)
-	}
-	err = tctx.kubeClient.CoreV1().Namespaces().Delete(context.TODO(), tctx.pubNamespace, metav1.DeleteOptions{})
-	if err != nil {
-		tctx.Errorf("cleanup public namespace %q: %s", tctx.namespace, err)
-	}
+	return nil
 }
 
 // subtest derives a new test function from a function accepting a test context.
@@ -365,22 +386,171 @@ func (tctx *OperatorContext) subtest(f func(context.Context, *OperatorContext)) 
 	}
 }
 
-// cleanupAllNamespaces deletes all namespaces created as part of test contexts.
-func cleanupAllNamespaces(ctx context.Context) error {
-	kubeClient, err := kubernetes.NewForConfig(kubeconfig)
+func getGroupVersionKinds(discoveryClient discovery.DiscoveryInterface) ([]schema.GroupVersionKind, error) {
+	_, resources, err := discoveryClient.ServerGroupsAndResources()
 	if err != nil {
-		return fmt.Errorf("build Kubernetes clientset: %w", err)
+		return nil, err
 	}
-	namespaces, err := kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
-		LabelSelector: "gmp-operator-test=true",
-	})
-	if err != nil {
-		return fmt.Errorf("delete namespaces by label: %w", err)
-	}
-	for _, ns := range namespaces.Items {
-		if err := kubeClient.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{}); err != nil {
-			fmt.Fprintf(os.Stderr, "deleting namespace %q failed: %s\n", ns.Name, err)
+	var errs []error
+	var gvks []schema.GroupVersionKind
+	for _, resource := range resources {
+		for _, api := range resource.APIResources {
+			gv, err := schema.ParseGroupVersion(resource.GroupVersion)
+			if err != nil {
+				errs = append(errs, nil)
+				continue
+			}
+			gvks = append(gvks, gv.WithKind(api.Kind))
 		}
 	}
+	return gvks, errors.Join(errs...)
+}
+
+func getNamespaces(ctx context.Context, kubeClient client.Client) ([]string, error) {
+	var namespaces []string
+	var namespaceList corev1.NamespaceList
+	if err := kubeClient.List(ctx, &namespaceList); err != nil {
+		return nil, err
+	}
+	for _, namespace := range namespaceList.Items {
+		namespaces = append(namespaces, namespace.Name)
+	}
+	return namespaces, nil
+}
+
+func isNamespaced(discovery discovery.DiscoveryInterface, gvk schema.GroupVersionKind) (bool, error) {
+	resources, err := discovery.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
+	if err != nil {
+		return false, err
+	}
+	for _, resource := range resources.APIResources {
+		if resource.Kind == gvk.Kind {
+			return resource.Namespaced, nil
+		}
+	}
+	return false, fmt.Errorf("resource not discovered %s", gvk.String())
+}
+
+// isNoMatchError returns true if the error indicates that the type does not exist.
+func isNoMatchError(err error, gvk schema.GroupVersionKind) bool {
+	return err.Error() == fmt.Sprintf("no matches for kind %q in version %q", gvk.Kind, gvk.GroupVersion().String())
+}
+
+func labelListOptions(labelName, labelValue, namespace string) (client.ListOptions, error) {
+	listOpts := client.ListOptions{}
+	if labelValue == "" {
+		req, err := labels.NewRequirement(labelName, selection.Exists, []string{})
+		if err != nil {
+			return listOpts, err
+		}
+		listOpts.LabelSelector = labels.NewSelector().Add(*req)
+	} else {
+		req, err := labels.NewRequirement(labelName, selection.Equals, []string{labelValue})
+		if err != nil {
+			return listOpts, err
+		}
+		listOpts.LabelSelector = labels.NewSelector().Add(*req)
+	}
+	if namespace != "" {
+		listOpts.Namespace = namespace
+	}
+	return listOpts, nil
+}
+
+func cleanupResource(ctx context.Context, kubeClient client.Client, gvk schema.GroupVersionKind, labelValue, namespace string) error {
+	listOpts, err := labelListOptions(testLabel, labelValue, namespace)
+	if err != nil {
+		return err
+	}
+
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	obj := metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiVersion,
+			Kind:       kind,
+		},
+	}
+
+	if err := kubeClient.DeleteAllOf(ctx, &obj, &client.DeleteAllOfOptions{
+		ListOptions: listOpts,
+	}); err != nil {
+		if apierrors.IsMethodNotSupported(err) {
+			// We are not allowed to touch Kubernetes-managed objects.
+			return nil
+		}
+		if isNoMatchError(err, gvk) {
+			// This is a meta-resource used in client-go and doesn't exist.
+			return nil
+		}
+		return fmt.Errorf("unable to delete %s: %w", gvk.String(), err)
+	}
 	return nil
+}
+
+// cleanupResources cleans all resources created by tests. If no label value is provided, then all
+// resources with the label are removed.
+func cleanupResources(ctx context.Context, restConfig *rest.Config, labelValue string) error {
+	kubeClient, err := client.New(restConfig, client.Options{})
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+	gvks, err := getGroupVersionKinds(discoveryClient)
+	if err != nil {
+		return err
+	}
+
+	namespaces, err := getNamespaces(ctx, kubeClient)
+	if err != nil {
+		return err
+	}
+
+	// The namespaces have to be deleted last, so skip those.
+	namespaceGVK := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Namespace",
+	}
+
+	var errs []error
+	for _, gvk := range gvks {
+		if namespaceGVK == gvk {
+			continue
+		}
+
+		namespaced, err := isNamespaced(discoveryClient, gvk)
+		if err != nil {
+			return err
+		}
+		if namespaced {
+			for _, namespace := range namespaces {
+				if err := cleanupResource(ctx, kubeClient, gvk, labelValue, namespace); err != nil {
+					errs = append(errs, err)
+				}
+			}
+		} else {
+			if err := cleanupResource(ctx, kubeClient, gvk, labelValue, ""); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	// DeleteAllOf does not work for namespaces, so we must delete individually.
+	listOpts, err := labelListOptions(testLabel, labelValue, "")
+	if err != nil {
+		return err
+	}
+	namespaceList := corev1.NamespaceList{}
+	if err := kubeClient.List(ctx, &namespaceList, &listOpts); err != nil {
+		return err
+	}
+	for _, namespace := range namespaceList.Items {
+		if err := kubeClient.Delete(ctx, &namespace, &client.DeleteOptions{}); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -38,8 +38,8 @@ func TestWebhookCABundleInjection(t *testing.T) {
 	// Create webhook configs. The operator must populate their caBundles.
 	vwc := &arv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            whConfigName,
-			OwnerReferences: tctx.ownerReferences,
+			Name:   whConfigName,
+			Labels: tctx.getSubTestLabels(),
 		},
 		Webhooks: []arv1.ValidatingWebhook{
 			{
@@ -63,8 +63,8 @@ func TestWebhookCABundleInjection(t *testing.T) {
 	}
 	mwc := &arv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            whConfigName,
-			OwnerReferences: tctx.ownerReferences,
+			Name:   whConfigName,
+			Labels: tctx.getSubTestLabels(),
 		},
 		Webhooks: []arv1.MutatingWebhook{
 			{

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	k8s.io/code-generator v0.26.8
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.6
-	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -118,6 +117,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20221207184640-f3cff1453715 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 // Exclude pre-go-mod kubernetes tags, as they are older


### PR DESCRIPTION
This PR is the first part of multiple for allowing tests to be able to run run isolated from each other. Currently some subtests are broken because they rely on configurations to get created from prior subtests.

Using labels for tests allows us to remove resources in subtests in the future to ensure that all subtests are completely independent. This also helps prevent name collisions in resources and allows tests to be more robust.  The existing tests already used labels for namespaces, but this expands them by making labels more explicit.