### PR TITLE
feat: pod lifecycle filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ e2e:         ## Run e2e test suite against fresh kind k8s cluster. By default it
 ifeq ($(NO_DOCKER), 1)
 	@echo ">> running e2e against your cluster"
 	kubectl apply -f manifests/setup.yaml
+	kubectl apply -f cmd/operator/deploy/operator/00-namespace.yaml
 	kubectl apply -f cmd/operator/deploy/operator/01-priority-class.yaml
 	kubectl apply -f cmd/operator/deploy/operator/03-role.yaml
 	go test -v "./e2e/..." -run "$(or $(TEST_RUN), .)" -args -project-id="$(PROJECT_ID)" -cluster="$(GMP_CLUSTER)" -location="$(GMP_LOCATION)" $(TEST_ARGS)

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -163,7 +163,7 @@ spec:
                   - port
               filterRunning:
                 type: boolean
-                description: 'FilterRunning will drop any pods that are in the "Failed" or "Succeeded" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase This prevents noisy errors when attempting to scrape Suceeded pods from K8s Jobs. Additionally, it can mitigate issues with reusing stale target labels in cases where Pod IPs are reused (e.g. spot containers). See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145'
+                description: 'FilterRunning will drop any pods that are in the "Failed" or "Succeeded" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase Specifically, this prevents scraping Suceeded pods from K8s jobs, which could contribute to noisy logs or irrelevent metrics. Additionally, it can mitigate issues with reusing stale target labels in cases where Pod IPs are reused (e.g. spot containers). See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145'
               limits:
                 type: object
                 description: Limits to apply at scrape time.

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -161,6 +161,9 @@ spec:
                           description: Used to verify the hostname for the targets.
                   required:
                   - port
+              filterRunning:
+                type: boolean
+                description: 'FilterRunning will drop any pods that are in the "Failed" or "Succeeded" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase This prevents noisy errors when attempting to scrape Suceeded pods from K8s Jobs. Additionally, it can mitigate issues with reusing stale target labels in cases where Pod IPs are reused (e.g. spot containers). See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145'
               limits:
                 type: object
                 description: Limits to apply at scrape time.

--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -161,6 +161,9 @@ spec:
                           description: Used to verify the hostname for the targets.
                   required:
                   - port
+              filterRunning:
+                type: boolean
+                description: 'FilterRunning will drop any pods that are in the "Failed" or "Succeeded" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
               limits:
                 type: object
                 description: Limits to apply at scrape time.

