### PR TITLE
Support empty auth parameters in go-synthetic

### DIFF
--- a/examples/instrumentation/go-synthetic/auth.go
+++ b/examples/instrumentation/go-synthetic/auth.go
@@ -233,7 +233,7 @@ func authorizationHandler(handler http.Handler, scheme, parameters string) http.
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
 		expected := scheme + " " + parameters
-		if auth == expected {
+		if strings.TrimSpace(auth) == strings.TrimSpace(expected) {
 			handler.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
Fixes allowing:
```bash
go run ./examples/instrumentation/go-synthetic/ --auth-scheme=Bearer 
curl -H "Authorization: Bearer" localhost:8080/metrics
# or
curl -H "Authorization: Bearer " localhost:8080/metrics
```