### PR TITLE
Remove NodeMonitoring port

### DIFF
--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_nodemonitorings.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_nodemonitorings.yaml
@@ -82,9 +82,6 @@ spec:
                   type: object
                   description: ScrapeNodeEndpoint specifies a Prometheus metrics endpoint on a node to scrape. It contains all the fields used in ScrapeEndpoint except for port string and HTTPClientConfig.
                   properties:
-                    port:
-                      type: integer
-                      description: Number of the port to scrape.
                     interval:
                       type: string
                       default: 1m

--- a/doc/api.md
+++ b/doc/api.md
@@ -694,7 +694,6 @@ ScrapeNodeEndpoint specifies a Prometheus metrics endpoint on a node to scrape. 
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| port | Number of the port to scrape. | int | false |
 | scheme | Protocol scheme to use to scrape. | string | false |
 | path | HTTP path to scrape metrics from. Defaults to \"/metrics\". | string | false |
 | params | HTTP GET params to use when scraping. | map[string][]string | false |

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -944,9 +944,6 @@ spec:
                   type: object
                   description: ScrapeNodeEndpoint specifies a Prometheus metrics endpoint on a node to scrape. It contains all the fields used in ScrapeEndpoint except for port string and HTTPClientConfig.
                   properties:
-                    port:
-                      type: integer
-                      description: Number of the port to scrape.
                     interval:
                       type: string
                       default: 1m

--- a/pkg/operator/apis/monitoring/v1/types_test.go
+++ b/pkg/operator/apis/monitoring/v1/types_test.go
@@ -529,16 +529,6 @@ func TestValidateNodeMonitoring(t *testing.T) {
 			fail:        true,
 			errContains: "scrape timeout 2s must not be greater than scrape interval 1s",
 		},
-		{
-			desc: "port not supported",
-			eps: []ScrapeNodeEndpoint{
-				{
-					Port: 12,
-				},
-			},
-			fail:        true,
-			errContains: "port not supported",
-		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Remove NodeMonitoring port.
It seems Kubelet just has [one port](https://pkg.go.dev/k8s.io/api/core/v1#NodeDaemonEndpoints) that is used by [Prometheus as the default](https://github.com/GoogleCloudPlatform/prometheus/blob/release-2.41.0-gmp/discovery/kubernetes/node.go#L196).

I suggest we remove port support to simplify our code until we have a good reason to add it.

@bwplotka @pintohutch do you see any reason to keep NodeMonitoring port? 