### PR TITLE
Replace deprecated wait methods

### DIFF
--- a/e2e/kubeutil/deployment.go
+++ b/e2e/kubeutil/deployment.go
@@ -58,11 +58,11 @@ func IsDeploymentReady(ctx context.Context, kubeClient client.Client, namespace,
 
 func WaitForDeploymentReady(ctx context.Context, kubeClient client.Client, namespace, name string) error {
 	var err error
-	if waitErr := wait.Poll(3*time.Second, 1*time.Minute, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		err := IsDeploymentReady(ctx, kubeClient, namespace, name)
 		return err == nil, nil
 	}); waitErr != nil {
-		if errors.Is(waitErr, wait.ErrWaitTimeout) {
+		if errors.Is(waitErr, context.DeadlineExceeded) {
 			return err
 		}
 		return waitErr

--- a/e2e/kubeutil/pod.go
+++ b/e2e/kubeutil/pod.go
@@ -54,14 +54,14 @@ func WaitForPodContainerReady(ctx context.Context, t testing.TB, restConfig *res
 		return nil
 	}
 	t.Logf("waiting for pod to be ready: %s", err)
-	if waitErr := wait.Poll(2*time.Second, 30*time.Second, func() (done bool, err error) {
+	if waitErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		if err = kubeClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 			return false, err
 		}
 		err = IsPodContainerReady(ctx, restConfig, pod, container)
 		return err == nil, nil
 	}); waitErr != nil {
-		if errors.Is(waitErr, wait.ErrWaitTimeout) {
+		if errors.Is(waitErr, context.DeadlineExceeded) {
 			return err
 		}
 		return waitErr
@@ -87,14 +87,14 @@ func WaitForPodReady(ctx context.Context, t *testing.T, restConfig *rest.Config,
 		return nil
 	}
 	t.Logf("waiting for pod to be ready: %s", err)
-	if waitErr := wait.Poll(2*time.Second, 30*time.Second, func() (done bool, err error) {
+	if waitErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		if err = kubeClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 			return false, err
 		}
 		err = IsPodReady(ctx, restConfig, pod)
 		return err == nil, nil
 	}); waitErr != nil {
-		if errors.Is(waitErr, wait.ErrWaitTimeout) {
+		if errors.Is(waitErr, context.DeadlineExceeded) {
 			return err
 		}
 		return waitErr

--- a/e2e/operator_context_test.go
+++ b/e2e/operator_context_test.go
@@ -39,7 +39,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/discovery"
@@ -367,12 +366,6 @@ func createGCPSecretResources(ctx context.Context, kubeClient client.Client, nam
 		}
 	}
 	return nil
-}
-
-func parseResourceYAML(b []byte) (runtime.Object, error) {
-	// Ignore returned schema. It's redundant since it's already encoded in obj.
-	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(b, nil, nil)
-	return obj, err
 }
 
 func createCollectorResources(ctx context.Context, kubeClient client.Client, namespace, labelValue string) error {

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -65,7 +65,7 @@ func TestWebhookCABundleInjection(t *testing.T) {
 		}
 
 		// Wait for caBundle injection.
-		err := wait.Poll(3*time.Second, 2*time.Minute, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 			if err := tctx.Client().Get(ctx, client.ObjectKeyFromObject(vwc), vwc); err != nil {
 				return false, fmt.Errorf("get validatingwebhook configuration: %w", err)
 			}
@@ -112,7 +112,7 @@ func TestWebhookCABundleInjection(t *testing.T) {
 		}
 
 		// Wait for caBundle injection.
-		err := wait.Poll(3*time.Second, 2*time.Minute, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 			if err := tctx.Client().Get(ctx, client.ObjectKeyFromObject(mwc), mwc); err != nil {
 				return false, fmt.Errorf("get mutatingwebhook configuration: %w", err)
 			}

--- a/pkg/operator/collection_test.go
+++ b/pkg/operator/collection_test.go
@@ -29,7 +29,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -108,7 +107,7 @@ func TestCollectionStatus(t *testing.T) {
 
 	kubeClient := newFakeClientBuilder().
 		WithObjects(&monitoringv1.PodMonitoring{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "prom-example",
 				Namespace: "gmp-test",
 			},
@@ -121,7 +120,7 @@ func TestCollectionStatus(t *testing.T) {
 			Status: statusIn,
 		}).
 		WithObjects(&monitoringv1.OperatorConfig{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      NameOperatorConfig,
 				Namespace: opts.PublicNamespace,
 			},
@@ -161,13 +160,12 @@ func TestCollectionStatus(t *testing.T) {
 		for i := range status.Conditions {
 			// Normalize times because we cannot predict this.
 			condition := &status.Conditions[i]
-			condition.LastUpdateTime = v1.Time{}
-			condition.LastTransitionTime = v1.Time{}
+			condition.LastUpdateTime = metav1.Time{}
+			condition.LastTransitionTime = metav1.Time{}
 		}
 		if diff := cmp.Diff(status, statusOut); diff != "" {
 			t.Fatalf("invalid PodMonitoringStatus: %s", diff)
 		}
-		break
 	default:
 		t.Fatalf("invalid PodMonitorings found: %d", amount)
 	}


### PR DESCRIPTION
The update to the new wait methods broke a couple of tests due to the new immediate execution of the poll callback. The fix is just updating the poll methods to retry after an error. This is something we would have had to fix anyway because failures could still happen without the immediate execution, if the operator had any delay updating the resources. We have seen some flaky tests in the recent past, and this might have been the reason.