### PR TITLE
Add options to leak and cleanup resources

### DIFF
--- a/e2e/alertmanager_test.go
+++ b/e2e/alertmanager_test.go
@@ -123,7 +123,6 @@ func testAlertmanagerDeployed(ctx context.Context, t *OperatorContext) {
 			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
-			t.Log(fmt.Errorf("getting alertmanager StatefulSet failed: %w", err))
 			return false, fmt.Errorf("getting alertmanager StatefulSet failed: %w", err)
 		}
 
@@ -154,13 +153,11 @@ func testAlertmanagerConfig(ctx context.Context, t *OperatorContext, pub *corev1
 			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
-			t.Log(fmt.Errorf("getting alertmanager secret failed: %s", err))
 			return false, fmt.Errorf("getting alertmanager secret failed: %w", err)
 		}
 
 		bytes, ok := secret.Data["config.yaml"]
 		if !ok {
-			t.Log(errors.New("getting alertmanager secret data in config.yaml failed"))
 			return false, errors.New("getting alertmanager secret data in config.yaml failed")
 		}
 

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -383,10 +383,9 @@ func testCollectorTargetStatus(ctx context.Context, t *OperatorContext) {
 	})
 	if pollErr != nil {
 		if errors.Is(pollErr, wait.ErrWaitTimeout) && err != nil {
-			t.Errorf("unable to validate status: %s", err)
-		} else {
-			t.Error("unable to validate status due to timeout")
+			pollErr = err
 		}
+		t.Errorf("unable to validate status: %s", pollErr)
 	}
 }
 

--- a/e2e/operator_context_test.go
+++ b/e2e/operator_context_test.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -66,7 +67,7 @@ const (
 
 var (
 	startTime    = time.Now().UTC()
-	globalLogger = zap.New(zap.Level(zapcore.Level(-1)))
+	globalLogger = zap.New(zap.Level(zapcore.DebugLevel))
 
 	kubeconfig        *rest.Config
 	projectID         string
@@ -123,8 +124,8 @@ func TestMain(m *testing.M) {
 	flag.BoolVar(&skipGCM, "skip-gcm", false, "Skip validating GCM ingested points.")
 	flag.StringVar(&gcpServiceAccount, "gcp-service-account", "", "Path to GCP service account file for usage by deployed containers.")
 	flag.BoolVar(&portForward, "port-forward", true, "Whether to port-forward Kubernetes HTTP requests.")
-	flag.BoolVar(&leakResources, "leak-resources", false, "If set, prevents deleting resources. Useful for debugging.")
-	flag.BoolVar(&cleanup, "cleanup-resources", false, "If set, cleans resources before running tests.")
+	flag.BoolVar(&leakResources, "leak-resources", true, "If set, prevents deleting resources. Useful for debugging.")
+	flag.BoolVar(&cleanup, "cleanup-resources", true, "If set, cleans resources before running tests.")
 
 	flag.Parse()
 
@@ -154,6 +155,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if cleanup {
+		fmt.Fprintln(os.Stderr, "cleaning resources before tests...", err)
 		if err := cleanupResources(context.Background(), kubeconfig, c, ""); err != nil {
 			fmt.Fprintln(os.Stderr, "cleaning up failed:", err)
 			os.Exit(1)
@@ -294,7 +296,14 @@ func (tctx *OperatorContext) createOperatorConfigFrom(ctx context.Context, opCfg
 		}
 	}
 
-	if err := tctx.Client().Create(ctx, &opCfg); err != nil {
+	// Create a copy which wil represents the current object if it already exists.
+	obj := opCfg.DeepCopy()
+	if _, err := controllerutil.CreateOrUpdate(ctx, tctx.Client(), obj, func() error {
+		// For updates, we need the resource version in the object meta to match. Replace everything else.
+		opCfg.ObjectMeta = obj.ObjectMeta
+		*obj = opCfg
+		return nil
+	}); err != nil {
 		tctx.Fatalf("create OperatorConfig: %s", err)
 	}
 }

--- a/hack/kind-test.sh
+++ b/hack/kind-test.sh
@@ -39,4 +39,5 @@ done
 kubectl --context kind-kind apply -f "${REPO_ROOT}/manifests/rule-evaluator.yaml"
 
 echo ">>> executing gmp e2e tests"
-go test -v "${REPO_ROOT}/e2e" -run "${TEST_RUN:-.}" -args -project-id=test-proj -cluster=test-cluster -location=test-loc -skip-gcm ${TEST_ARGS}
+# We don't cleanup resources because this script recreates the cluster.
+go test -v "${REPO_ROOT}/e2e" -run "${TEST_RUN:-.}" -args -project-id=test-proj -cluster=test-cluster -location=test-loc -skip-gcm=true -cleanup-resources=false ${TEST_ARGS}


### PR DESCRIPTION
Provides the ability to leak and cleanup resources for an improved debugging experience, especially when running tests locally.