### PR TITLE
Improve e2e test reliability when running on GitHub Actions

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -62,3 +62,5 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run e2e
       run: make e2e
+      env:
+        GO_ARGS: "-timeout=15m"

--- a/Makefile
+++ b/Makefile
@@ -164,14 +164,14 @@ ifeq ($(NO_DOCKER), 1)
 	kubectl apply -f cmd/operator/deploy/operator/00-namespace.yaml
 	kubectl apply -f cmd/operator/deploy/operator/01-priority-class.yaml
 	kubectl apply -f cmd/operator/deploy/operator/03-role.yaml
-	go test -v "./e2e/..." -run "$(or $(TEST_RUN), .)" -args -project-id="$(PROJECT_ID)" -cluster="$(GMP_CLUSTER)" -location="$(GMP_LOCATION)" $(TEST_ARGS)
+	go test -v $(GO_ARGS) "./e2e/..." -run "$(or $(TEST_RUN), .)" -args -project-id="$(PROJECT_ID)" -cluster="$(GMP_CLUSTER)" -location="$(GMP_LOCATION)" $(TEST_ARGS)
 else
 	@echo ">> building kindtest image"
 	$(call docker_build, -f hack/Dockerfile --target kindtest -t gmp/kindtest .)
 	@echo ">> running container"
 # We lose some isolation by sharing the host network with the kind containers.
 # However, we avoid a gcloud-shell "Dockerception" and save on build times.
-	docker run --env TEST_RUN="$(TEST_RUN)" --env TEST_ARGS="$(TEST_ARGS)" --network host --rm -v $(DOCKER_VOLUME):/var/run/docker.sock gmp/kindtest ./hack/kind-test.sh
+	docker run --env TEST_RUN="$(TEST_RUN)" --env TEST_ARGS="$(TEST_ARGS)" --env GO_ARGS="$(GO_ARGS)" --network host --rm -v $(DOCKER_VOLUME):/var/run/docker.sock gmp/kindtest ./hack/kind-test.sh
 endif
 
 .PHONY: presubmit

