### PR TITLE
Remove delete permission for rule-evaluator deployment

### DIFF
--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -73,7 +73,7 @@ rules:
   - deployments
   apiGroups: ["apps"]
   resourceNames: ["rule-evaluator"]
-  verbs: ["get", "delete", "patch", "update"]
+  verbs: ["get", "patch", "update"]
 - resources:
   - services
   apiGroups: [""]

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -103,7 +103,7 @@ rules:
   - deployments
   apiGroups: ["apps"]
   resourceNames: ["rule-evaluator"]
-  verbs: ["get", "delete", "patch", "update"]
+  verbs: ["get", "patch", "update"]
 - resources:
   - services
   apiGroups: [""]


### PR DESCRIPTION
The ability to delete the rule-evaluator deployment is no longer necessary.