### PR TITLE
[E2E refactor - 9] use matrix strategy to parallelize github action e2e test runs

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -56,11 +56,21 @@ jobs:
       env:
         GCM_SECRET: ${{ secrets.GCM_SECRET }}
       run: make test-script-gcm
+  e2e-testruns:
+    runs-on: ubuntu-latest
+    outputs:
+      testrun: ${{ steps.set-testruns.outputs.testrun }}
+    steps:
+    - uses: actions/checkout@v3
+    - id: set-testruns
+      run: echo "testrun=$(go test ./e2e/... -list=. | grep -E 'Test*' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
   e2e-test:
     runs-on: ubuntu-latest
+    needs: [e2e-testruns]
+    strategy:
+      matrix:
+        testrun: ${{fromJson(needs.e2e-testruns.outputs.testrun)}}
     steps:
     - uses: actions/checkout@v3
     - name: Run e2e
-      run: make e2e
-      env:
-        GO_ARGS: "-timeout=15m -parallel=2"
+      run: TEST_RUN=${{matrix.testrun}} make e2e


### PR DESCRIPTION
I decided to break out the kind E2E test refactor PR https://github.com/GoogleCloudPlatform/prometheus-engine/pull/738 into smaller, digestible PRs for reviewing.

Note: because of the nature of the change, presubmits (i.e. Github Actions) may fail until the final PR is merged.

This is the ninth one, where we use parallel Github Actions to run each kind cluster test in parallel for faster and more reliable tests (< 10m total).