### PR TITLE
feat: [kubelet/cAdvisor metrics package] add frontend for NodeMonitoring

### DIFF
--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_nodemonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_nodemonitorings.yaml
@@ -137,8 +137,6 @@ spec:
                     timeout:
                       type: string
                       description: Timeout for metrics scrapes. Must be a valid Prometheus duration. Must not be larger then the scrape interval.
-                  required:
-                  - port
               limits:
                 type: object
                 description: Limits to apply at scrape time.

--- a/cmd/operator/deploy/operator/03-role.yaml
+++ b/cmd/operator/deploy/operator/03-role.yaml
@@ -128,6 +128,7 @@ rules:
   - clusterpodmonitorings
   - clusterrules
   - globalrules
+  - nodemonitorings
   - podmonitorings
   - rules
   apiGroups: ["monitoring.googleapis.com"]

--- a/cmd/operator/deploy/operator/08-validatingwebhookconfiguration.yaml
+++ b/cmd/operator/deploy/operator/08-validatingwebhookconfiguration.yaml
@@ -61,6 +61,28 @@ webhooks:
     - CREATE
     - UPDATE
   sideEffects: None
+- name: validate.nodemonitorings.gmp-operator.gmp-system.monitoring.googleapis.com
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    # caBundle populated by operator.
+    service:
+      name: gmp-operator
+      namespace: gmp-system
+      port: 443
+      path: /validate/monitoring.googleapis.com/v1/nodemonitorings
+  failurePolicy: Fail
+  rules:
+  - resources:
+    - nodemonitorings
+    apiGroups:
+    - monitoring.googleapis.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+  sideEffects: None
 - name: validate.rules.gmp-operator.gmp-system.monitoring.googleapis.com
   admissionReviewVersions:
   - v1

--- a/doc/api.md
+++ b/doc/api.md
@@ -694,7 +694,7 @@ ScrapeNodeEndpoint specifies a Prometheus metrics endpoint on a node to scrape. 
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| port | Number of the port to scrape. | int | true |
+| port | Number of the port to scrape. | int | false |
 | scheme | Protocol scheme to use to scrape. | string | false |
 | path | HTTP path to scrape metrics from. Defaults to \"/metrics\". | string | false |
 | params | HTTP GET params to use when scraping. | map[string][]string | false |

--- a/examples/cadvisor-metrics.yaml
+++ b/examples/cadvisor-metrics.yaml
@@ -15,7 +15,7 @@
 apiVersion: monitoring.googleapis.com/v1
 kind: NodeMonitoring
 metadata:
-  name: kubelet-cadvisor
+  name: gmp-kubelet-cadvisor
 spec:
   endpoints:
   - path: /metrics/cadvisor

--- a/examples/cadvisor-metrics.yaml
+++ b/examples/cadvisor-metrics.yaml
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: NodeMonitoring
+metadata:
+  name: kubelet-cadvisor
+spec:
+  endpoints:
+  - path: /metrics/cadvisor
+    interval: 30s
+    scheme: https
+    metricRelabeling:
+    - sourceLabels: [__name__]
+      regex: >
+        container_(cpu_cfs_periods_total|cpu_cfs_throttled_periods_total|cpu_usage_seconds_total|memory_rss|memory_working_set_bytes)|
+        container_fs_(limit_bytes|read_seconds_total|reads_bytes_total|reads_total|usage_bytes|write_seconds_total|writes_bytes_total|writes_total)|
+        container_network_(receive_bytes|receive_packets_dropped|receive_packets|transmit_bytes|transmit_packets_dropped|transmit_packets)_total
+      action: keep

