### PR TITLE
Allow Prometheus to run GitHub Actions in e2e tests

### DIFF
--- a/cmd/operator/deploy/operator/10-collector.yaml
+++ b/cmd/operator/deploy/operator/10-collector.yaml
@@ -57,8 +57,8 @@ spec:
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
-        - --reload-url=http://localhost:19090/-/reload
-        - --ready-url=http://localhost:19090/-/ready
+        - --reload-url=http://127.0.0.1:19090/-/reload
+        - --ready-url=http://127.0.0.1:19090/-/ready
         - --listen-address=:19091
         ports:
         - name: cfg-rel-metrics

--- a/cmd/operator/deploy/operator/11-rule-evaluator.yaml
+++ b/cmd/operator/deploy/operator/11-rule-evaluator.yaml
@@ -60,8 +60,8 @@ spec:
         - --config-file-output=/prometheus/config_out/config.yaml
         - --watched-dir=/etc/rules
         - --watched-dir=/etc/secrets
-        - --reload-url=http://localhost:19092/-/reload
-        - --ready-url=http://localhost:19092/-/ready
+        - --reload-url=http://127.0.0.1:19092/-/reload
+        - --ready-url=http://127.0.0.1:19092/-/ready
         - --listen-address=:19093
         ports:
         - name: cfg-rel-metrics

--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -101,8 +101,8 @@ spec:
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml
-        - --reload-url=http://localhost:9093/-/reload
-        - --ready-url=http://localhost:9093/-/ready
+        - --reload-url=http://127.0.0.1:9093/-/reload
+        - --ready-url=http://127.0.0.1:9093/-/ready
         - --listen-address=:19091
         ports:
         - name: cfg-rel-metrics

--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -45,8 +45,8 @@ spec:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
         - --watched-dir=/etc/rules
-        - --reload-url=http://localhost:9092/-/reload
-        - --ready-url=http://localhost:9092/-/ready
+        - --reload-url=http://127.0.0.1:9092/-/reload
+        - --ready-url=http://127.0.0.1:9092/-/ready
         - --listen-address=:9093
         ports:
         - name: cfg-rel-metrics

--- a/e2e/operator_context_test.go
+++ b/e2e/operator_context_test.go
@@ -360,6 +360,15 @@ func createCollectorResources(ctx context.Context, kubeClient client.Client, nam
 	}
 	collector := obj.(*appsv1.DaemonSet)
 	collector.Namespace = namespace
+	if skipGCM {
+		for i := range collector.Spec.Template.Spec.Containers {
+			container := &collector.Spec.Template.Spec.Containers[i]
+			if container.Name == "prometheus" {
+				container.Args = append(container.Args, "--export.debug.disable-auth")
+				break
+			}
+		}
+	}
 
 	if err = kubeClient.Create(ctx, collector); err != nil {
 		return fmt.Errorf("create collector DaemonSet: %w", err)

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -585,8 +585,8 @@ spec:
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
-        - --reload-url=http://localhost:19090/-/reload
-        - --ready-url=http://localhost:19090/-/ready
+        - --reload-url=http://127.0.0.1:19090/-/reload
+        - --ready-url=http://127.0.0.1:19090/-/ready
         - --listen-address=:19091
         ports:
         - name: cfg-rel-metrics
@@ -761,8 +761,8 @@ spec:
         - --config-file-output=/prometheus/config_out/config.yaml
         - --watched-dir=/etc/rules
         - --watched-dir=/etc/secrets
-        - --reload-url=http://localhost:19092/-/reload
-        - --ready-url=http://localhost:19092/-/ready
+        - --reload-url=http://127.0.0.1:19092/-/reload
+        - --ready-url=http://127.0.0.1:19092/-/ready
         - --listen-address=:19093
         ports:
         - name: cfg-rel-metrics
@@ -967,8 +967,8 @@ spec:
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml
-        - --reload-url=http://localhost:9093/-/reload
-        - --ready-url=http://localhost:9093/-/ready
+        - --reload-url=http://127.0.0.1:9093/-/reload
+        - --ready-url=http://127.0.0.1:9093/-/ready
         - --listen-address=:19091
         ports:
         - name: cfg-rel-metrics

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -77,8 +77,8 @@ spec:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
         - --watched-dir=/etc/rules
-        - --reload-url=http://localhost:9092/-/reload
-        - --ready-url=http://localhost:9092/-/ready
+        - --reload-url=http://127.0.0.1:9092/-/reload
+        - --ready-url=http://127.0.0.1:9092/-/ready
         - --listen-address=:9093
         ports:
         - name: cfg-rel-metrics


### PR DESCRIPTION
Our current e2e tests are not deploying the Prometheus collector pods correctly on GitHub Actions due to 2 reasons:

1. GitHub Actions does not support "localhost". It only supports the loopback address directory.
2. GitHub Actions does not have Google Cloud credentials.

These issues cause the collector pods to crash loop indefinitely in e2e tests. cc @pintohutch 