### PR TITLE
Add explicit directories for updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,23 @@
 version: 2
 updates:
 - package-ecosystem: docker
-  directory: /
+  directory: /hack
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /cmd/rule-evaluator
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /cmd/operator
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /cmd/frontend
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /cmd/config-reloader
   schedule:
     interval: weekly
 - package-ecosystem: gomod


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/prometheus-engine/pull/589, I added a dependabot config that just looks at the root directory. This just explicitly lists the directories we want to look at.

Let me know if we want to include '/hack' or not.