### PR TITLE
Fix bench library error

### DIFF
--- a/pkg/export/bench/README.md
+++ b/pkg/export/bench/README.md
@@ -18,7 +18,7 @@ load broad coverage of potential race conditions, which will be logged.
 
 ## Resource usage
 
-The Prometheus server scrapse itself, which allows gauging the resource usage of the Prometheus
+The Prometheus server scrapes itself, which allows gauging the resource usage of the Prometheus
 binary as well as the overhead relative to a regular Prometheus server.
 
 The example app allows tweaking its flags to expose more or fewer metrics. Lowering the scrape

--- a/pkg/export/bench/app/example_app.go
+++ b/pkg/export/bench/app/example_app.go
@@ -45,19 +45,19 @@ var (
 
 var (
 	availableLabels = map[string][]string{
-		"method": []string{
+		"method": {
 			"POST",
 			"PUT",
 			"GET",
 		},
-		"status": []string{
+		"status": {
 			"200",
 			"300",
 			"400",
 			"404",
 			"500",
 		},
-		"path": []string{
+		"path": {
 			"/",
 			"/index",
 			"/topics",

--- a/pkg/export/bench/run.sh
+++ b/pkg/export/bench/run.sh
@@ -31,7 +31,7 @@ rm -rf data1 data2 data3
 
 echo "Starting example metrics application"
 
-go run example_app.go 2>&1 | sed -e "s/^/[example-app] /" &
+go run app/example_app.go 2>&1 | sed -e "s/^/[example-app] /" &
 
 echo "Starting fake GCM endpoint"
 

--- a/pkg/export/bench/server.go
+++ b/pkg/export/bench/server.go
@@ -23,10 +23,10 @@ import (
 	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
 	"time"
 
+	monitoring_pb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"github.com/golang/protobuf/ptypes/empty"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	monitoring_pb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/grpc"
 )
 


### PR DESCRIPTION
Fixes:
```
pkg/export/bench/server.go:33:6: main redeclared in this block
        pkg/export/bench/example_app.go:143:6: other declaration of main
```