### PR TITLE
Add ability to pass cert files to operator

### DIFF
--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -63,12 +63,34 @@ spec:
           requests:
             cpu: 1m
             memory: 16M
+        volumeMounts:
+        - name: tls
+          readOnly: true
+          mountPath: "/etc/tls/private"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - all
           privileged: false
+      volumes:
+      - name: tls
+        projected:
+          sources:
+          - secret:
+              name: webhook-tls
+              items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+              optional: true
+          - configMap:
+              name: webhook-ca
+              items:
+              - key: ca.crt
+                path: ca.crt
+              optional: true
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -38,6 +38,13 @@ import (
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator"
 )
 
+const (
+	defaultTLSDir       = "/etc/tls/private"
+	defaultCertFile     = defaultTLSDir + "/tls.crt"
+	defaultKeyFile      = defaultTLSDir + "/tls.key"
+	defaultClientCAFile = defaultTLSDir + "/ca.crt"
+)
+
 func unstableFlagHelp(help string) string {
 	return help + " (Setting this flag voids any guarantees of proper behavior of the operator.)"
 }
@@ -68,10 +75,13 @@ func main() {
 		publicNamespace = flag.String("public-namespace", operator.DefaultPublicNamespace,
 			"Namespace in which the operator reads user-provided resources.")
 
-		tlsCert     = flag.String("tls-cert-base64", "", "The base64-encoded TLS certificate.")
-		tlsKey      = flag.String("tls-key-base64", "", "The base64-encoded TLS key.")
-		caCert      = flag.String("ca-cert-base64", "", "The base64-encoded certificate authority.")
-		webhookAddr = flag.String("webhook-addr", ":10250",
+		tlsCert      = flag.String("tls-cert-base64", "", "The base64-encoded TLS certificate.")
+		tlsKey       = flag.String("tls-key-base64", "", "The base64-encoded TLS key.")
+		caCert       = flag.String("ca-cert-base64", "", "The base64-encoded certificate authority.")
+		certFile     = flag.String("cert-file", defaultCertFile, "Path to TLS certificate for webhook server.")
+		keyFile      = flag.String("key-file", defaultKeyFile, "Path to TLS key for webhook server.")
+		clientCAFile = flag.String("client-ca-file", defaultClientCAFile, "Client CA certificate to trust the webhook server.")
+		webhookAddr  = flag.String("webhook-addr", ":10250",
 			"Address to listen to for incoming kube admission webhook connections.")
 		metricsAddr = flag.String("metrics-addr", ":18080", "Address to emit metrics on.")
 
@@ -110,6 +120,9 @@ func main() {
 		TLSCert:           *tlsCert,
 		TLSKey:            *tlsKey,
 		CACert:            *caCert,
+		KeyFile:           *keyFile,
+		CertFile:          *certFile,
+		ClientCAFile:      *clientCAFile,
 		ListenAddr:        *webhookAddr,
 		CleanupAnnotKey:   *cleanupAnnotKey,
 	})

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -265,12 +265,34 @@ spec:
           requests:
             cpu: 1m
             memory: 16M
+        volumeMounts:
+        - name: tls
+          readOnly: true
+          mountPath: "/etc/tls/private"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - all
           privileged: false
+      volumes:
+      - name: tls
+        projected:
+          sources:
+          - secret:
+              name: webhook-tls
+              items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+              optional: true
+          - configMap:
+              name: webhook-ca
+              items:
+              - key: ca.crt
+                path: ca.crt
+              optional: true
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Currently, the GMP Operator accepts a Certificate for the webhook server
and a CA Cert for clients as arguments on the command line. This is not
the most secure way of passing the server certificate, as noted by
GKE Security (b/297043491#comment2).

This change allows these certificates to be passed as files instead of
command line arguments and prioritizes the files over the command line
args (args will be ignored if files exist).

Expected usage is that a Kubernetes Secret (`webhook-cert`) will be created with the server cert and
a ConfigMap (`webhook-ca`) will be created with the Client CA, which can then be
mounted to the operator as a projected volume at the default path of
`/etc/tls/private/`, using standard filenames `tls.crt`, `tls.key`, and
`ca.crt`, respectively.

The paths can be customized using the new flags, if desired. These flags
to the operator are `--cert-file`, `--key-file`, and `--client-ca-file`,
respectively.

The `--tls-cert-base64`, `--tls-key-base64`, and `--ca-cert--base64`
flags should be considered deprecated and are planned to be removed in
the future.