### PR TITLE
Add support for generic Kubernetes client on e2e tests

### DIFF
--- a/pkg/operator/collection_test.go
+++ b/pkg/operator/collection_test.go
@@ -73,7 +73,7 @@ func TestCollectionStatus(t *testing.T) {
 		Message:            "",
 	})
 
-	scheme, err := getScheme()
+	scheme, err := NewScheme()
 	if err != nil {
 		t.Fatal("Unable to get scheme")
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -153,7 +153,7 @@ func (o *Options) defaultAndValidate(logger logr.Logger) error {
 	return nil
 }
 
-func getScheme() (*runtime.Scheme, error) {
+func NewScheme() (*runtime.Scheme, error) {
 	sc := runtime.NewScheme()
 
 	if err := scheme.AddToScheme(sc); err != nil {
@@ -176,7 +176,7 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 		return nil, fmt.Errorf("create temporary certificate dir: %w", err)
 	}
 
-	sc, err := getScheme()
+	sc, err := NewScheme()
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize Kubernetes scheme: %w", err)
 	}

--- a/pkg/operator/target_status_test.go
+++ b/pkg/operator/target_status_test.go
@@ -148,7 +148,7 @@ func targetFetchFromMap(m map[string]*prometheusv1.TargetsResult) getTargetFn {
 }
 
 func TestUpdateTargetStatus(t *testing.T) {
-	scheme, err := getScheme()
+	scheme, err := NewScheme()
 	if err != nil {
 		t.Fatal("Unable to get scheme")
 	}
@@ -1169,7 +1169,7 @@ func TestPolling(t *testing.T) {
 
 	fakeClock := tclock.NewFakeClock(time.Now())
 
-	scheme, err := getScheme()
+	scheme, err := NewScheme()
 	if err != nil {
 		t.Fatal("Unable to get scheme")
 	}
@@ -1401,7 +1401,7 @@ func TestPolling(t *testing.T) {
 }
 
 func TestShouldPoll(t *testing.T) {
-	scheme, err := getScheme()
+	scheme, err := NewScheme()
 	if err != nil {
 		t.Fatal("unable to get scheme")
 	}
@@ -1549,7 +1549,7 @@ func TestFetchTargets(t *testing.T) {
 		t.Fatal("Invalid options:", err)
 	}
 
-	scheme, err := getScheme()
+	scheme, err := NewScheme()
 	if err != nil {
 		t.Fatal("Unable to get scheme")
 	}


### PR DESCRIPTION
Minor refactoring. Makes the code more readable because:
- The namespace in the type definition is used.
- The code is shorter and easier to write.
- You don't need multiple clientsets.
- You can change types you create effortlessly.
- We can create a special Kubernetes client which adds subtest labels automagically.