### PR TITLE
Add and parallelize target-status ClusterPodMonitoring e2e tests

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -137,7 +137,7 @@ ClusterPodMonitoringList is a list of ClusterPodMonitorings.
 
 ## ClusterPodMonitoringSpec
 
-ClusterPodMonitoringSpec contains specification parameters for PodMonitoring.
+ClusterPodMonitoringSpec contains specification parameters for ClusterPodMonitoring.
 
 
 <em>appears in: [ClusterPodMonitoring](#clusterpodmonitoring)</em>

--- a/e2e/kubeutil/deployment.go
+++ b/e2e/kubeutil/deployment.go
@@ -1,0 +1,77 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package e2e contains tests that validate the behavior of gmp-operator against a cluster.
+// To make tests simple and fast, the test suite runs the operator internally. The CRDs
+// are expected to be installed out of band (along with the operator deployment itself in
+// a real world setup).
+package kubeutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsDeploymentReady returns nil if the Deployment obtained from the given namespace and name
+// has all expected replicas ready, otherwise returns an error why the Deployment is not ready.
+func IsDeploymentReady(ctx context.Context, kubeClient client.Client, namespace, name string) error {
+	wrapErrFunc := func(err error) error {
+		return fmt.Errorf("deployment %s/%s not ready: %w", namespace, name, err)
+	}
+	var deployment appsv1.Deployment
+	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &deployment); err != nil {
+		return wrapErrFunc(fmt.Errorf("not found: %w", err))
+	}
+
+	// Set to default replicas value.
+	expected := int32(1)
+	if deployment.Spec.Replicas != nil {
+		expected = *deployment.Spec.Replicas
+	}
+	if deployment.Status.ReadyReplicas != expected {
+		return wrapErrFunc(errors.New("replicas unavailable"))
+	}
+	return nil
+}
+
+func WaitForDeploymentReady(ctx context.Context, kubeClient client.Client, namespace, name string) error {
+	var err error
+	if waitErr := wait.Poll(3*time.Second, 1*time.Minute, func() (bool, error) {
+		err := IsDeploymentReady(ctx, kubeClient, namespace, name)
+		return err == nil, nil
+	}); waitErr != nil {
+		if errors.Is(waitErr, wait.ErrWaitTimeout) {
+			return err
+		}
+		return waitErr
+	}
+	return nil
+}
+
+func DeploymentContainer(deployment *appsv1.Deployment, name string) (*corev1.Container, error) {
+	for i := range deployment.Spec.Template.Spec.Containers {
+		container := &deployment.Spec.Template.Spec.Containers[i]
+		if container.Name == name {
+			return container, nil
+		}
+	}
+	return nil, fmt.Errorf("unable to find container %q", name)
+}

--- a/e2e/kubeutil/parse.go
+++ b/e2e/kubeutil/parse.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package e2e contains tests that validate the behavior of gmp-operator against a cluster.
+// To make tests simple and fast, the test suite runs the operator internally. The CRDs
+// are expected to be installed out of band (along with the operator deployment itself in
+// a real world setup).
+package kubeutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ParseResourceYAML(scheme *runtime.Scheme, b []byte) (client.Object, error) {
+	codec := serializer.NewCodecFactory(scheme)
+	// Ignore returned schema. It's redundant since it's already encoded in obj.
+	obj, _, err := codec.UniversalDeserializer().Decode(b, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	clientObj, ok := obj.(client.Object)
+	if !ok {
+		return nil, fmt.Errorf("unable to convert resource into client object: %s", obj.GetObjectKind().GroupVersionKind().String())
+	}
+	return clientObj, err
+}
+
+func ResourcesFromFile(scheme *runtime.Scheme, filepath string) ([]client.Object, error) {
+	fileBytes, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("read YAML at path %q: %w", filepath, err)
+	}
+
+	var objs []client.Object
+	var errs []error
+	for i, doc := range strings.Split(string(fileBytes), "---") {
+		obj, err := ParseResourceYAML(scheme, []byte(doc))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("decode resource yaml %d: %w", i, err))
+			continue
+		}
+		objs = append(objs, obj)
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, fmt.Errorf("at path %q: %w", filepath, err)
+	}
+
+	return objs, nil
+}
+
+func ResourceFromFile(scheme *runtime.Scheme, filepath string) (client.Object, error) {
+	objs, err := ResourcesFromFile(scheme, filepath)
+	if err != nil {
+		return nil, err
+	}
+	if len(objs) != 1 {
+		return nil, fmt.Errorf("expected 1 resource but found %d at path %q", len(objs), filepath)
+	}
+	return objs[0], nil
+}

