### PR TITLE
Use a single manager cache for the operator

### DIFF
--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -44,7 +44,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
@@ -112,8 +111,8 @@ func setupCollectionControllers(op *Operator) error {
 				predicate.GenerationChangedPredicate{},
 			)).
 		// Detect and undo changes to the secret.
-		WatchesRawSource(
-			source.Kind(op.managedNamespacesCache, &corev1.Secret{}),
+		Watches(
+			&corev1.Secret{},
 			enqueueConst(objRequest),
 			builder.WithPredicates(objFilterSecret)).
 		Complete(newCollectionReconciler(op.manager.GetClient(), op.opts))

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -45,7 +45,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -155,18 +154,18 @@ func setupOperatorConfigControllers(op *Operator) error {
 				objFilterRuleEvaluator,
 				predicate.GenerationChangedPredicate{},
 			)).
-		WatchesRawSource(
-			source.Kind(op.managedNamespacesCache, &corev1.Secret{}),
+		Watches(
+			&corev1.Secret{},
 			enqueueConst(objRequest),
 			builder.WithPredicates(predicate.NewPredicateFuncs(secretFilter(op.opts.PublicNamespace))),
 		).
 		// Detect and undo changes to the secret.
-		WatchesRawSource(
-			source.Kind(op.managedNamespacesCache, &corev1.Secret{}),
+		Watches(
+			&corev1.Secret{},
 			enqueueConst(objRequest),
 			builder.WithPredicates(objFilterRuleEvaluatorSecret)).
-		WatchesRawSource(
-			source.Kind(op.managedNamespacesCache, &corev1.Secret{}),
+		Watches(
+			&corev1.Secret{},
 			enqueueConst(objRequest),
 			builder.WithPredicates(objFilterAlertManagerSecret)).
 		Complete(newOperatorConfigReconciler(op.manager.GetClient(), op.opts))


### PR DESCRIPTION
The recent controller-runtime allows use to use a single cache for the operator and remove our hacky secondary cache.