--- a/examples/kubelet-metrics.yaml
+++ b/examples/kubelet-metrics.yaml
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: NodeMonitoring
+metadata:
+  name: kubelet-metrics
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 30s
+    scheme: https
+    metricRelabeling:
+    - sourceLabels: [__name__]
+      regex: > 
+            kubelet_(node_name|certificate_manager_server_ttl_seconds|pleg_relist_duration_seconds|pod_worker_duration_seconds|running_containers|running_pods|runtime_operations_total)|
+            kubelet_volume_(stats_available_bytes|stats_capacity_bytes|stats_inodes_free|stats_inodes_used|stats_inodes|stats_used_bytes)
+      action: keep

--- a/examples/kubelet-metrics.yaml
+++ b/examples/kubelet-metrics.yaml
@@ -15,7 +15,7 @@
 apiVersion: monitoring.googleapis.com/v1
 kind: NodeMonitoring
 metadata:
-  name: kubelet-metrics
+  name: gmp-kubelet-metrics
 spec:
   endpoints:
   - path: /metrics

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -154,6 +154,7 @@ rules:
   - clusterpodmonitorings
   - clusterrules
   - globalrules
+  - nodemonitorings
   - podmonitorings
   - rules
   apiGroups: ["monitoring.googleapis.com"]
@@ -381,6 +382,28 @@ webhooks:
   rules:
   - resources:
     - clusterpodmonitorings
+    apiGroups:
+    - monitoring.googleapis.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+  sideEffects: None
+- name: validate.nodemonitorings.gmp-operator.gmp-system.monitoring.googleapis.com
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    # caBundle populated by operator.
+    service:
+      name: gmp-operator
+      namespace: gmp-system
+      port: 443
+      path: /validate/monitoring.googleapis.com/v1/nodemonitorings
+  failurePolicy: Fail
+  rules:
+  - resources:
+    - nodemonitorings
     apiGroups:
     - monitoring.googleapis.com
     apiVersions:

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -999,8 +999,6 @@ spec:
                     timeout:
                       type: string
                       description: Timeout for metrics scrapes. Must be a valid Prometheus duration. Must not be larger then the scrape interval.
-                  required:
-                  - port
               limits:
                 type: object
                 description: Limits to apply at scrape time.

--- a/pkg/operator/apis/monitoring/v1/register.go
+++ b/pkg/operator/apis/monitoring/v1/register.go
@@ -65,6 +65,16 @@ func ClusterPodMonitoringResource() metav1.GroupVersionResource {
 	}
 }
 
