### PR TITLE
Remove permissions to delete collector daemonset

### DIFF
--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -64,7 +64,7 @@ rules:
   - daemonsets
   apiGroups: ["apps"]
   resourceNames: ["collector"]
-  verbs: ["get", "list", "watch", "delete", "patch", "update"]
+  verbs: ["get", "list", "watch", "patch", "update"]
 - resources:
   - deployments
   apiGroups: ["apps"]

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -94,7 +94,7 @@ rules:
   - daemonsets
   apiGroups: ["apps"]
   resourceNames: ["collector"]
-  verbs: ["get", "list", "watch", "delete", "patch", "update"]
+  verbs: ["get", "list", "watch", "patch", "update"]
 - resources:
   - deployments
   apiGroups: ["apps"]


### PR DESCRIPTION
The ability to delete the collector DaemonSet is no longer necessary.