--- a/doc/api.md
+++ b/doc/api.md
@@ -148,7 +148,7 @@ ClusterPodMonitoringSpec contains specification parameters for ClusterPodMonitor
 | endpoints | The endpoints to scrape on the selected pods. | [][ScrapeEndpoint](#scrapeendpoint) | true |
 | targetLabels | Labels to add to the Prometheus target for discovered endpoints. The `instance` label is always set to `<pod_name>:<port>` or `<node_name>:<port>` if the scraped pod is controlled by a DaemonSet. | [TargetLabels](#targetlabels) | false |
 | limits | Limits to apply at scrape time. | *[ScrapeLimits](#scrapelimits) | false |
-| filterRunning | FilterRunning will drop any pods that are in the \"Failed\" or \"Succeeded\" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase This prevents noisy errors when attempting to scrape Suceeded pods from K8s Jobs. Additionally, it can mitigate issues with reusing stale target labels in cases where Pod IPs are reused (e.g. spot containers). See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145 | *bool | false |
+| filterRunning | FilterRunning will drop any pods that are in the \"Failed\" or \"Succeeded\" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase Specifically, this prevents scraping Suceeded pods from K8s jobs, which could contribute to noisy logs or irrelevent metrics. Additionally, it can mitigate issues with reusing stale target labels in cases where Pod IPs are reused (e.g. spot containers). See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145 | *bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -148,6 +148,7 @@ ClusterPodMonitoringSpec contains specification parameters for ClusterPodMonitor
 | endpoints | The endpoints to scrape on the selected pods. | [][ScrapeEndpoint](#scrapeendpoint) | true |
 | targetLabels | Labels to add to the Prometheus target for discovered endpoints. The `instance` label is always set to `<pod_name>:<port>` or `<node_name>:<port>` if the scraped pod is controlled by a DaemonSet. | [TargetLabels](#targetlabels) | false |
 | limits | Limits to apply at scrape time. | *[ScrapeLimits](#scrapelimits) | false |
+| filterRunning | FilterRunning will drop any pods that are in the \"Failed\" or \"Succeeded\" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase This prevents noisy errors when attempting to scrape Suceeded pods from K8s Jobs. Additionally, it can mitigate issues with reusing stale target labels in cases where Pod IPs are reused (e.g. spot containers). See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145 | *bool | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -400,6 +401,7 @@ PodMonitoringSpec contains specification parameters for PodMonitoring.
 | endpoints | The endpoints to scrape on the selected pods. | [][ScrapeEndpoint](#scrapeendpoint) | true |
 | targetLabels | Labels to add to the Prometheus target for discovered endpoints. The `instance` label is always set to `<pod_name>:<port>` or `<node_name>:<port>` if the scraped pod is controlled by a DaemonSet. | [TargetLabels](#targetlabels) | false |
 | limits | Limits to apply at scrape time. | *[ScrapeLimits](#scrapelimits) | false |
+| filterRunning | FilterRunning will drop any pods that are in the \"Failed\" or \"Succeeded\" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase | *bool | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -165,7 +165,7 @@ spec:
                   - port
               filterRunning:
                 type: boolean
-                description: 'FilterRunning will drop any pods that are in the "Failed" or "Succeeded" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase This prevents noisy errors when attempting to scrape Suceeded pods from K8s Jobs. Additionally, it can mitigate issues with reusing stale target labels in cases where Pod IPs are reused (e.g. spot containers). See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145'
+                description: 'FilterRunning will drop any pods that are in the "Failed" or "Succeeded" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase Specifically, this prevents scraping Suceeded pods from K8s jobs, which could contribute to noisy logs or irrelevent metrics. Additionally, it can mitigate issues with reusing stale target labels in cases where Pod IPs are reused (e.g. spot containers). See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145'
               limits:
                 type: object
                 description: Limits to apply at scrape time.

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -163,6 +163,9 @@ spec:
                           description: Used to verify the hostname for the targets.
                   required:
                   - port
+              filterRunning:
+                type: boolean
+                description: 'FilterRunning will drop any pods that are in the "Failed" or "Succeeded" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase This prevents noisy errors when attempting to scrape Suceeded pods from K8s Jobs. Additionally, it can mitigate issues with reusing stale target labels in cases where Pod IPs are reused (e.g. spot containers). See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145'
               limits:
                 type: object
                 description: Limits to apply at scrape time.
@@ -1578,6 +1581,9 @@ spec:
                           description: Used to verify the hostname for the targets.
                   required:
                   - port
+              filterRunning:
+                type: boolean
+                description: 'FilterRunning will drop any pods that are in the "Failed" or "Succeeded" pod lifecycle. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
               limits:
                 type: object
                 description: Limits to apply at scrape time.

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -528,7 +528,7 @@ const (
 	ClientName = "prometheus-engine-export"
 	// mainModuleVersion is the version of the main module. Align with git tag.
 	// TODO(TheSpiritXIII): Remove with https://github.com/golang/go/issues/50603
-	mainModuleVersion = "v0.8.0-rc.0"
+	mainModuleVersion = "v0.9.0-rc.0"
 	// mainModuleName is the name of the main module. Align with go.mod.
 	mainModuleName = "github.com/GoogleCloudPlatform/prometheus-engine"
 )

--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -1044,8 +1044,9 @@ type ClusterPodMonitoringSpec struct {
 	// FilterRunning will drop any pods that are in the "Failed" or "Succeeded"
 	// pod lifecycle.
 	// See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
-	// This prevents noisy errors when attempting to scrape Suceeded pods from
-	// K8s Jobs. Additionally, it can mitigate issues with reusing stale target
+	// Specifically, this prevents scraping Suceeded pods from K8s jobs, which
+	// could contribute to noisy logs or irrelevent metrics.
+	// Additionally, it can mitigate issues with reusing stale target
 	// labels in cases where Pod IPs are reused (e.g. spot containers).
 	// See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145
 	FilterRunning *bool `json:"filterRunning,omitempty"`

--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -1044,6 +1044,10 @@ type ClusterPodMonitoringSpec struct {
 	// FilterRunning will drop any pods that are in the "Failed" or "Succeeded"
 	// pod lifecycle.
 	// See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+	// This prevents noisy errors when attempting to scrape Suceeded pods from
+	// K8s Jobs. Additionally, it can mitigate issues with reusing stale target
+	// labels in cases where Pod IPs are reused (e.g. spot containers).
+	// See: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145
 	FilterRunning *bool `json:"filterRunning,omitempty"`
 }
 

--- a/pkg/operator/apis/monitoring/v1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1/types_test.go
@@ -645,6 +645,9 @@ relabel_configs:
 - target_label: job
   replacement: name1
   action: replace
+- source_labels: [__meta_kubernetes_pod_phase]
+  regex: (Failed|Succeeded)
+  action: drop
 - target_label: project_id
   replacement: test_project
   action: replace
@@ -720,6 +723,9 @@ relabel_configs:
 - target_label: job
   replacement: name1
   action: replace
+- source_labels: [__meta_kubernetes_pod_phase]
+  regex: (Failed|Succeeded)
+  action: drop
 - target_label: project_id
   replacement: test_project
   action: replace
@@ -858,6 +864,9 @@ relabel_configs:
 - target_label: job
   replacement: name1
   action: replace
+- source_labels: [__meta_kubernetes_pod_phase]
+  regex: (Failed|Succeeded)
+  action: drop
 - target_label: project_id
   replacement: test_project
   action: replace
@@ -928,6 +937,9 @@ relabel_configs:
 - target_label: job
   replacement: name1
   action: replace
+- source_labels: [__meta_kubernetes_pod_phase]
+  regex: (Failed|Succeeded)
+  action: drop
 - target_label: project_id
   replacement: test_project
   action: replace

--- a/pkg/operator/apis/monitoring/v1/zz_generated.deepcopy.go
+++ b/pkg/operator/apis/monitoring/v1/zz_generated.deepcopy.go
@@ -174,6 +174,11 @@ func (in *ClusterPodMonitoringSpec) DeepCopyInto(out *ClusterPodMonitoringSpec) 
 		*out = new(ScrapeLimits)
 		**out = **in
 	}
+	if in.FilterRunning != nil {
+		in, out := &in.FilterRunning, &out.FilterRunning
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -634,6 +639,11 @@ func (in *PodMonitoringSpec) DeepCopyInto(out *PodMonitoringSpec) {
 	if in.Limits != nil {
 		in, out := &in.Limits, &out.Limits
 		*out = new(ScrapeLimits)
+		**out = **in
+	}
+	if in.FilterRunning != nil {
+		in, out := &in.FilterRunning, &out.FilterRunning
+		*out = new(bool)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
Only pods that are not "Failed" or "Succeeded" will be default candidates for scraping.

BREAKING CHANGE: this changes the default behavior of PodMonitoring and ClusterPodMonitoring