### PR TITLE
[E2E refactor - 11] fix go-synthetic e2e deploy and reduce local parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ E2E_DOCKER_ARGS += --env KIND_PERSIST=1
 endif
 REGISTRY_NAME=kind-registry
 REGISTRY_PORT=5001
-KIND_PARALLEL?=5
+KIND_PARALLEL?=3
 
 # For now assume the docker daemon is mounted through a unix socket.
 # TODO(pintohutch): will this work if using a remote docker over tcp?

--- a/hack/kind-test.sh
+++ b/hack/kind-test.sh
@@ -137,6 +137,9 @@ docker_tag_push() {
 update_manifests() {
   for bin in "$@"; do
     find manifests -type f -name "*.yaml" -exec sed -i "s#image: .*/${bin}:.*#image: localhost:${REGISTRY_PORT}/${bin}:${TAG_NAME}#g" {} \;
+    if [ "$bin" = "go-synthetic" ]; then
+      find examples/instrumentation -type f -name "*.yaml" -exec sed -i "s#image: .*/example-app:.*#image: localhost:${REGISTRY_PORT}/${bin}:${TAG_NAME}#g" {} \;
+    fi
   done
 }
 


### PR DESCRIPTION
I decided to break out the kind E2E test refactor PR https://github.com/GoogleCloudPlatform/prometheus-engine/pull/738 into smaller, digestible PRs for reviewing.

Note: because of the nature of the change, presubmits (i.e. Github Actions) may fail until the final PR is merged.

This is the eleventh (and really final!) one, where we fix a bug that allows a build and deploy of the go-synthetic container from source. Also reduce the parallelism for local e2e test runs to improve stability.