### PR TITLE
Update dependabot.yaml to group PRs for gomod changes.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,3 +24,12 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  groups:
+    # Group dep updates into one PR as single update already updates co-located deps.
+    # Skip biggest and the most complex deps: Thanos and Prometheus.
+    go-deps:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "github.com/thanos-io/thanos"
+        - "github.com/prometheus/prometheus"


### PR DESCRIPTION
This is also due to potential issues with vendor file not being updated properly (investigating) https://github.com/GoogleCloudPlatform/prometheus-engine/pull/616