--- a/e2e/kubeutil/pod.go
+++ b/e2e/kubeutil/pod.go
@@ -16,7 +16,7 @@
 // To make tests simple and fast, the test suite runs the operator internally. The CRDs
 // are expected to be installed out of band (along with the operator deployment itself in
 // a real world setup).
-package e2e
+package kubeutil
 
 import (
 	"context"
@@ -55,7 +55,7 @@ func IsPodContainerReady(ctx context.Context, restConfig *rest.Config, pod *core
 	return fmt.Errorf("no container named %s found in pod %s", container, key)
 }
 
-func WaitForPodContainerReady(ctx context.Context, t *testing.T, restConfig *rest.Config, kubeClient client.Client, pod *corev1.Pod, container string) error {
+func WaitForPodContainerReady(ctx context.Context, t testing.TB, restConfig *rest.Config, kubeClient client.Client, pod *corev1.Pod, container string) error {
 	// Prevent doing an extra API lookup by checking first.
 	var err error
 	if err = IsPodContainerReady(ctx, restConfig, pod, container); err == nil {

--- a/e2e/network.go
+++ b/e2e/network.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/prometheus-engine/e2e/kubeutil"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
@@ -86,7 +87,7 @@ func writerFromFn(fn func(p []byte) (n int, err error)) io.Writer {
 }
 
 // PortForwardClient returns a client that ports-forward all Kubernetes-local HTTP requests to the host.
-func PortForwardClient(t *testing.T, restConfig *rest.Config, kubeClient client.Client) (*http.Client, error) {
+func PortForwardClient(t testing.TB, restConfig *rest.Config, kubeClient client.Client) (*http.Client, error) {
 	restClient, err := rest.RESTClientFor(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create REST client: %w", err)
@@ -103,11 +104,11 @@ func PortForwardClient(t *testing.T, restConfig *rest.Config, kubeClient client.
 					return nil, fmt.Errorf("unable to resolve TCP addr: %w", err)
 				}
 
-				pod, container, err := PodByAddr(ctx, kubeClient, addr)
+				pod, container, err := kubeutil.PodByAddr(ctx, kubeClient, addr)
 				if err != nil {
 					return nil, fmt.Errorf("unable to get pod from IP %s: %w", addr.IP, err)
 				}
-				if err := WaitForPodContainerReady(ctx, t, restConfig, kubeClient, pod, container); err != nil {
+				if err := kubeutil.WaitForPodContainerReady(ctx, t, restConfig, kubeClient, pod, container); err != nil {
 					return nil, fmt.Errorf("failed waiting for pod from IP %s: %w", addr.IP, err)
 				}
 				resourceURL := restClient.

--- a/e2e/podmonitoringutil.go
+++ b/e2e/podmonitoringutil.go
@@ -1,0 +1,135 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsPodMonitoringReady(pm monitoringv1.PodMonitoringCRD, targetStatusEnabled bool) error {
+	for _, condition := range pm.GetStatus().Conditions {
+		if condition.Type == monitoringv1.ConfigurationCreateSuccess {
+			if condition.Status != corev1.ConditionTrue {
+				return fmt.Errorf("configuration was not created successfully: %s", condition.Status)
+			}
+		} else {
+			return fmt.Errorf("unknown condition type: %s", condition.Type)
+		}
+	}
+	if !targetStatusEnabled {
+		return nil
+	}
+	return isPodMonitoringEndpointStatusReady(pm)
+}
+
+func isPodMonitoringEndpointStatusReady(pm monitoringv1.PodMonitoringCRD) error {
+	endpointStatuses := pm.GetStatus().EndpointStatuses
+	expectedEndpoints := len(pm.GetEndpoints())
+	if size := len(endpointStatuses); size == 0 {
+		return errors.New("empty endpoint status")
+	} else if size != expectedEndpoints {
+		return fmt.Errorf("expected %d endpoints, but got: %d", expectedEndpoints, size)
+	}
+	return nil
+}
+
+func WaitForPodMonitoringReady(ctx context.Context, kubeClient client.Client, pm monitoringv1.PodMonitoringCRD, targetStatusEnabled bool) error {
+	timeout := 1 * time.Minute
+	if targetStatusEnabled {
+		// Wait for target status to get polled.
+		timeout = 2 * time.Minute
+	}
+
+	var err error
+	var resVer string
+	pollErr := wait.Poll(3*time.Second, timeout, func() (bool, error) {
+		if err = kubeClient.Get(ctx, client.ObjectKeyFromObject(pm), pm); err != nil {
+			return false, fmt.Errorf("getting PodMonitoring failed: %w", err)
+		}
+
+		// Ensure no status update cycles.
+		// This is not a perfect check as it's possible the get call returns before the operator
+		// would sync again, however it can serve as a valuable guardrail in case sporadic test
+		// failures start happening due to update cycles.
+		if resVer != pm.GetResourceVersion() {
+			resVer = pm.GetResourceVersion()
+			err = errors.New("waiting for resource version to stabilize")
+			return false, nil
+		}
+
+		if err = IsPodMonitoringReady(pm, targetStatusEnabled); err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if pollErr != nil {
+		if errors.Is(pollErr, wait.ErrWaitTimeout) && err != nil {
+			return err
+		}
+		return pollErr
+	}
+	return nil
+}
+
+func isPodMonitoringScrapeEndpointSuccess(status *monitoringv1.ScrapeEndpointStatus) error {
+	var errs []error
+	if status.UnhealthyTargets != 0 {
+		errs = append(errs, fmt.Errorf("unhealthy targets: %d", status.UnhealthyTargets))
+	}
+	if status.CollectorsFraction != "1" {
+		errs = append(errs, fmt.Errorf("collectors failed: %s", status.CollectorsFraction))
+	}
+	if len(status.SampleGroups) == 0 {
+		errs = append(errs, errors.New("missing sample groups"))
+	} else {
+		for i, group := range status.SampleGroups {
+			if len(group.SampleTargets) == 0 {
+				errs = append(errs, fmt.Errorf("missing sample targets for group %d", i))
+			} else {
+				for _, target := range group.SampleTargets {
+					if target.Health != "up" {
+						errs = append(errs, fmt.Errorf("unhealthy target %q at group %d", target.Health, i))
+						break
+					}
+				}
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func IsPodMonitoringSuccess(pm monitoringv1.PodMonitoringCRD, targetStatusEnabled bool) error {
+	if err := IsPodMonitoringReady(pm, targetStatusEnabled); err != nil {
+		return err
+	}
+	if !targetStatusEnabled {
+		return nil
+	}
+	var errs []error
+	for _, status := range pm.GetStatus().EndpointStatuses {
+		if err := isPodMonitoringScrapeEndpointSuccess(&status); err != nil {
+			errs = append(errs, fmt.Errorf("unhealthy endpoint status %q: %w", status.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/e2e/syntheticutil.go
+++ b/e2e/syntheticutil.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/prometheus-engine/e2e/kubeutil"
+	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	SyntheticAppPortName      = "web"
+	SyntheticAppContainerName = "go-synthetic"
+
+	appManifest = "../examples/instrumentation/go-synthetic/go-synthetic.yaml"
+)
+
+func syntheticAppDeployment(scheme *runtime.Scheme) (*appsv1.Deployment, error) {
+	resources, err := kubeutil.ResourcesFromFile(scheme, appManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	var deployment *appsv1.Deployment
+	for _, resource := range resources {
+		var ok bool
+		deployment, ok = resource.(*appsv1.Deployment)
+		if ok {
+			break
+		}
+	}
+	if deployment == nil {
+		return nil, errors.New("unable to find app deployment")
+	}
+	return deployment, nil
+}
+
+func SyntheticAppDeploy(ctx context.Context, kubeClient client.Client, namespace, name string, args []string) (*appsv1.Deployment, error) {
+	deployment, err := syntheticAppDeployment(kubeClient.Scheme())
+	if err != nil {
+		return nil, err
+	}
+
+	deployment.Namespace = namespace
+	deployment.Name = name
+	if deployment.Spec.Template.Labels == nil {
+		deployment.Spec.Template.Labels = map[string]string{}
+	}
+	deployment.Spec.Template.Labels[operator.LabelInstanceName] = name
+
+	container, err := kubeutil.DeploymentContainer(deployment, SyntheticAppContainerName)
+	if err != nil {
+		return nil, err
+	}
+	container.Args = append(container.Args, args...)
+
+	if err := kubeClient.Create(ctx, deployment); err != nil {
+		return nil, fmt.Errorf("unable to create app deployment: %w", err)
+	}
+	return deployment, nil
+}

--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -249,12 +249,14 @@ type SecretOrConfigMap struct {
 	ConfigMap *corev1.ConfigMapKeySelector `json:"configMap,omitempty"`
 }
 
-// PodMonitoringStatusContainer represents a Kubernetes CRD that monitors pods
-// and contains a status sub-resource.
-type PodMonitoringStatusContainer interface {
+// PodMonitoringCRD represents a Kubernetes CRD that monitors Pod endpoints.
+type PodMonitoringCRD interface {
 	client.Object
 
-	// Returns this CRD's status sub-resource.
+	// GetEndpoints returns the endpoints scraped by this CRD.
+	GetEndpoints() []ScrapeEndpoint
+
+	// GetStatus returns this CRD's status sub-resource.
 	GetStatus() *PodMonitoringStatus
 }
 
@@ -277,6 +279,10 @@ type PodMonitoring struct {
 
 func (p *PodMonitoring) GetKey() string {
 	return fmt.Sprintf("PodMonitoring/%s/%s", p.Namespace, p.Name)
+}
+
+func (p *PodMonitoring) GetEndpoints() []ScrapeEndpoint {
+	return p.Spec.Endpoints
 }
 
 func (p *PodMonitoring) GetStatus() *PodMonitoringStatus {
@@ -312,6 +318,10 @@ type ClusterPodMonitoring struct {
 
 func (p *ClusterPodMonitoring) GetKey() string {
 	return fmt.Sprintf("ClusterPodMonitoring/%s", p.Name)
+}
+
+func (p *ClusterPodMonitoring) GetEndpoints() []ScrapeEndpoint {
+	return p.Spec.Endpoints
 }
 
 func (p *ClusterPodMonitoring) GetStatus() *PodMonitoringStatus {
@@ -986,7 +996,7 @@ type ScrapeLimits struct {
 	LabelValueLength uint64 `json:"labelValueLength,omitempty"`
 }
 
-// ClusterPodMonitoringSpec contains specification parameters for PodMonitoring.
+// ClusterPodMonitoringSpec contains specification parameters for ClusterPodMonitoring.
 type ClusterPodMonitoringSpec struct {
 	// Label selector that specifies which pods are selected for this monitoring
 	// configuration.

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -126,7 +126,7 @@ func setupCollectionControllers(op *Operator) error {
 type collectionReconciler struct {
 	client        client.Client
 	opts          Options
-	statusUpdates []monitoringv1.PodMonitoringStatusContainer
+	statusUpdates []monitoringv1.PodMonitoringCRD
 }
 
 func newCollectionReconciler(c client.Client, opts Options) *collectionReconciler {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -68,8 +68,11 @@ const (
 	// Filename for configuration files.
 	configFilename = "config.yaml"
 
-	// LabelAppName is the  well-known app name label.
+	// LabelAppName is the well-known app name label.
 	LabelAppName = "app.kubernetes.io/name"
+	// LabelInstanceName is the well-known instance name label.
+	LabelInstanceName = "app.kubernetes.io/instance"
+
 	// AnnotationMetricName is the component name, will be exposed as metric name.
 	AnnotationMetricName = "components.gke.io/component-name"
 	// ClusterAutoscalerSafeEvictionLabel is the annotation label that determines

--- a/pkg/operator/target_status.go
+++ b/pkg/operator/target_status.go
@@ -326,7 +326,7 @@ func buildClusterPodMonitoringFromJob(job []string) (*monitoringv1.ClusterPodMon
 	return pm, nil
 }
 
-func buildPodMonitoring(job string) (monitoringv1.PodMonitoringStatusContainer, error) {
+func buildPodMonitoring(job string) (monitoringv1.PodMonitoringCRD, error) {
 	split := strings.Split(job, "/")
 	if pm, err := buildPodMonitoringFromJob(split); err == nil {
 		return pm, nil
@@ -369,13 +369,13 @@ func updateTargetStatus(ctx context.Context, logger logr.Logger, kubeClient clie
 		if strings.HasPrefix(job, "kubelet") {
 			continue
 		}
-		podMonitoringStatusContainer, err := buildPodMonitoring(job)
+		pm, err := buildPodMonitoring(job)
 		if err != nil {
 			return fmt.Errorf("building podmonitoring: %s: %w", job, err)
 		}
-		podMonitoringStatusContainer.GetStatus().EndpointStatuses = endpointStatuses
+		pm.GetStatus().EndpointStatuses = endpointStatuses
 
-		if err := patchPodMonitoringStatus(ctx, kubeClient, podMonitoringStatusContainer, *podMonitoringStatusContainer.GetStatus()); err != nil {
+		if err := patchPodMonitoringStatus(ctx, kubeClient, pm, *pm.GetStatus()); err != nil {
 			// Save and log any error encountered while patching the status.
 			// We don't want to prematurely return if the error was transient
 			// as we should continue patching all statuses before exiting.


### PR DESCRIPTION
Additionally this change:

- Creates generic utilities for checking if a PodMonitoring is started. This will be used in future PRs.
- Add labels to collectors so that self-scraping tests don't start looking at collectors outside of the current test.
