### PR TITLE
Fix e2e tests cannot run locally after webhook cert dir changes

### DIFF
--- a/e2e/operator_context_test.go
+++ b/e2e/operator_context_test.go
@@ -236,6 +236,16 @@ func newOperatorContext(t *testing.T) *OperatorContext {
 		}
 	}
 
+	certDir, err := os.MkdirTemp("", "gmp-e2e-test")
+	if err != nil {
+		t.Fatalf("unable to create cert dir: %s", err)
+	}
+	defer func() {
+		if err := os.Remove(certDir); err != nil {
+			t.Logf("unable to remove cert dir: %s", err)
+		}
+	}()
+
 	op, err := operator.New(globalLogger, kubeconfig, operator.Options{
 		ProjectID:         projectID,
 		Cluster:           cluster,
@@ -245,6 +255,7 @@ func newOperatorContext(t *testing.T) *OperatorContext {
 		// Pick a random available port.
 		ListenAddr:          ":0",
 		CollectorHTTPClient: httpClient,
+		CertDir:             certDir,
 	})
 	if err != nil {
 		t.Fatalf("instantiating operator: %s", err)


### PR DESCRIPTION
#601 introduced a small regression where the operator fails when running e2e tests locally. The reason is because the original code always created a temp dir while the new code creates a dir at a static location (/etc/tls) which fails on my system. Even if it passed, it would not work if every e2e uses the same directory.

As such, the e2e tests now create and manage a temp dir on their own.

Note, I accidentally pushed this commit to the main branch earlier which I reverted so we could code review this properly.