### PR TITLE
fix: updateversions make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ CURRENT_TAG = v0.8.0-gke.4
 CURRENT_PROM_TAG = v2.41.0-gmp.5-gke.0
 CURRENT_AM_TAG = v0.25.1-gmp.1-gke.0
 LABEL_API_VERSION = 0.8.0
-FILES_TO_UPDATE = $(shell find . -type f -name "*.yaml" ! -name "kube-state-metrics.yaml" ! -name "node-exporter.yaml")
+FILES_TO_UPDATE = $(shell find manifests cmd/operator/deploy -type f -name "*.yaml")
 updateversions: ## Modify all manifests, so it contains the expected versions.
                 ##
                 ## TODO(bwplotka): CI does not check updateversions--add that there.

--- a/examples/hpa/prometheus-adapter.yaml
+++ b/examples/hpa/prometheus-adapter.yaml
@@ -102,7 +102,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/version: 0.8.0
+    app.kubernetes.io/version: 0.11.1
   name: prometheus-adapter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -119,7 +119,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/version: 0.8.0
+    app.kubernetes.io/version: 0.11.1
   name: resource-metrics-server-resources
 rules:
 - apiGroups:
@@ -135,7 +135,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/version: 0.8.0
+    app.kubernetes.io/version: 0.11.1
   name: prometheus-adapter
 rules:
 - apiGroups:
@@ -178,7 +178,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/version: 0.8.0
+    app.kubernetes.io/version: 0.11.1
   name: adapter-config
   namespace: monitoring
 ---
@@ -188,7 +188,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/version: 0.8.0
+    app.kubernetes.io/version: 0.11.1
   name: prometheus-adapter
   namespace: monitoring
 spec:
@@ -208,7 +208,7 @@ spec:
       labels:
         app.kubernetes.io/component: metrics-adapter
         app.kubernetes.io/name: prometheus-adapter
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.11.1
     spec:
       automountServiceAccountToken: true
       containers:
@@ -289,7 +289,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/version: 0.8.0
+    app.kubernetes.io/version: 0.11.1
   name: prometheus-adapter
   namespace: monitoring
 spec:
@@ -326,7 +326,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/version: 0.8.0
+    app.kubernetes.io/version: 0.11.1
   name: resource-metrics-auth-reader
   namespace: kube-system
 roleRef:
@@ -345,7 +345,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/version: 0.8.0
+    app.kubernetes.io/version: 0.11.1
   name: prometheus-adapter
   namespace: monitoring
 ---
@@ -355,7 +355,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/version: 0.8.0
+    app.kubernetes.io/version: 0.11.1
   name: prometheus-adapter
   namespace: monitoring
 spec:


### PR DESCRIPTION
Ensure only valid install manifests have their version updated, avoiding example manifests.