### PR TITLE
[E2E refactor - 1] slim down cmd Dockerfiles

### DIFF
--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -1,6 +1,10 @@
 FROM golang:1.21-bullseye AS buildbase
 WORKDIR /app
-COPY . ./
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
 
 FROM buildbase as appbase
 RUN CGO_ENABLED=0 go build -mod=vendor -o config-reloader cmd/config-reloader/*.go

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -1,6 +1,10 @@
 FROM golang:1.21-bullseye AS buildbase
 WORKDIR /app
-COPY . ./
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
 
 FROM buildbase as appbase
 RUN CGO_ENABLED=0 go build -mod=vendor -o operator cmd/operator/*.go

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -1,6 +1,10 @@
 FROM golang:1.21-bullseye AS buildbase
 WORKDIR /app
-COPY . ./
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
 
 FROM buildbase as appbase
 RUN CGO_ENABLED=0 go build -mod=vendor -o rule-evaluator cmd/rule-evaluator/*.go


### PR DESCRIPTION
I decided to break out the kind E2E test refactor PR #738 into smaller, digestible PRs for reviewing.

Note: because of the nature of the change, presubmits (i.e. Github Actions) may fail until the final PR is merged.

This is the first one, where we slim down the buildbase for our cmd images to only copy code that's necessary to build and run the binary.