### PR TITLE
Add user namespace to e2e tests

### DIFF
--- a/e2e/authorization_test.go
+++ b/e2e/authorization_test.go
@@ -59,12 +59,12 @@ func defaultEndpoint(endpoint *monitoringv1.ScrapeEndpoint) {
 func setupAuthTestMissingAuth(ctx context.Context, t *OperatorContext, appName string, args []string, podMonitoringNamePrefix string, endpointNoAuth monitoringv1.ScrapeEndpoint, expectedFn func(string) error) *appsv1.Deployment {
 	defaultEndpoint(&endpointNoAuth)
 
-	deployment, err := operatorutil.SyntheticAppDeploy(ctx, t.Client(), t.namespace, appName, args)
+	deployment, err := operatorutil.SyntheticAppDeploy(ctx, t.Client(), t.userNamespace, appName, args)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := kubeutil.WaitForDeploymentReady(ctx, t.Client(), t.namespace, appName); err != nil {
-		kubeutil.DeploymentDebug(t.T, ctx, t.RestConfig(), t.Client(), t.namespace, appName)
+	if err := kubeutil.WaitForDeploymentReady(ctx, t.Client(), t.userNamespace, appName); err != nil {
+		kubeutil.DeploymentDebug(t.T, ctx, t.RestConfig(), t.Client(), t.userNamespace, appName)
 		t.Fatalf("failed to start app: %s", err)
 	}
 
@@ -74,7 +74,7 @@ func setupAuthTestMissingAuth(ctx context.Context, t *OperatorContext, appName s
 		pm := &monitoringv1.PodMonitoring{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("pod%s-missing-config", podMonitoringNamePrefix),
-				Namespace: t.namespace,
+				Namespace: t.userNamespace,
 			},
 			Spec: monitoringv1.PodMonitoringSpec{
 				Selector: metav1.LabelSelector{
@@ -103,7 +103,7 @@ func setupAuthTestMissingAuth(ctx context.Context, t *OperatorContext, appName s
 
 		pm := &monitoringv1.ClusterPodMonitoring{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("c%s-failure", podMonitoringNamePrefix),
+				Name: fmt.Sprintf("%s-c%s-failure", t.namespace, podMonitoringNamePrefix),
 			},
 			Spec: monitoringv1.ClusterPodMonitoringSpec{
 				Selector: metav1.LabelSelector{
@@ -142,7 +142,7 @@ func setupAuthTest(ctx context.Context, t *OperatorContext, appName string, args
 		pm := &monitoringv1.PodMonitoring{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("pod%s-success", podMonitoringNamePrefix),
-				Namespace: t.namespace,
+				Namespace: t.userNamespace,
 			},
 			Spec: monitoringv1.PodMonitoringSpec{
 				Selector: metav1.LabelSelector{
@@ -171,8 +171,7 @@ func setupAuthTest(ctx context.Context, t *OperatorContext, appName string, args
 
 		pm := &monitoringv1.ClusterPodMonitoring{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("c%s-success", podMonitoringNamePrefix),
-				Namespace: t.namespace,
+				Name: fmt.Sprintf("c%s-success", podMonitoringNamePrefix),
 			},
 			Spec: monitoringv1.ClusterPodMonitoringSpec{
 				Selector: metav1.LabelSelector{

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -99,13 +99,13 @@ func TestCollector(t *testing.T) {
 		}))
 
 		const appName = "collector-synthetic"
-		deployment, err := operatorutil.SyntheticAppDeploy(ctx, tctx.Client(), tctx.namespace, appName, []string{})
+		deployment, err := operatorutil.SyntheticAppDeploy(ctx, tctx.Client(), tctx.userNamespace, appName, []string{})
 		if err != nil {
 			tctx.Fatal(err)
 		}
 
-		if err := kubeutil.WaitForDeploymentReady(ctx, tctx.Client(), tctx.namespace, appName); err != nil {
-			kubeutil.DeploymentDebug(tctx.T, ctx, tctx.RestConfig(), tctx.Client(), tctx.namespace, appName)
+		if err := kubeutil.WaitForDeploymentReady(ctx, tctx.Client(), tctx.userNamespace, appName); err != nil {
+			kubeutil.DeploymentDebug(tctx.T, ctx, tctx.RestConfig(), tctx.Client(), tctx.userNamespace, appName)
 			tctx.Fatalf("failed to start app: %s", err)
 		}
 		t.Run("synthetic-podmonitoring", tctx.subtest(func(ctx context.Context, t *OperatorContext) {
@@ -113,7 +113,7 @@ func TestCollector(t *testing.T) {
 			testCollector(ctx, t, &monitoringv1.PodMonitoring{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "synthetic-podmon",
-					Namespace: t.namespace,
+					Namespace: t.userNamespace,
 				},
 				Spec: monitoringv1.PodMonitoringSpec{
 					Selector: metav1.LabelSelector{


### PR DESCRIPTION
This PR adds a 3rd namespace to e2e tests.

Here's when you use each now:
1. `namespace`: The operator namespace. Use only for operator resources or for `PodMonitoring` or `ClusterPodMonitorings` that are self-scraping.
2. `pubNamespace`: The operator public namespace. Use only for resources that are stored here, e.g. `OperatorConfig` and the rule evaluator `ConfigMaps` and `Secrets` .
3. `userNamespace`: For everything else -- applications, `PodMonitorings` or `ClusterPodMonitorings`, application `Secrets`. etc.