+// NodeMonitoringResource returns a NodeMonitoring GroupVersionResource.
+// This can be used to enforce API types.
+func NodeMonitoringResource() metav1.GroupVersionResource {
+	return metav1.GroupVersionResource{
+		Group:    monitoring.GroupName,
+		Version:  Version,
+		Resource: "nodemonitorings",
+	}
+}
+
 // OperatorConfigResource returns a OperatorConfig GroupVersionResource.
 // This can be used to enforce API types.
 func OperatorConfigResource() metav1.GroupVersionResource {
@@ -112,6 +122,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&PodMonitoringList{},
 		&ClusterPodMonitoring{},
 		&ClusterPodMonitoringList{},
+		&NodeMonitoring{},
+		&NodeMonitoringList{},
 		&Rules{},
 		&RulesList{},
 		&ClusterRules{},

--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -1328,7 +1328,7 @@ type RulesStatus struct {
 // It contains all the fields used in ScrapeEndpoint except for port string and HTTPClientConfig.
 type ScrapeNodeEndpoint struct {
 	// Number of the port to scrape.
-	Port int `json:"port"`
+	Port int `json:"port,omitempty"`
 	// Protocol scheme to use to scrape.
 	Scheme string `json:"scheme,omitempty"`
 	// HTTP path to scrape metrics from. Defaults to "/metrics".

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -96,6 +96,12 @@ func setupCollectionControllers(op *Operator) error {
 			enqueueConst(objRequest),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
+		// Any update to a NodeMonitoring requires regenerating the config.
+		Watches(
+			&monitoringv1.NodeMonitoring{},
+			enqueueConst(objRequest),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
 		// The configuration we generate for the collectors.
 		Watches(
 			&corev1.ConfigMap{},
@@ -380,6 +386,7 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 	var (
 		podMons        monitoringv1.PodMonitoringList
 		clusterPodMons monitoringv1.ClusterPodMonitoringList
+		NodeMons       monitoringv1.NodeMonitoringList
 		cond           *monitoringv1.MonitoringCondition
 	)
 	if err := r.client.List(ctx, &podMons); err != nil {
@@ -460,6 +467,41 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		if change {
 			r.statusUpdates = append(r.statusUpdates, &cmon)
 		}
+	}
+
+	if err := r.client.List(ctx, &NodeMons); err != nil {
+		return nil, fmt.Errorf("failed to list NodeMonitorings: %w", err)
+	}
+	// The following job names are reserved by GMP for NodeMonitoring. They will not be generated if kubeletScraping is enabled.
+	var (
+		reservedCAdvisorJobName = "gmp-cadvisor-metrics"
+		reservedKubeletJobName  = "gmp-kubelet-metrics"
+	)
+	// Mark status updates in batch with single timestamp.
+	for _, nm := range NodeMons.Items {
+		if spec.KubeletScraping != nil && (nm.Name == reservedKubeletJobName || nm.Name == reservedCAdvisorJobName) {
+			logger.Info("NodeMonitoring job %s not applied because KubeletScraping is enabled.", nm.Name)
+			continue
+		}
+		// Reassign so we can safely get a pointer.
+		nm := nm
+		cond = &monitoringv1.MonitoringCondition{
+			Type:   monitoringv1.ConfigurationCreateSuccess,
+			Status: corev1.ConditionTrue,
+		}
+		cfgs, err := nm.ScrapeConfigs(projectID, location, cluster)
+		if err != nil {
+			msg := "generating scrape config failed for NodeMonitoring endpoint"
+			cond = &monitoringv1.MonitoringCondition{
+				Type:    monitoringv1.ConfigurationCreateSuccess,
+				Status:  corev1.ConditionFalse,
+				Reason:  "ScrapeConfigError",
+				Message: msg,
+			}
+			logger.Error(err, msg, "namespace", nm.Namespace, "name", nm.Name)
+			continue
+		}
+		cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
 	}
 
 	// Sort to ensure reproducible configs.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -228,6 +228,9 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 					&monitoringv1.ClusterPodMonitoring{}: {
 						Field: fields.Everything(),
 					},
+					&monitoringv1.NodeMonitoring{}: {
+						Field: fields.Everything(),
+					},
 					&monitoringv1.GlobalRules{}: {
 						Field: fields.Everything(),
 					},
@@ -313,6 +316,10 @@ func (o *Operator) setupAdmissionWebhooks(ctx context.Context) error {
 	s.Register(
 		validatePath(monitoringv1.ClusterPodMonitoringResource()),
 		admission.ValidatingWebhookFor(o.manager.GetScheme(), &monitoringv1.ClusterPodMonitoring{}),
+	)
+	s.Register(
+		validatePath(monitoringv1.NodeMonitoringResource()),
+		admission.ValidatingWebhookFor(o.manager.GetScheme(), &monitoringv1.NodeMonitoring{}),
 	)
 	s.Register(
 		validatePath(monitoringv1.OperatorConfigResource()),


### PR DESCRIPTION
Add the frontend part of NodeMonitoring and make port optional.

Tested via running the following commands:
1. `DOCKER_PUSH=1 make operator` 
2. `kubectl apply -f manifests/setup.yaml`
3. `kubectl apply -f manifests/operator.yaml`
4. `kubectl apply -f examples/cadvisor-metrics.yaml` and `kubectl apply -f examples/kubelet-metrics.yaml` 

You can see the node metrics being scraped after that. Additionally I toggled KubeletScraping on/off to watch the scraping turn off/on.