### PR TITLE
OperatorConfig compression setting is now also applied for rule-eval. configMap from *Rules CRs [0.9]

### DIFF
--- a/cmd/operator/deploy/crds/monitoring.googleapis.com_operatorconfigs.yaml
+++ b/cmd/operator/deploy/crds/monitoring.googleapis.com_operatorconfigs.yaml
@@ -99,7 +99,7 @@ spec:
                 properties:
                   compression:
                     type: string
-                    description: Compression enables compression of the config data propagated by the operator to collectors. It is recommended to use the gzip option when using a large number of ClusterPodMonitoring and/or PodMonitoring.
+                    description: Compression enables compression of the config data propagated by the operator to collectors and the rule-evaluator. It is recommended to use the gzip option when using a large number of ClusterPodMonitoring, PodMonitoring, GlobalRules, ClusterRules, and/or Rules.
                     enum:
                     - none
                     - gzip

--- a/doc/api.md
+++ b/doc/api.md
@@ -203,7 +203,7 @@ ConfigSpec holds configurations for the Prometheus configuration.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| compression | Compression enables compression of the config data propagated by the operator to collectors. It is recommended to use the gzip option when using a large number of ClusterPodMonitoring and/or PodMonitoring. | CompressionType | false |
+| compression | Compression enables compression of the config data propagated by the operator to collectors and the rule-evaluator. It is recommended to use the gzip option when using a large number of ClusterPodMonitoring, PodMonitoring, GlobalRules, ClusterRules, and/or Rules. | CompressionType | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/e2e/operator_context_test.go
+++ b/e2e/operator_context_test.go
@@ -199,6 +199,9 @@ type OperatorContext struct {
 	namespace, pubNamespace string
 
 	kClient kubeutil.DelegatingClient
+
+	// NOTE(bwplotka): Only used by rule tests so far.
+	features monitoringv1.OperatorFeatures
 }
 
 func newOperatorContext(t *testing.T) *OperatorContext {
@@ -211,7 +214,7 @@ func newOperatorContext(t *testing.T) *OperatorContext {
 	// Create a namespace per test and run. This is to ensure that repeated runs of
 	// tests don't falsify results. Either by old test resources not being cleaned up
 	// (less likely) or metrics observed in GCP being from a previous run (more likely).
-	namespace := fmt.Sprintf("gmp-test-%s-%s", strings.ToLower(t.Name()), startTime.Format("20060102-150405"))
+	namespace := fmt.Sprintf("gmp-test-%s-%s", strings.ToLower(strings.Replace(t.Name(), "/", "-", -1)), startTime.Format("20060102-150405"))
 	pubNamespace := fmt.Sprintf("%s-pub", namespace)
 
 	tctx := &OperatorContext{

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -951,7 +951,7 @@ spec:
                 properties:
                   compression:
                     type: string
-                    description: Compression enables compression of the config data propagated by the operator to collectors. It is recommended to use the gzip option when using a large number of ClusterPodMonitoring and/or PodMonitoring.
+                    description: Compression enables compression of the config data propagated by the operator to collectors and the rule-evaluator. It is recommended to use the gzip option when using a large number of ClusterPodMonitoring, PodMonitoring, GlobalRules, ClusterRules, and/or Rules.
                     enum:
                     - none
                     - gzip

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -528,7 +528,7 @@ const (
 	ClientName = "prometheus-engine-export"
 	// mainModuleVersion is the version of the main module. Align with git tag.
 	// TODO(TheSpiritXIII): Remove with https://github.com/golang/go/issues/50603
-	mainModuleVersion = "v0.9.1-rc.2"
+	mainModuleVersion = "v0.9.1-rc.3"
 	// mainModuleName is the name of the main module. Align with go.mod.
 	mainModuleName = "github.com/GoogleCloudPlatform/prometheus-engine"
 )

--- a/pkg/operator/apis/monitoring/v1/types.go
+++ b/pkg/operator/apis/monitoring/v1/types.go
@@ -121,9 +121,8 @@ type OperatorFeatures struct {
 
 // ConfigSpec holds configurations for the Prometheus configuration.
 type ConfigSpec struct {
-	// Compression enables compression of the config data propagated by the operator to collectors.
-	// It is recommended to use the gzip option when using a large number of ClusterPodMonitoring
-	// and/or PodMonitoring.
+	// Compression enables compression of the config data propagated by the operator to collectors and the rule-evaluator.
+	// It is recommended to use the gzip option when using a large number of ClusterPodMonitoring, PodMonitoring, GlobalRules, ClusterRules, and/or Rules.
 	Compression CompressionType `json:"compression,omitempty"`
 }
 

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -356,7 +356,9 @@ func (r *collectionReconciler) ensureCollectorConfig(ctx context.Context, spec *
 			Name:      NameCollector,
 		},
 	}
-	setConfigMapData(cm, compression, configFilename, string(cfgEncoded))
+	if err := setConfigMapData(cm, compression, configFilename, string(cfgEncoded)); err != nil {
+		return err
+	}
 
 	if err := r.client.Update(ctx, cm); apierrors.IsNotFound(err) {
 		if err := r.client.Create(ctx, cm); err != nil {

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -314,6 +314,31 @@ func gzipData(data []byte) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
+func setConfigMapData(cm *corev1.ConfigMap, c monitoringv1.CompressionType, fn string, data string) error {
+	// Thanos config-reloader detects gzip compression automatically, so no sync with
+	// config-reloaders is needed when switching between these.
+	switch c {
+	case monitoringv1.CompressionGzip:
+		compressed, err := gzipData([]byte(data))
+		if err != nil {
+			return fmt.Errorf("gzip Prometheus config: %w", err)
+		}
+
+		if cm.BinaryData == nil {
+			cm.BinaryData = map[string][]byte{}
+		}
+		cm.BinaryData[fn] = compressed
+	case "", monitoringv1.CompressionNone:
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data[fn] = data
+	default:
+		return fmt.Errorf("unknown compression type: %q", c)
+	}
+	return nil
+}
+
 // ensureCollectorConfig generates the collector config and creates or updates it.
 func (r *collectionReconciler) ensureCollectorConfig(ctx context.Context, spec *monitoringv1.CollectionSpec, compression monitoringv1.CompressionType) error {
 	cfg, err := r.makeCollectorConfig(ctx, spec)
@@ -331,26 +356,7 @@ func (r *collectionReconciler) ensureCollectorConfig(ctx context.Context, spec *
 			Name:      NameCollector,
 		},
 	}
-
-	// Thanos config-reloader detects gzip compression automatically, so no sync with
-	// config-reloaders is needed when switching between these.
-	switch compression {
-	case monitoringv1.CompressionGzip:
-		compressedCfg, err := gzipData(cfgEncoded)
-		if err != nil {
-			return fmt.Errorf("gzip Prometheus config: %w", err)
-		}
-
-		cm.BinaryData = map[string][]byte{
-			configFilename: compressedCfg,
-		}
-	case "", monitoringv1.CompressionNone:
-		cm.Data = map[string]string{
-			configFilename: string(cfgEncoded),
-		}
-	default:
-		return fmt.Errorf("unknown compression type: %q", compression)
-	}
+	setConfigMapData(cm, compression, configFilename, string(cfgEncoded))
 
 	if err := r.client.Update(ctx, cm); apierrors.IsNotFound(err) {
 		if err := r.client.Create(ctx, cm); err != nil {

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -168,7 +168,9 @@ func (r *rulesReconciler) ensureRuleConfigs(ctx context.Context, projectID, loca
 			logger.Error(err, "converting rules failed", "rules_namespace", rs.Namespace, "rules_name", rs.Name)
 		}
 		filename := fmt.Sprintf("rules__%s__%s.yaml", rs.Namespace, rs.Name)
-		setConfigMapData(cm, compression, filename, result)
+		if err := setConfigMapData(cm, compression, filename, result); err != nil {
+			return err
+		}
 	}
 
 	var clusterRulesList monitoringv1.ClusterRulesList
@@ -182,7 +184,9 @@ func (r *rulesReconciler) ensureRuleConfigs(ctx context.Context, projectID, loca
 			logger.Error(err, "converting rules failed", "clusterrules_name", rs.Name)
 		}
 		filename := fmt.Sprintf("clusterrules__%s.yaml", rs.Name)
-		setConfigMapData(cm, compression, filename, result)
+		if err := setConfigMapData(cm, compression, filename, result); err != nil {
+			return err
+		}
 	}
 
 	var globalRulesList monitoringv1.GlobalRulesList
@@ -196,7 +200,9 @@ func (r *rulesReconciler) ensureRuleConfigs(ctx context.Context, projectID, loca
 			logger.Error(err, "converting rules failed", "globalrules_name", rs.Name)
 		}
 		filename := fmt.Sprintf("globalrules__%s.yaml", rs.Name)
-		setConfigMapData(cm, compression, filename, result)
+		if err := setConfigMapData(cm, compression, filename, result); err != nil {
+			return err
+		}
 	}
 
 	// Create or update generated rule ConfigMap.


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/prometheus-engine/issues/549