### PR TITLE
Add syncing timeouts and instructions for Workload identity

### DIFF
--- a/cmd/datasource-syncer/README.md
+++ b/cmd/datasource-syncer/README.md
@@ -30,7 +30,7 @@ GRAFANA_API_TOKEN=YOUR_GRAFANA_SERVICE_ACCOUNT_TOKEN
 GRAFANA_API_ENDPOINT=YOUR_GRAFANA_INSTANCE_URL
 PROJECT_ID=PROJECT_ID_TO_QUERY_GCM
  # Optional Credentials file. Can be left empty if default credentials have sufficient permission.
-CREDENTIALS=OPTIONAL_GOOGLE_CLOUD_SERVICE_ACCOUNT_WITH_GOOGLE_CLOUD_MONITORING_READ_ACCESS
+GOOGLE_APPLICATION_CREDENTIALS=OPTIONAL_GOOGLE_CLOUD_SERVICE_ACCOUNT_WITH_GOOGLE_CLOUD_MONITORING_READ_ACCESS
 ```
 
 Running the following Cron job will refresh the data source on initialization and every 30 minutes:
@@ -44,10 +44,15 @@ cat datasource-syncer.yaml \
 
 To query across multiple projects, you must [create a metrics scope](https://cloud.google.com/stackdriver/docs/managed-prometheus/query#scoping-intro) and authorize the local project's default compute service account to have monitoring.read access to the scoping project. If your local project is your scoping project, then this permission is granted by default and cross-project querying should work with no further configuration.
 
+### Workload Identity Setup
+If you're using WLI you need to grant the service account these two permissions:  `Monitoring Viewer` and `Service
+Account Token Creator`.
+
+
 ### Development
 ```bash
 go run main.go \
-  --credentials-file=$CREDENTIALS \
+  --query.credentials-file=$GOOGLE_APPLICATION_CREDENTIALS \
   --datasource-uids=$DATASOURCE_UIDS \
   --grafana-api-token=$GRAFANA_API_TOKEN \
   --grafana-api-endpoint=$GRAFANA_API_ENDPOINT \

--- a/cmd/datasource-syncer/main.go
+++ b/cmd/datasource-syncer/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	credentialsFile = flag.String("credentials-file", "",
+	credentialsFile = flag.String("query.credentials-file", "",
 		"JSON-encoded credentials (service account or refresh token). Can be left empty if default credentials have sufficient permission.")
 
 	datasourceUIDList = flag.String("datasource-uids", "", "datasource-uids is a comma separated list of data source UIDs to update.")
@@ -165,8 +165,17 @@ func buildUpdateDataSourceRequest(dataSource grafana.DataSource, token string) (
 	} else {
 		dataSource.URL = fmt.Sprintf("https://monitoring.googleapis.com/v1/projects/%s/location/global/prometheus/", *projectID)
 	}
+
+	// Miscellaneous updates to make Grafana more compatible with GMP.
 	jsonData := dataSource.JSONData
-	// Miscellaneous changes to make Grafana more compatible with GMP.
+	if jsonData["queryTimeout"] == nil {
+		jsonData["queryTimeout"] = "2m"
+	}
+
+	if jsonData["timeout"] == nil {
+		jsonData["timeout"] = "120"
+	}
+
 	jsonData["httpMethod"] = http.MethodGet
 	if jsonData["prometheusType"] == nil {
 		jsonData["prometheusType"] = "Prometheus"

--- a/cmd/datasource-syncer/main_test.go
+++ b/cmd/datasource-syncer/main_test.go
@@ -32,6 +32,8 @@ func TestBuildUpdateDataSourceRequest(t *testing.T) {
 					"httpMethod":        "GET",
 					"prometheusType":    "Prometheus",
 					"prometheusVersion": "2.40.0",
+					"queryTimeout":      "2m",
+					"timeout":           "120",
 				},
 				SecureJSONData: map[string]interface{}{
 					"httpHeaderValue1": "Bearer 12345",
@@ -58,6 +60,8 @@ func TestBuildUpdateDataSourceRequest(t *testing.T) {
 					"httpMethod":        "GET",
 					"prometheusType":    "Prometheus",
 					"prometheusVersion": "2.40.0",
+					"queryTimeout":      "2m",
+					"timeout":           "120",
 				},
 				SecureJSONData: map[string]interface{}{
 					"httpHeaderValue3": "Bearer 12345",
@@ -88,6 +92,8 @@ func TestBuildUpdateDataSourceRequest(t *testing.T) {
 					"httpMethod":        "GET",
 					"prometheusType":    "Prometheus",
 					"prometheusVersion": "2.40.0",
+					"queryTimeout":      "2m",
+					"timeout":           "120",
 				},
 				SecureJSONData: map[string]interface{}{
 					"httpHeaderValue2": "Bearer 12345",
@@ -95,7 +101,7 @@ func TestBuildUpdateDataSourceRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "prometheus server url override",
+			name: "prometheus server url override is reset and prometheus version upgraded to latest supported version",
 			input: grafana.DataSource{
 				Type: "prometheus",
 				URL:  "http://localhost:9090",
@@ -118,6 +124,8 @@ func TestBuildUpdateDataSourceRequest(t *testing.T) {
 					"httpMethod":        "GET",
 					"prometheusType":    "Prometheus",
 					"prometheusVersion": "2.40.0",
+					"queryTimeout":      "2m",
+					"timeout":           "120",
 				},
 				SecureJSONData: map[string]interface{}{
 					"httpHeaderValue3": "Bearer 12345",
@@ -125,13 +133,15 @@ func TestBuildUpdateDataSourceRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "prometheus version 2.40+ is supported",
+			name: "prometheus version 2.40+ and editing data source fields is supported",
 			input: grafana.DataSource{
 				Type: "prometheus",
 				URL:  "http://localhost:9090",
 				JSONData: map[string]interface{}{
 					"prometheusType":    "Prometheus",
 					"prometheusVersion": "2.42.0",
+					"queryTimeout":      "3m",
+					"timeout":           "160",
 				},
 			},
 			want: grafana.DataSource{
@@ -142,6 +152,8 @@ func TestBuildUpdateDataSourceRequest(t *testing.T) {
 					"httpMethod":        "GET",
 					"prometheusType":    "Prometheus",
 					"prometheusVersion": "2.42.0",
+					"queryTimeout":      "3m",
+					"timeout":           "160",
 				},
 				SecureJSONData: map[string]interface{}{
 					"httpHeaderValue1": "Bearer 12345",


### PR DESCRIPTION
These changes ensure:
The **Timeout** field of the **HTTP** pane, set the value to 120.
The **Query timeout** field, set the value to 2m.

Also adding instructions for Workload identity.