### PR TITLE
fix operator role for alertmanager externalURL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,10 +175,10 @@ presubmit:   ## Regenerate all resources, build all images and run all tests.
 presubmit: updateversions regen bin test e2e
 
 .PHONY: updateversions
-CURRENT_TAG = v0.8.0-gke.4
-CURRENT_PROM_TAG = v2.41.0-gmp.5-gke.0
-CURRENT_AM_TAG = v0.25.1-gmp.1-gke.0
-LABEL_API_VERSION = 0.8.0
+CURRENT_TAG = v0.9.0-gke.1
+CURRENT_PROM_TAG = v2.41.0-gmp.7-gke.0
+CURRENT_AM_TAG = v0.25.1-gmp.2-gke.0
+LABEL_API_VERSION = 0.9.0
 FILES_TO_UPDATE = $(shell find manifests cmd/operator/deploy -type f -name "*.yaml")
 updateversions: ## Modify all manifests, so it contains the expected versions.
                 ##

--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -79,6 +79,12 @@ rules:
   apiGroups: [""]
   resourceNames: ["alertmanager"]
   verbs: ["get", "list", "watch"]
+- resources:
+  - statefulsets
+  apiGroups: ["apps"]
+  resourceNames:
+  - alertmanager
+  verbs: ["patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -134,3 +140,7 @@ rules:
   - rules/status
   apiGroups: ["monitoring.googleapis.com"]
   verbs: ["get", "patch", "update"]
+- resources:
+  - statefulsets
+  apiGroups: ["apps"]
+  verbs: ["get", "list", "watch"]

--- a/cmd/operator/deploy/operator/05-deployment.yaml
+++ b/cmd/operator/deploy/operator/05-deployment.yaml
@@ -36,14 +36,14 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/operator:v0.9.0-gke.1
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"

--- a/cmd/operator/deploy/operator/10-collector.yaml
+++ b/cmd/operator/deploy/operator/10-collector.yaml
@@ -28,7 +28,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -53,7 +53,7 @@ spec:
           privileged: false
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -88,7 +88,7 @@ spec:
             - all
           privileged: false
       - name: prometheus
-        image: gke.gcr.io/prometheus-engine/prometheus:v2.41.0-gmp.5-gke.0
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.41.0-gmp.7-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage

--- a/cmd/operator/deploy/operator/11-rule-evaluator.yaml
+++ b/cmd/operator/deploy/operator/11-rule-evaluator.yaml
@@ -29,7 +29,7 @@ spec:
       labels:
         app: managed-prometheus-rule-evaluator
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -54,7 +54,7 @@ spec:
           privileged: false
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -91,7 +91,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.9.0-gke.1
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092

--- a/cmd/operator/deploy/operator/12-alertmanager.yaml
+++ b/cmd/operator/deploy/operator/12-alertmanager.yaml
@@ -41,7 +41,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
@@ -62,7 +62,7 @@ spec:
           privileged: false
       containers:
       - name: alertmanager
-        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.1-gke.0
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.2-gke.0
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data
@@ -97,7 +97,7 @@ spec:
             - all
           privileged: false
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
+++ b/cmd/operator/deploy/rule-evaluator/01-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
@@ -40,7 +40,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -74,7 +74,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.9.0-gke.1
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -109,6 +109,12 @@ rules:
   apiGroups: [""]
   resourceNames: ["alertmanager"]
   verbs: ["get", "list", "watch"]
+- resources:
+  - statefulsets
+  apiGroups: ["apps"]
+  resourceNames:
+  - alertmanager
+  verbs: ["patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -160,6 +166,10 @@ rules:
   - rules/status
   apiGroups: ["monitoring.googleapis.com"]
   verbs: ["get", "patch", "update"]
+- resources:
+  - statefulsets
+  apiGroups: ["apps"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -238,14 +248,14 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/operator:v0.9.0-gke.1
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"
@@ -534,7 +544,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -559,7 +569,7 @@ spec:
           privileged: false
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -594,7 +604,7 @@ spec:
             - all
           privileged: false
       - name: prometheus
-        image: gke.gcr.io/prometheus-engine/prometheus:v2.41.0-gmp.5-gke.0
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.41.0-gmp.7-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage
@@ -708,7 +718,7 @@ spec:
       labels:
         app: managed-prometheus-rule-evaluator
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -733,7 +743,7 @@ spec:
           privileged: false
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -770,7 +780,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.9.0-gke.1
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
@@ -885,7 +895,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
@@ -906,7 +916,7 @@ spec:
           privileged: false
       containers:
       - name: alertmanager
-        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.1-gke.0
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.2-gke.0
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data
@@ -941,7 +951,7 @@ spec:
             - all
           privileged: false
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -59,7 +59,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
@@ -72,7 +72,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -106,7 +106,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.9.0-gke.1
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"


### PR DESCRIPTION
also bump the version and images

Note: I had to add the get/list/watch abilities to the ClusterRole instead of the Role. This is obviously less preferable, however the controller-runtime library errors if I add those to the role:
```
E1204 22:39:49.710415       1 reflector.go:140] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:262: Failed to watch *v1.StatefulSet: failed to list *v1.StatefulSet: statefulsets.apps is forbidden: User "system:serviceaccount:gmp-system:operator" cannot list resource "statefulsets" in API group "apps" at the cluster scope
```