### PR TITLE
Revert "Add ability to pass cert files to operator"

### DIFF
--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -63,34 +63,12 @@ spec:
           requests:
             cpu: 1m
             memory: 16M
-        volumeMounts:
-        - name: tls
-          readOnly: true
-          mountPath: "/etc/tls/private"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - all
           privileged: false
-      volumes:
-      - name: tls
-        projected:
-          sources:
-          - secret:
-              name: webhook-tls
-              items:
-              - key: tls.crt
-                path: tls.crt
-              - key: tls.key
-                path: tls.key
-              optional: true
-          - configMap:
-              name: webhook-ca
-              items:
-              - key: ca.crt
-                path: ca.crt
-              optional: true
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -38,13 +38,6 @@ import (
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator"
 )
 
-const (
-	defaultTLSDir       = "/etc/tls/private"
-	defaultCertFile     = defaultTLSDir + "/tls.crt"
-	defaultKeyFile      = defaultTLSDir + "/tls.key"
-	defaultClientCAFile = defaultTLSDir + "/ca.crt"
-)
-
 func unstableFlagHelp(help string) string {
 	return help + " (Setting this flag voids any guarantees of proper behavior of the operator.)"
 }
@@ -75,13 +68,10 @@ func main() {
 		publicNamespace = flag.String("public-namespace", operator.DefaultPublicNamespace,
 			"Namespace in which the operator reads user-provided resources.")
 
-		tlsCert      = flag.String("tls-cert-base64", "", "The base64-encoded TLS certificate.")
-		tlsKey       = flag.String("tls-key-base64", "", "The base64-encoded TLS key.")
-		caCert       = flag.String("ca-cert-base64", "", "The base64-encoded certificate authority.")
-		certFile     = flag.String("cert-file", defaultCertFile, "Path to TLS certificate for webhook server.")
-		keyFile      = flag.String("key-file", defaultKeyFile, "Path to TLS key for webhook server.")
-		clientCAFile = flag.String("client-ca-file", defaultClientCAFile, "Client CA certificate to trust the webhook server.")
-		webhookAddr  = flag.String("webhook-addr", ":10250",
+		tlsCert     = flag.String("tls-cert-base64", "", "The base64-encoded TLS certificate.")
+		tlsKey      = flag.String("tls-key-base64", "", "The base64-encoded TLS key.")
+		caCert      = flag.String("ca-cert-base64", "", "The base64-encoded certificate authority.")
+		webhookAddr = flag.String("webhook-addr", ":10250",
 			"Address to listen to for incoming kube admission webhook connections.")
 		metricsAddr = flag.String("metrics-addr", ":18080", "Address to emit metrics on.")
 
@@ -120,9 +110,6 @@ func main() {
 		TLSCert:           *tlsCert,
 		TLSKey:            *tlsKey,
 		CACert:            *caCert,
-		KeyFile:           *keyFile,
-		CertFile:          *certFile,
-		ClientCAFile:      *clientCAFile,
 		ListenAddr:        *webhookAddr,
 		CleanupAnnotKey:   *cleanupAnnotKey,
 	})

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -265,34 +265,12 @@ spec:
           requests:
             cpu: 1m
             memory: 16M
-        volumeMounts:
-        - name: tls
-          readOnly: true
-          mountPath: "/etc/tls/private"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - all
           privileged: false
-      volumes:
-      - name: tls
-        projected:
-          sources:
-          - secret:
-              name: webhook-tls
-              items:
-              - key: tls.crt
-                path: tls.crt
-              - key: tls.key
-                path: tls.key
-              optional: true
-          - configMap:
-              name: webhook-ca
-              items:
-              - key: ca.crt
-                path: ca.crt
-              optional: true
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -90,9 +90,6 @@ const (
 
 	// The level of concurrency to use to fetch all targets.
 	defaultTargetPollConcurrency = 4
-
-	// certDir is the directory where TLS certificates are stored
-	certDir = "/etc/tls/private"
 )
 
 // Operator to implement managed collection for Google Prometheus Engine.
@@ -121,12 +118,6 @@ type Options struct {
 	// Namespace to which the operator looks for user-specified configuration
 	// data, like Secrets and ConfigMaps.
 	PublicNamespace string
-	// KeyFile specifies the path to the client TLS key for the webhook server
-	KeyFile string
-	// CertFile specifies the path to the client TLS cert for the webhook server
-	CertFile string
-	// ClientCAFile is the path to the CA used by webhook clients to establish trust with the webhook server
-	ClientCAFile string
 	// Certificate of the server in base 64.
 	TLSCert string
 	// Key of the server in base 64.
@@ -193,6 +184,11 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 	if err := opts.defaultAndValidate(logger); err != nil {
 		return nil, fmt.Errorf("invalid options: %w", err)
 	}
+	// Create temporary directory to store webhook serving cert files.
+	certDir, err := os.MkdirTemp("", "operator-cert")
+	if err != nil {
+		return nil, fmt.Errorf("create temporary certificate dir: %w", err)
+	}
 
 	sc, err := NewScheme()
 	if err != nil {
@@ -207,7 +203,6 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 	if err != nil {
 		return nil, fmt.Errorf("invalid port: %w", err)
 	}
-
 	manager, err := ctrl.NewManager(clientConfig, manager.Options{
 		Scheme: sc,
 		Host:   host,
@@ -308,7 +303,7 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 // custom resources and registers handlers with the webhook server.
 func (o *Operator) setupAdmissionWebhooks(ctx context.Context) error {
 	// Write provided cert files.
-	caBundle, err := o.ensureCerts(ctx, certDir)
+	caBundle, err := o.ensureCerts(ctx, o.manager.GetWebhookServer().CertDir)
 	if err != nil {
 		return err
 	}
@@ -454,9 +449,6 @@ func (o *Operator) ensureCerts(ctx context.Context, dir string) ([]byte, error) 
 		crt, key, caData []byte
 		err              error
 	)
-	if fileExists(o.opts.CertFile) && fileExists(o.opts.KeyFile) && fileExists(o.opts.ClientCAFile) {
-		return os.ReadFile(o.opts.ClientCAFile)
-	}
 	if o.opts.TLSKey != "" && o.opts.TLSCert != "" {
 		crt, err = base64.StdEncoding.DecodeString(o.opts.TLSCert)
 		if err != nil {
@@ -489,9 +481,6 @@ func (o *Operator) ensureCerts(ctx context.Context, dir string) ([]byte, error) 
 		return nil, errors.New("flags key-base64 and cert-base64 must both be set")
 	}
 	// Create cert/key files.
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return nil, fmt.Errorf("create cert directory: %w", err)
-	}
 	if err := os.WriteFile(filepath.Join(dir, "tls.crt"), crt, 0666); err != nil {
 		return nil, fmt.Errorf("create cert file: %w", err)
 	}
@@ -499,13 +488,6 @@ func (o *Operator) ensureCerts(ctx context.Context, dir string) ([]byte, error) 
 		return nil, fmt.Errorf("create key file: %w", err)
 	}
 	return caData, nil
-}
-
-func fileExists(f string) bool {
-	if _, err := os.Stat(f); err != nil {
-		return false
-	}
-	return true
 }
 
 // namespacedNamePredicate is an event filter predicate that only allows events with


### PR DESCRIPTION
Reverts GoogleCloudPlatform/prometheus-engine#601

   This change broke self-installed with the error "init admission
    resources: create cert file: open /etc/tls/private/tls.crt: read-only
    file system"