### PR TITLE
Add TLS to datasource-syncer

### DIFF
--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 60
   template:
+    metadata:
+      labels:
+        app: datasource-syncer-init
     spec:
       containers:
       - name: datasource-syncer-init
@@ -26,6 +29,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: datasource-syncer
         spec:
           containers:
           - name: datasource-syncer

--- a/cmd/datasource-syncer/main.go
+++ b/cmd/datasource-syncer/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	grafana "github.com/grafana/grafana-api-golang-client"
+	"github.com/hashicorp/go-cleanhttp"
 	"golang.org/x/mod/semver"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -37,8 +38,8 @@ var (
 
 	certFile           = flag.String("tls-cert", "", "Path to the server TLS certificate.")
 	keyFile            = flag.String("tls-key", "", "Path to the server TLS key.")
-	caFile             = flag.String("ca-cert", "", "Path to the server certificate authority")
-	InsecureSkipVerify = flag.Bool("insecure-skip-verify", false, "Skip TLS certificate verification")
+	caFile             = flag.String("tls-ca-cert", "", "Path to the server certificate authority")
+	insecureSkipVerify = flag.Bool("insecure-skip-verify", false, "Skip TLS certificate verification")
 )
 
 func main() {
@@ -67,7 +68,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	client, err := getTLSClient(logger, *certFile, *keyFile, *caFile, *InsecureSkipVerify)
+	client, err := getTLSClient(*certFile, *keyFile, *caFile, *insecureSkipVerify)
 	if err != nil {
 		level.Error(logger).Log("msg", "couldn't create client", "err", err)
 		os.Exit(1)
@@ -89,6 +90,7 @@ func main() {
 	}
 
 	dsSuccessfullyUpdated := []string{}
+	dsErrors := []string{}
 	datasourceUIDs := strings.Split(*datasourceUIDList, ",")
 	for _, datasourceUID := range datasourceUIDs {
 		datasourceUID = strings.TrimSpace(datasourceUID)
@@ -98,25 +100,32 @@ func main() {
 
 		dataSource, err := grafanaClient.DataSourceByUID(datasourceUID)
 		if err != nil {
+			dsErrors = append(dsErrors, datasourceUID)
 			level.Error(logger).Log("msg", fmt.Sprintf("error fetching data source config of data source uid: %s", datasourceUID), "err", err)
 			continue
 		}
 
 		dataSource, err = buildUpdateDataSourceRequest(*dataSource, token)
 		if err != nil {
+			dsErrors = append(dsErrors, datasourceUID)
 			level.Error(logger).Log("msg", fmt.Sprintf("couldn't build data source update request for data source uid: %s", datasourceUID), "err", err)
 			continue
 		}
 
 		err = grafanaClient.UpdateDataSourceByUID(dataSource)
 		if err != nil {
+			dsErrors = append(dsErrors, datasourceUID)
 			level.Error(logger).Log("msg", fmt.Sprintf("couldn't send update data source request to data source id: %s", datasourceUID), "err", err)
 			continue
 		}
 		dsSuccessfullyUpdated = append(dsSuccessfullyUpdated, datasourceUID)
 	}
 	if len(dsSuccessfullyUpdated) != 0 {
-		level.Info(logger).Log("msg", fmt.Sprintf("Updated grafana data source uids: %s", dsSuccessfullyUpdated))
+		level.Info(logger).Log("msg", fmt.Sprintf("Updated Grafana data source uids: %s", dsSuccessfullyUpdated))
+	}
+	if len(dsErrors) != 0 {
+		level.Error(logger).Log("msg", fmt.Sprintf("Failed to update Grafana data source uids: %s", dsErrors))
+		os.Exit(1)
 	}
 }
 
@@ -239,16 +248,15 @@ func buildUpdateDataSourceRequest(dataSource grafana.DataSource, token string) (
 	return &dataSource, nil
 }
 
-func getTLSClient(logger log.Logger, certFile, keyFile, caFile string, insecureSkipVerify bool) (*http.Client, error) {
+func getTLSClient(certFile, keyFile, caFile string, insecureSkipVerify bool) (*http.Client, error) {
 	if (certFile != "" || keyFile != "") && (certFile == "" || keyFile == "") {
 		return nil, fmt.Errorf("--tls-cert and tls-key must both be set or unset")
 	}
 
 	if certFile == "" && keyFile == "" && caFile == "" && !insecureSkipVerify {
-		return http.DefaultClient, nil
+		return nil, nil
 	}
 
-	var client *http.Client
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: insecureSkipVerify,
 	}
@@ -271,10 +279,10 @@ func getTLSClient(logger log.Logger, certFile, keyFile, caFile string, insecureS
 		tlsConfig.RootCAs = caCertPool
 	}
 
-	transport := &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
 
-	client = &http.Client{Transport: transport}
+	client := cleanhttp.DefaultClient()
+	client.Transport = transport
 	return client, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.12.0
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/oklog/run v1.1.0
 	github.com/oklog/ulid v1.3.1
 	github.com/prometheus/client_golang v1.18.0
@@ -79,7 +80,6 @@ require (
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect


### PR DESCRIPTION
1. Added TLS support, including four new flags `tls-cert`, `tls-key`, `tls-ca-cert` and `insecure-skip-verify`.
2. Added a condition to return error and exist if any data source syncs fail.
3. Added a label to datasource-syncer.yaml so users can use `kubectl get pods -l app=datasource-syncer` to view pods associated with their job.