### PR TITLE
[E2E refactor - 1] slim down Dockerfiles

### DIFF
--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -1,6 +1,10 @@
 FROM golang:1.21-bullseye AS buildbase
 WORKDIR /app
-COPY . ./
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
 
 FROM buildbase as appbase
 RUN CGO_ENABLED=0 go build -mod=vendor -o config-reloader cmd/config-reloader/*.go

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -1,6 +1,10 @@
 FROM golang:1.21-bullseye AS buildbase
 WORKDIR /app
-COPY . ./
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
 
 FROM buildbase as appbase
 RUN CGO_ENABLED=0 go build -mod=vendor -o operator cmd/operator/*.go

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -1,6 +1,10 @@
 FROM golang:1.21-bullseye AS buildbase
 WORKDIR /app
-COPY . ./
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY cmd cmd
+COPY pkg pkg
+COPY vendor vendor
 
 FROM buildbase as appbase
 RUN CGO_ENABLED=0 go build -mod=vendor -o rule-evaluator cmd/rule-evaluator/*.go

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -51,15 +51,28 @@ COPY --from=hermetic /workspace/vendor vendor.tmp
 
 ## kindtest image for running tests against kind cluster in hermetic environment.
 FROM golang:1.21-bullseye as buildbase
-FROM google/cloud-sdk:slim as kindtest
+FROM docker:24.0-cli as docker
+FROM debian:stable-slim as kindtest
 
 WORKDIR /build
 
 # Install go.
 COPY --from=buildbase /usr/local/go /usr/local
 
-# Install kubectl.
-RUN apt-get install kubectl
+# Install docker cli.
+COPY --from=docker /usr/local/bin/docker /usr/local/bin
+
+# Install curl.
+RUN apt update
+RUN apt install -y curl
+
+# Install kubectl, jq.
+RUN curl -Lo ./kubectl https://dl.k8s.io/release/v1.27.0/bin/linux/amd64/kubectl
+RUN install -o root -g root -m 07555 kubectl /usr/local/bin/kubectl \
+  && rm kubectl
+RUN curl -Lo ./jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64
+RUN install -o root -g root -m 07555 jq /usr/local/bin/jq \
+  && rm jq
 
 # Install kind.
 RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
@@ -67,4 +80,12 @@ RUN install -o root -g root -m 0755 kind /usr/local/bin/kind \
   && rm kind
 
 # Get resources into image.
-COPY . .
+COPY examples examples
+COPY cmd cmd
+COPY manifests manifests
+COPY vendor vendor
+COPY pkg pkg
+COPY e2e e2e
+COPY hack hack
+COPY go.mod go.mod
+COPY go.sum go.sum


### PR DESCRIPTION
I decided to break out the kind E2E test refactor PR https://github.com/GoogleCloudPlatform/prometheus-engine/pull/738 into smaller, digestible PRs for reviewing.

Note: because of the nature of the change, presubmits (i.e. Github Actions) may fail until the final PR is merged.

This is the first one, where we slim down our Docker images to only copy code that's necessary to build and run the binary or script.