--- a/e2e/alertmanager_test.go
+++ b/e2e/alertmanager_test.go
@@ -120,7 +120,7 @@ func testAlertmanager(ctx context.Context, t *OperatorContext, spec *monitoringv
 
 func testAlertmanagerDeployed(ctx context.Context, t *OperatorContext, config *monitoringv1.ManagedAlertmanagerSpec) {
 	var err error
-	pollErr := wait.PollUntilContextTimeout(ctx, time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var ss appsv1.StatefulSet
 		if err = t.Client().Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: operator.NameAlertmanager}, &ss); err != nil {
 			if apierrors.IsNotFound(err) {

--- a/e2e/authorization_test.go
+++ b/e2e/authorization_test.go
@@ -87,9 +87,9 @@ func setupAuthTestMissingAuth(ctx context.Context, t *OperatorContext, appName s
 			t.Fatalf("create collector PodMonitoring: %s", err)
 		}
 
-		if err := operatorutil.WaitForPodMonitoringReady(ctx, t.Client(), pm, true); err != nil {
+		if err := operatorutil.WaitForPodMonitoringReady(ctx, t.Client(), t.namespace, pm, true); err != nil {
 			kubeutil.DaemonSetDebug(t.T, ctx, t.RestConfig(), t.Client(), t.namespace, operator.NameCollector)
-			t.Fatalf("collector not ready: %s", err)
+			t.Fatalf("PodMonitoring not ready: %s", err)
 		}
 
 		if err := operatorutil.WaitForPodMonitoringFailure(ctx, t.Client(), pm, expectedFn); err != nil {
@@ -116,7 +116,7 @@ func setupAuthTestMissingAuth(ctx context.Context, t *OperatorContext, appName s
 			t.Fatalf("create collector PodMonitoring: %s", err)
 		}
 
-		if err := operatorutil.WaitForPodMonitoringReady(ctx, t.Client(), pm, true); err != nil {
+		if err := operatorutil.WaitForPodMonitoringReady(ctx, t.Client(), t.namespace, pm, true); err != nil {
 			kubeutil.DaemonSetDebug(t.T, ctx, t.RestConfig(), t.Client(), t.namespace, operator.NameCollector)
 			t.Fatalf("collector not ready: %s", err)
 		}
@@ -155,7 +155,7 @@ func setupAuthTest(ctx context.Context, t *OperatorContext, appName string, args
 			t.Fatalf("create collector: %s", err)
 		}
 
-		if err := operatorutil.WaitForPodMonitoringReady(ctx, t.Client(), pm, true); err != nil {
+		if err := operatorutil.WaitForPodMonitoringReady(ctx, t.Client(), t.namespace, pm, true); err != nil {
 			kubeutil.DaemonSetDebug(t.T, ctx, t.RestConfig(), t.Client(), t.namespace, operator.NameCollector)
 			t.Errorf("collector not ready: %s", err)
 		}
@@ -184,7 +184,7 @@ func setupAuthTest(ctx context.Context, t *OperatorContext, appName string, args
 			t.Fatalf("create collector: %s", err)
 		}
 
-		if err := operatorutil.WaitForPodMonitoringReady(ctx, t.Client(), pm, true); err != nil {
+		if err := operatorutil.WaitForPodMonitoringReady(ctx, t.Client(), t.namespace, pm, true); err != nil {
 			kubeutil.DaemonSetDebug(t.T, ctx, t.RestConfig(), t.Client(), t.namespace, operator.NameCollector)
 			t.Errorf("collector not ready: %s", err)
 		}

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -180,7 +180,6 @@ func testCollectorDeployed(ctx context.Context, t *OperatorContext) {
 			if apierrors.IsNotFound(err) {
 				return false, nil
 			}
-			t.Log(fmt.Errorf("getting collector DaemonSet failed: %w", err))
 			return false, fmt.Errorf("getting collector DaemonSet failed: %w", err)
 		}
 		// At first creation the DaemonSet may appear with 0 desired replicas. This should

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -269,7 +269,7 @@ func testCollector(ctx context.Context, t *OperatorContext, pm monitoringv1.PodM
 	}
 	t.Logf("Waiting for %q to be processed", pm.GetName())
 
-	if err := operatorutil.WaitForPodMonitoringReady(ctx, t.Client(), pm, true); err != nil {
+	if err := operatorutil.WaitForPodMonitoringReady(ctx, t.Client(), t.namespace, pm, true); err != nil {
 		t.Errorf("unable to validate status: %s", err)
 	}
 

--- a/e2e/kubeutil/container.go
+++ b/e2e/kubeutil/container.go
@@ -105,7 +105,8 @@ func containerDebug(t testing.TB, ctx context.Context, restConfig *rest.Config, 
 
 	// Worse case, let's just show the first one.
 	t.Log("found no crash-looping pods -- showing logs of first pod")
-	for _, pod := range pods {
+	if len(pods) > 0 {
+		pod := pods[0]
 		for _, status := range pod.Status.ContainerStatuses {
 			showPodLogs(&pod, status.Name)
 		}

--- a/e2e/kubeutil/deployment.go
+++ b/e2e/kubeutil/deployment.go
@@ -34,24 +34,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// IsDeploymentReady returns nil if the Deployment obtained from the given namespace and name
-// has all expected replicas ready, otherwise returns an error why the Deployment is not ready.
-func IsDeploymentReady(ctx context.Context, kubeClient client.Client, namespace, name string) error {
-	wrapErrFunc := func(err error) error {
-		return fmt.Errorf("deployment %s/%s not ready: %w", namespace, name, err)
-	}
-	var deployment appsv1.Deployment
-	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &deployment); err != nil {
-		return wrapErrFunc(fmt.Errorf("not found: %w", err))
-	}
-
+func isDeploymentReady(deployment *appsv1.Deployment) error {
 	// Set to default replicas value.
 	expected := int32(1)
 	if deployment.Spec.Replicas != nil {
 		expected = *deployment.Spec.Replicas
 	}
 	if deployment.Status.ReadyReplicas != expected {
-		return wrapErrFunc(errors.New("replicas unavailable"))
+		return errors.New("replicas unavailable")
 	}
 	return nil
 }
@@ -59,13 +49,19 @@ func IsDeploymentReady(ctx context.Context, kubeClient client.Client, namespace,
 func WaitForDeploymentReady(ctx context.Context, kubeClient client.Client, namespace, name string) error {
 	var err error
 	if waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
-		err := IsDeploymentReady(ctx, kubeClient, namespace, name)
-		return err == nil, nil
-	}); waitErr != nil {
-		if errors.Is(waitErr, context.DeadlineExceeded) {
-			return err
+		var deployment appsv1.Deployment
+		if err = kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &deployment); err != nil {
+			return false, nil
 		}
-		return waitErr
+		if err = isDeploymentReady(&deployment); err != nil {
+			return false, nil
+		}
+		return true, nil
+	}); waitErr != nil {
+		if errors.Is(waitErr, context.DeadlineExceeded) && err != nil {
+			waitErr = err
+		}
+		return fmt.Errorf("deployment %s/%s not ready: %w", namespace, name, waitErr)
 	}
 	return nil
 }

--- a/e2e/kubeutil/pod.go
+++ b/e2e/kubeutil/pod.go
@@ -56,7 +56,7 @@ func WaitForPodContainerReady(ctx context.Context, t testing.TB, restConfig *res
 		return nil
 	}
 	t.Logf("waiting for pod to be ready: %s", err)
-	if waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	if waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		if err = kubeClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 			return false, err
 		}

--- a/e2e/kubeutil/pod.go
+++ b/e2e/kubeutil/pod.go
@@ -56,7 +56,7 @@ func WaitForPodContainerReady(ctx context.Context, t testing.TB, restConfig *res
 		return nil
 	}
 	t.Logf("waiting for pod to be ready: %s", err)
-	if waitErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	if waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		if err = kubeClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 			return false, err
 		}
@@ -89,7 +89,7 @@ func WaitForPodReady(ctx context.Context, t *testing.T, restConfig *rest.Config,
 		return nil
 	}
 	t.Logf("waiting for pod to be ready: %s", err)
-	if waitErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	if waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		if err = kubeClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 			return false, err
 		}

--- a/e2e/kubeutil/pod.go
+++ b/e2e/kubeutil/pod.go
@@ -55,19 +55,20 @@ func WaitForPodContainerReady(ctx context.Context, t testing.TB, restConfig *res
 	if err = IsPodContainerReady(ctx, restConfig, pod, container); err == nil {
 		return nil
 	}
-	t.Logf("waiting for pod to be ready: %s", err)
+	t.Logf("waiting for pod container to be ready: %s", err)
 	if waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		if err = kubeClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
-			return false, err
+			return false, nil
 		}
 		err = IsPodContainerReady(ctx, restConfig, pod, container)
 		return err == nil, nil
 	}); waitErr != nil {
-		if errors.Is(waitErr, context.DeadlineExceeded) {
+		if errors.Is(waitErr, context.DeadlineExceeded) && err != nil {
 			return err
 		}
 		return waitErr
 	}
+	t.Log("pod container ready")
 	return nil
 }
 
@@ -91,16 +92,17 @@ func WaitForPodReady(ctx context.Context, t *testing.T, restConfig *rest.Config,
 	t.Logf("waiting for pod to be ready: %s", err)
 	if waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		if err = kubeClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
-			return false, err
+			return false, nil
 		}
 		err = IsPodReady(ctx, restConfig, pod)
 		return err == nil, nil
 	}); waitErr != nil {
-		if errors.Is(waitErr, context.DeadlineExceeded) {
+		if errors.Is(waitErr, context.DeadlineExceeded) && err != nil {
 			return err
 		}
 		return waitErr
 	}
+	t.Log("pod ready")
 	return nil
 }
 

--- a/e2e/operatorutil/collection.go
+++ b/e2e/operatorutil/collection.go
@@ -1,0 +1,27 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operatorutil
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/prometheus-engine/e2e/kubeutil"
+	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func WaitForCollectionReady(ctx context.Context, kubeClient client.Client, operatorNamespace string) error {
+	return kubeutil.WaitForDaemonSetReady(ctx, kubeClient, operatorNamespace, operator.NameCollector)
+}

--- a/e2e/operatorutil/podmonitoringutil.go
+++ b/e2e/operatorutil/podmonitoringutil.go
@@ -54,15 +54,16 @@ func isPodMonitoringEndpointStatusReady(pm monitoringv1.PodMonitoringCRD) error 
 }
 
 func WaitForPodMonitoringReady(ctx context.Context, kubeClient client.Client, pm monitoringv1.PodMonitoringCRD, targetStatusEnabled bool) error {
-	timeout := 1 * time.Minute
+	timeout := 2 * time.Minute
+	interval := 3 * time.Second
 	if targetStatusEnabled {
 		// Wait for target status to get polled.
-		timeout = 2 * time.Minute
+		timeout = 3 * time.Minute
 	}
 
 	var err error
 	var resVer string
-	pollErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		if err = kubeClient.Get(ctx, client.ObjectKeyFromObject(pm), pm); err != nil {
 			return false, fmt.Errorf("getting PodMonitoring failed: %w", err)
 		}

--- a/e2e/operatorutil/podmonitoringutil.go
+++ b/e2e/operatorutil/podmonitoringutil.go
@@ -68,7 +68,7 @@ func WaitForPodMonitoringReady(ctx context.Context, kubeClient client.Client, op
 	var err error
 	pollErr := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		if err = kubeClient.Get(ctx, client.ObjectKeyFromObject(pm), pm); err != nil {
-			return false, fmt.Errorf("getting PodMonitoring failed: %w", err)
+			return false, nil
 		}
 
 		if err = IsPodMonitoringReady(pm, targetStatusEnabled); err != nil {

--- a/e2e/ruler_test.go
+++ b/e2e/ruler_test.go
@@ -156,7 +156,7 @@ func testRuleEvaluatorSecrets(ctx context.Context, t *OperatorContext, cert, key
 		fmt.Sprintf("secret_%s_alertmanager-authorization_token", t.pubNamespace): []byte("auth-bearer-password"),
 	}
 	var err error
-	pollErr := wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var secret corev1.Secret
 		if err = t.Client().Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: operator.RulesSecretName}, &secret); err != nil {
 			if apierrors.IsNotFound(err) {
@@ -241,7 +241,7 @@ rule_files:
 `),
 	}
 	var err error
-	pollErr := wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var cm corev1.ConfigMap
 		if err = t.Client().Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: operator.NameRuleEvaluator}, &cm); err != nil {
 			if apierrors.IsNotFound(err) {
@@ -265,7 +265,7 @@ rule_files:
 
 func testRuleEvaluatorDeployment(ctx context.Context, t *OperatorContext) {
 	var err error
-	pollErr := wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var deploy appsv1.Deployment
 		if err = t.Client().Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: operator.NameRuleEvaluator}, &deploy); err != nil {
 			if apierrors.IsNotFound(err) {
@@ -467,7 +467,7 @@ func testRulesGeneration(ctx context.Context, t *OperatorContext) {
 
 	var diff string
 
-	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 3*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 		var cm corev1.ConfigMap
 		if err := t.Client().Get(ctx, client.ObjectKey{Namespace: t.namespace, Name: "rules-generated"}, &cm); err != nil {
 			if apierrors.IsNotFound(err) {
@@ -512,7 +512,7 @@ func testValidateRuleEvaluationMetrics(ctx context.Context, t *OperatorContext) 
 	}
 	defer metricClient.Close()
 
-	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 		now := time.Now()
 
 		// Validate the majority of labels being set correctly by filtering along them.

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -65,7 +65,7 @@ func TestWebhookCABundleInjection(t *testing.T) {
 		}
 
 		// Wait for caBundle injection.
-		err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 			if err := tctx.Client().Get(ctx, client.ObjectKeyFromObject(vwc), vwc); err != nil {
 				return false, fmt.Errorf("get validatingwebhook configuration: %w", err)
 			}
@@ -112,7 +112,7 @@ func TestWebhookCABundleInjection(t *testing.T) {
 		}
 
 		// Wait for caBundle injection.
-		err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 			if err := tctx.Client().Get(ctx, client.ObjectKeyFromObject(mwc), mwc); err != nil {
 				return false, fmt.Errorf("get mutatingwebhook configuration: %w", err)
 			}

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -15,6 +15,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -65,22 +66,27 @@ func TestWebhookCABundleInjection(t *testing.T) {
 		}
 
 		// Wait for caBundle injection.
-		err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
-			if err := tctx.Client().Get(ctx, client.ObjectKeyFromObject(vwc), vwc); err != nil {
-				return false, fmt.Errorf("get validatingwebhook configuration: %w", err)
+		var err error
+		waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+			if err = tctx.Client().Get(ctx, client.ObjectKeyFromObject(vwc), vwc); err != nil {
+				return false, nil
 			}
 			if len(vwc.Webhooks) != 2 {
 				return false, fmt.Errorf("expected 2 webhooks but got %d", len(vwc.Webhooks))
 			}
-			for _, wh := range vwc.Webhooks {
+			for i, wh := range vwc.Webhooks {
 				if len(wh.ClientConfig.CABundle) == 0 {
+					err = fmt.Errorf("webhook %d has no CA bundle", i)
 					return false, nil
 				}
 			}
 			return true, nil
 		})
-		if err != nil {
-			t.Fatalf("waiting for ValidatingWebhook CA bundle failed: %s", err)
+		if waitErr != nil {
+			if errors.Is(waitErr, context.DeadlineExceeded) && err != nil {
+				waitErr = err
+			}
+			t.Fatalf("waiting for ValidatingWebhook CA bundle failed: %s", waitErr)
 		}
 	}))
 
@@ -112,22 +118,27 @@ func TestWebhookCABundleInjection(t *testing.T) {
 		}
 
 		// Wait for caBundle injection.
-		err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
-			if err := tctx.Client().Get(ctx, client.ObjectKeyFromObject(mwc), mwc); err != nil {
-				return false, fmt.Errorf("get mutatingwebhook configuration: %w", err)
+		var err error
+		waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+			if err = tctx.Client().Get(ctx, client.ObjectKeyFromObject(mwc), mwc); err != nil {
+				return false, nil
 			}
 			if len(mwc.Webhooks) != 2 {
 				return false, fmt.Errorf("expected 2 webhooks but got %d", len(mwc.Webhooks))
 			}
-			for _, wh := range mwc.Webhooks {
+			for i, wh := range mwc.Webhooks {
 				if len(wh.ClientConfig.CABundle) == 0 {
+					err = fmt.Errorf("webhook %d has no CA bundle", i)
 					return false, nil
 				}
 			}
 			return true, nil
 		})
-		if err != nil {
-			t.Fatalf("waiting for MutatingWebhook CA bundle failed: %s", err)
+		if waitErr != nil {
+			if errors.Is(waitErr, context.DeadlineExceeded) && err != nil {
+				waitErr = err
+			}
+			t.Fatalf("waiting for MutatingWebhook CA bundle failed: %s", waitErr)
 		}
 	}))
 }

--- a/hack/kind-test.sh
+++ b/hack/kind-test.sh
@@ -40,4 +40,5 @@ kubectl --context kind-kind apply -f "${REPO_ROOT}/manifests/rule-evaluator.yaml
 
 echo ">>> executing gmp e2e tests"
 # We don't cleanup resources because this script recreates the cluster.
-go test -v "${REPO_ROOT}/e2e" -run "${TEST_RUN:-.}" -args -project-id=test-proj -cluster=test-cluster -location=test-loc -skip-gcm=true -cleanup-resources=false ${TEST_ARGS}
+# shellcheck disable=SC2086
+go test -v ${GO_ARGS} "${REPO_ROOT}/e2e" -run "${TEST_RUN:-.}" -args -project-id=test-proj -cluster=test-cluster -location=test-loc -skip-gcm=true -cleanup-resources=false ${TEST_ARGS}


### PR DESCRIPTION
- Increases timeouts for a few tests.
- Ensures we don't poll too regularly and accidentally overload the Kubernetes API server.
- Ensures that we can recover when we get an error due to the Kubernetes API server being overloaded (e.g. try to fetch an object and get a timeout).
- Waits until collectors are up before validating the PodMonitoring status.
- Increases e2e timeout on GitHub Actions.

Why: I am adding more tests and without this change, the tests are very flaky.