### PR TITLE
style: resolve linter errors and enable linter

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -26,6 +26,12 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build go images
       run: make bin
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Lint code with golangci-lint
+      run: make lint
   validate:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   disable:
     - errcheck
     - ineffassign
-    - gosimple
     - govet
     - staticcheck
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,3 @@
 linters:
-  disable:
-    - govet
+  enable:
+  - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,4 +3,3 @@ linters:
     - errcheck
     - ineffassign
     - govet
-    - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,4 @@
 linters:
   disable:
     - errcheck
-    - ineffassign
     - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+linters:
+  disable:
+    - errcheck
+    - ineffassign
+    - gosimple
+    - govet
+    - staticcheck
+    - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,4 +4,3 @@ linters:
     - ineffassign
     - govet
     - staticcheck
-    - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,3 @@
 linters:
   disable:
-    - errcheck
     - govet

--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/thanos-io/thanos/pkg/reloader"
 )
@@ -56,8 +57,8 @@ func main() {
 
 	metrics := prometheus.NewRegistry()
 	metrics.MustRegister(
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 
 	reloadURL, err := url.Parse(*reloadURLStr)

--- a/cmd/datasource-syncer/main.go
+++ b/cmd/datasource-syncer/main.go
@@ -50,26 +50,31 @@ func main() {
 	logger = log.With(logger, "caller", log.DefaultCaller)
 
 	if len(*datasourceUIDList) == 0 {
+		//nolint:errcheck
 		level.Error(logger).Log("msg", "--datasource-uid must be set")
 		os.Exit(1)
 	}
 
 	if *grafanaAPIToken == "" {
+		//nolint:errcheck
 		level.Error(logger).Log("msg", "--grafana-api-token must be set")
 		os.Exit(1)
 	}
 	if *grafanaEndpoint == "" {
+		//nolint:errcheck
 		level.Error(logger).Log("msg", "--grafana-api-endpoint must be set")
 		os.Exit(1)
 	}
 
 	if *projectID == "" {
+		//nolint:errcheck
 		level.Error(logger).Log("msg", "--project-id must be set")
 		os.Exit(1)
 	}
 
 	client, err := getTLSClient(*certFile, *keyFile, *caFile, *insecureSkipVerify)
 	if err != nil {
+		//nolint:errcheck
 		level.Error(logger).Log("msg", "couldn't create client", "err", err)
 		os.Exit(1)
 	}
@@ -79,12 +84,14 @@ func main() {
 		Client: client,
 	})
 	if err != nil {
+		//nolint:errcheck
 		level.Error(logger).Log("msg", "couldn't create grafana client", "err", err)
 		os.Exit(1)
 	}
 
 	token, err := getOAuth2Token(*credentialsFile)
 	if err != nil {
+		//nolint:errcheck
 		level.Error(logger).Log("msg", "couldn't get Google OAuth2 token", "err", err)
 		os.Exit(1)
 	}
@@ -101,6 +108,7 @@ func main() {
 		dataSource, err := grafanaClient.DataSourceByUID(datasourceUID)
 		if err != nil {
 			dsErrors = append(dsErrors, datasourceUID)
+			//nolint:errcheck
 			level.Error(logger).Log("msg", fmt.Sprintf("error fetching data source config of data source uid: %s", datasourceUID), "err", err)
 			continue
 		}
@@ -108,6 +116,7 @@ func main() {
 		dataSource, err = buildUpdateDataSourceRequest(*dataSource, token)
 		if err != nil {
 			dsErrors = append(dsErrors, datasourceUID)
+			//nolint:errcheck
 			level.Error(logger).Log("msg", fmt.Sprintf("couldn't build data source update request for data source uid: %s", datasourceUID), "err", err)
 			continue
 		}
@@ -115,15 +124,18 @@ func main() {
 		err = grafanaClient.UpdateDataSourceByUID(dataSource)
 		if err != nil {
 			dsErrors = append(dsErrors, datasourceUID)
+			//nolint:errcheck
 			level.Error(logger).Log("msg", fmt.Sprintf("couldn't send update data source request to data source id: %s", datasourceUID), "err", err)
 			continue
 		}
 		dsSuccessfullyUpdated = append(dsSuccessfullyUpdated, datasourceUID)
 	}
 	if len(dsSuccessfullyUpdated) != 0 {
+		//nolint:errcheck
 		level.Info(logger).Log("msg", fmt.Sprintf("Updated Grafana data source uids: %s", dsSuccessfullyUpdated))
 	}
 	if len(dsErrors) != 0 {
+		//nolint:errcheck
 		level.Error(logger).Log("msg", fmt.Sprintf("Failed to update Grafana data source uids: %s", dsErrors))
 		os.Exit(1)
 	}

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/api/option"
 	apihttp "google.golang.org/api/transport/http"
@@ -74,8 +75,8 @@ func main() {
 
 	metrics := prometheus.NewRegistry()
 	metrics.MustRegister(
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 
 	if *projectID == "" {

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -154,7 +154,7 @@ func main() {
 			level.Info(logger).Log("msg", "Starting web server for metrics", "listen", *listenAddress)
 			return server.ListenAndServe()
 		}, func(err error) {
-			ctx, _ = context.WithTimeout(ctx, time.Minute)
+			ctx, cancel = context.WithTimeout(ctx, time.Minute)
 			if err := server.Shutdown(ctx); err != nil {
 				//nolint:errcheck
 				level.Error(logger).Log("msg", "Server failed to shut down gracefully")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -38,10 +38,6 @@ import (
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator"
 )
 
-func unstableFlagHelp(help string) string {
-	return help + " (Setting this flag voids any guarantees of proper behavior of the operator.)"
-}
-
 func main() {
 	var (
 		defaultProjectID string

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -143,7 +143,9 @@ func main() {
 			return server.ListenAndServe()
 		}, func(err error) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			server.Shutdown(ctx)
+			if err := server.Shutdown(ctx); err != nil {
+				logger.Error(err, "Server failed to shut down gracefully.")
+			}
 			cancel()
 		})
 	}

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
@@ -79,8 +80,8 @@ func main() {
 
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		grpc_prometheus.DefaultClientMetrics,
 	)
 

--- a/pkg/export/bench/app/example_app.go
+++ b/pkg/export/bench/app/example_app.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -146,8 +147,8 @@ func main() {
 	metrics := prometheus.NewRegistry()
 
 	metrics.MustRegister(
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		metricIncomingRequestsPending,
 		metricOutgoingRequestsPending,
 		metricIncomingRequests,

--- a/pkg/export/bench/app/example_app.go
+++ b/pkg/export/bench/app/example_app.go
@@ -193,7 +193,9 @@ func main() {
 			return server.ListenAndServe()
 		}, func(err error) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			server.Shutdown(ctx)
+			if err := server.Shutdown(ctx); err != nil {
+				log.Printf("Server failed to shut down gracefully: %s", err)
+			}
 			cancel()
 		})
 	}

--- a/pkg/export/bench/server.go
+++ b/pkg/export/bench/server.go
@@ -28,6 +28,7 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 func main() {
@@ -46,7 +47,6 @@ func main() {
 	srv := grpc.NewServer(
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
-		grpc.RPCDecompressor(grpc.NewGZIPDecompressor()),
 	)
 	monitoring_pb.RegisterMetricServiceServer(srv, &server{latency: *backendLatency})
 

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -480,6 +480,7 @@ func (e *Exporter) Export(metadata MetadataFunc, batch []record.RefSample, exemp
 		)
 		samples, batch, err = builder.next(metadata, externalLabels, batch, exemplarMap)
 		if err != nil {
+			//nolint:errcheck
 			level.Debug(e.logger).Log("msg", "building sample failed", "err", err)
 			continue
 		}
@@ -844,6 +845,7 @@ func (e *Exporter) withUntypedDefaultMetadata(f MetadataFunc) MetadataFunc {
 		defer e.mtx.Unlock()
 
 		if _, ok := e.warnedUntypedMetrics[metric]; !ok {
+			//nolint:errcheck
 			level.Warn(e.logger).Log("msg", "no metadata found, defaulting to untyped metric", "metric_name", metric)
 			e.warnedUntypedMetrics[metric] = struct{}{}
 		}
@@ -944,6 +946,7 @@ func (b batch) send(
 				TimeSeries: l,
 			})
 			if err != nil {
+				//nolint:errcheck
 				level.Error(b.logger).Log("msg", "send batch", "size", len(l), "err", err)
 			}
 			samplesSent.Add(float64(len(l)))

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -43,6 +43,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/record"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 )
 
@@ -281,7 +282,7 @@ func newMetricClient(ctx context.Context, opts ExporterOpts) (*monitoring.Metric
 	if opts.DisableAuth {
 		clientOpts = append(clientOpts,
 			option.WithoutAuthentication(),
-			option.WithGRPCDialOption(grpc.WithInsecure()),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		)
 	}
 	if opts.CredentialsFile != "" {

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -343,6 +343,7 @@ func TestExporter_drainBacklog(t *testing.T) {
 	)
 	monitoring_pb.RegisterMetricServiceServer(srv, metricServer)
 
+	//nolint:errcheck
 	go srv.Serve(listener)
 	defer srv.Stop()
 
@@ -378,6 +379,7 @@ func TestExporter_drainBacklog(t *testing.T) {
 		}, nil)
 	}
 
+	//nolint:errcheck
 	go e.Run(ctx)
 	// As our samples are all for the same series, each batch can only contain a single sample.
 	// The exporter waits for the batch delay duration before sending it.

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/api/option"
 	monitoredres_pb "google.golang.org/genproto/googleapis/api/monitoredres"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 	empty_pb "google.golang.org/protobuf/types/known/emptypb"
 )
@@ -353,7 +354,7 @@ func TestExporter_drainBacklog(t *testing.T) {
 	}
 	metricClient, err := monitoring.NewMetricClient(ctx,
 		option.WithoutAuthentication(),
-		option.WithGRPCDialOption(grpc.WithInsecure()),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		option.WithGRPCDialOption(grpc.WithContextDialer(bufDialer)),
 	)
 	if err != nil {

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -193,6 +193,7 @@ func TestSampleInRange(t *testing.T) {
 			want:  false,
 		},
 	}
+	//nolint:govet
 	for _, c := range cases {
 		p := &monitoring_pb.TimeSeries{
 			Points: []*monitoring_pb.Point{

--- a/pkg/export/gcm/promtest/local_export.go
+++ b/pkg/export/gcm/promtest/local_export.go
@@ -96,12 +96,15 @@ func (l *localExportWithGCM) start(t testing.TB, _ e2e.Environment) (v1.API, map
 	}
 
 	// Apply empty config, so resources labels are attached.
-	l.e.ApplyConfig(&config.DefaultConfig)
+	if err := l.e.ApplyConfig(&config.DefaultConfig); err != nil {
+		t.Fatalf("apply config: %v", err)
+	}
 	l.e.SetLabelsByIDFunc(func(ref storage.SeriesRef) labels.Labels {
 		return l.labelsByRef[ref]
 	})
 
 	cancelableCtx, cancel := context.WithCancel(ctx)
+	//nolint:errcheck
 	go l.e.Run(cancelableCtx)
 	// TODO(bwplotka): Consider listening for KILL signal too.
 	t.Cleanup(cancel)

--- a/pkg/export/gcm/promtest/promtest.go
+++ b/pkg/export/gcm/promtest/promtest.go
@@ -169,6 +169,7 @@ type ingestionTestExpRecorder struct {
 
 func (ir *ingestionTestExpRecorder) Expect(val float64, metric prometheus.Metric, b Backend) ExpectationsRecorder {
 	m := dto.Metric{}
+	//nolint:errcheck
 	metric.Write(&m)
 	if m.GetSummary() != nil || m.GetHistogram() != nil {
 		// TODO(bwplotka): Implement an alternative.
@@ -226,6 +227,7 @@ func (it *ingestionTest) FatalOnUnexpectedPromQLResults(b Backend, metric promet
 	it.t.Helper()
 
 	m := dto.Metric{}
+	//nolint:errcheck
 	metric.Write(&m)
 
 	if m.GetSummary() != nil || m.GetHistogram() != nil {
@@ -296,6 +298,7 @@ func (it *ingestionTest) FatalOnUnexpectedPromQLResults(b Backend, metric promet
 
 func toModelMetric(metric prometheus.Metric) model.Metric {
 	m := dto.Metric{}
+	//nolint:errcheck
 	metric.Write(&m)
 
 	ret := model.Metric{}

--- a/pkg/export/gcm/promtest/promtest.go
+++ b/pkg/export/gcm/promtest/promtest.go
@@ -48,8 +48,6 @@ type ingestionTest struct {
 
 	testID string
 
-	env e2e.Environment
-
 	backends               map[string]backend
 	expectationsPerBackend map[string]model.Matrix
 

--- a/pkg/export/gcm/promtest/skip.go
+++ b/pkg/export/gcm/promtest/skip.go
@@ -20,7 +20,6 @@ func (n noopBackend) start(t testing.TB, env e2e.Environment) (api v1.API, extra
 }
 
 func (n noopBackend) injectScrapes(t testing.TB, scrapeRecordings [][]*dto.MetricFamily, timeout time.Duration) {
-	return
 }
 
 // NoopBackend creates noop backend, useful when you want to skip one backend for

--- a/pkg/export/series_cache.go
+++ b/pkg/export/series_cache.go
@@ -161,6 +161,8 @@ func (c *seriesCache) run(ctx context.Context) {
 			return
 		case <-tick.C:
 			if err := c.garbageCollect(10 * time.Minute); err != nil {
+				//nolint:errcheck
+				//nolint:errcheck
 				level.Error(c.logger).Log("msg", "garbage collection failed", "err", err)
 			}
 		}
@@ -218,6 +220,7 @@ func (c *seriesCache) garbageCollect(delay time.Duration) error {
 		delete(c.entries, ref)
 		i++
 	}
+	//nolint:errcheck
 	level.Info(c.logger).Log("msg", "garbage collection completed", "took", time.Since(start), "seriesPurged", i)
 
 	return nil
@@ -239,6 +242,7 @@ func (c *seriesCache) get(s record.RefSample, externalLabels labels.Labels, meta
 	}
 	if e.shouldRefresh() {
 		if err := c.populate(ref, e, externalLabels, metadata); err != nil {
+			//nolint:errcheck
 			level.Debug(c.logger).Log("msg", "populating series failed", "ref", s.Ref, "err", err)
 		}
 		e.setNextRefresh()
@@ -556,7 +560,9 @@ func hashSeries(s *monitoring_pb.TimeSeries) uint64 {
 	hashLabels(h, s.Resource.Labels)
 	h.Write([]byte(s.Metric.Type))
 	hashLabels(h, s.Metric.Labels)
+	//nolint:errcheck
 	binary.Write(h, binary.LittleEndian, s.MetricKind)
+	//nolint:errcheck
 	binary.Write(h, binary.LittleEndian, s.ValueType)
 
 	return h.Sum64()

--- a/pkg/export/series_cache_test.go
+++ b/pkg/export/series_cache_test.go
@@ -167,7 +167,9 @@ func TestSeriesCache_garbageCollect(t *testing.T) {
 	cache.get(record.RefSample{Ref: 1, T: (now - 100) * 1000}, labels.EmptyLabels(), nil)
 	cache.get(record.RefSample{Ref: 2, T: (now - 101) * 1000}, labels.EmptyLabels(), nil)
 
-	cache.garbageCollect(100 * time.Second)
+	if err := cache.garbageCollect(100 * time.Second); err != nil {
+		t.Fatal(err)
+	}
 
 	// Entry for series 1 should remain while 2 got dropped.
 	if len(cache.entries) != 1 {

--- a/pkg/export/transform.go
+++ b/pkg/export/transform.go
@@ -118,6 +118,7 @@ func (b *sampleBuilder) next(metadata MetadataFunc, externalLabels labels.Labels
 	// based on the type determined in the series cache.
 	// If both are set, we double-write the series as a gauge and a cumulative.
 	if g := entry.protos.gauge; g.proto != nil {
+		//nolint:govet
 		ts := *g.proto
 
 		ts.Points = []*monitoring_pb.Point{{
@@ -125,7 +126,7 @@ func (b *sampleBuilder) next(metadata MetadataFunc, externalLabels labels.Labels
 				EndTime: getTimestamp(sample.T),
 			},
 			Value: &monitoring_pb.TypedValue{
-				Value: &monitoring_pb.TypedValue_DoubleValue{sample.V},
+				Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: sample.V},
 			},
 		}}
 		result = append(result, hashedSeries{hash: g.hash, proto: &ts})
@@ -155,7 +156,7 @@ func (b *sampleBuilder) next(metadata MetadataFunc, externalLabels labels.Labels
 			}
 			if v != nil {
 				value = &monitoring_pb.TypedValue{
-					Value: &monitoring_pb.TypedValue_DistributionValue{v},
+					Value: &monitoring_pb.TypedValue_DistributionValue{DistributionValue: v},
 				}
 			}
 		} else {
@@ -164,7 +165,7 @@ func (b *sampleBuilder) next(metadata MetadataFunc, externalLabels labels.Labels
 			resetTimestamp, v, ok = b.series.getResetAdjusted(storage.SeriesRef(sample.Ref), sample.T, sample.V)
 			if ok {
 				value = &monitoring_pb.TypedValue{
-					Value: &monitoring_pb.TypedValue_DoubleValue{v},
+					Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: v},
 				}
 				discardExemplarIncIfExists(storage.SeriesRef(sample.Ref), exemplars, "counters-unsupported")
 			}
@@ -174,6 +175,7 @@ func (b *sampleBuilder) next(metadata MetadataFunc, externalLabels labels.Labels
 		//   1. It was the first sample of a cumulative and we only initialized  the reset timestamp with it.
 		//   2. We could not observe all necessary series to build a full distribution sample.
 		if value != nil {
+			//nolint:govet
 			ts := *c.proto
 
 			ts.Points = []*monitoring_pb.Point{{

--- a/pkg/export/transform_test.go
+++ b/pkg/export/transform_test.go
@@ -109,7 +109,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 3},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{0.6},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 0.6},
 						},
 					}},
 				},
@@ -136,7 +136,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 4},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{math.Inf(1)},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: math.Inf(1)},
 						},
 					}},
 				},
@@ -178,7 +178,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 3},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{0.6},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 0.6},
 						},
 					}},
 				},
@@ -205,7 +205,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 4},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{100},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 100},
 						},
 					}},
 				},
@@ -233,7 +233,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 4},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{99.4},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 99.4},
 						},
 					}},
 				},
@@ -279,7 +279,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 3},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{2.5},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 2.5},
 						},
 					}},
 				},
@@ -307,7 +307,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 4},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{3.5},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 3.5},
 						},
 					}},
 				},
@@ -337,7 +337,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 5},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{7},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 7},
 						},
 					}},
 				},
@@ -389,7 +389,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 4},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{3.5},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 3.5},
 						},
 					}},
 				},
@@ -419,7 +419,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 5},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{7},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 7},
 						},
 					}},
 				},
@@ -448,7 +448,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 5},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{7},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 7},
 						},
 					}},
 				},
@@ -516,7 +516,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 2},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{2},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 2},
 						},
 					}},
 				},
@@ -545,7 +545,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 3},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{20},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 20},
 						},
 					}},
 				},
@@ -573,7 +573,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 4},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{1},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 1},
 						},
 					}},
 				},
@@ -600,7 +600,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 4},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{4},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 4},
 						},
 					}},
 				},
@@ -652,7 +652,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 2},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{2},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 2},
 						},
 					}},
 				},
@@ -682,7 +682,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 4},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{1},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 1},
 						},
 					}},
 				},
@@ -709,7 +709,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 4},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{4},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 4},
 						},
 					}},
 				},
@@ -891,7 +891,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 1},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{3},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 3},
 						},
 					}},
 				},
@@ -1145,7 +1145,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 1},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{1},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 1},
 						},
 					}},
 				}, {
@@ -1171,7 +1171,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 2},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{2},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 2},
 						},
 					}},
 				},
@@ -1198,7 +1198,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime: &timestamp_pb.Timestamp{Seconds: 1},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{1},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 1},
 						},
 					}},
 				},
@@ -1469,7 +1469,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 3},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{2.5},
+							Value: &monitoring_pb.TypedValue_DoubleValue{DoubleValue: 2.5},
 						},
 					}},
 				},

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -146,8 +146,12 @@ func New(
 		opts.RenewDeadline = 10 * time.Second
 	}
 	if metrics != nil {
-		metrics.Register(leaseHolder)
-		metrics.Register(leaseFailingOpen)
+		if err := metrics.Register(leaseHolder); err != nil {
+			return nil, err
+		}
+		if err := metrics.Register(leaseFailingOpen); err != nil {
+			return nil, err
+		}
 	}
 	leaseHolder.WithLabelValues(lock.Describe()).Set(0)
 	leaseFailingOpen.WithLabelValues(lock.Describe()).Set(0)

--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -15,16 +15,10 @@
 package v1alpha1
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-)
-
-var (
-	errInvalidCond = fmt.Errorf("condition needs both 'Type' and 'Status' fields set")
 )
 
 // OperatorConfig defines configuration of the gmp-operator.

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -525,7 +525,7 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 
 type podMonitoringDefaulter struct{}
 
-func (d *podMonitoringDefaulter) Default(ctx context.Context, o runtime.Object) error {
+func (d *podMonitoringDefaulter) Default(_ context.Context, o runtime.Object) error {
 	pm := o.(*monitoringv1.PodMonitoring)
 
 	if pm.Spec.TargetLabels.Metadata == nil {
@@ -537,7 +537,7 @@ func (d *podMonitoringDefaulter) Default(ctx context.Context, o runtime.Object) 
 
 type clusterPodMonitoringDefaulter struct{}
 
-func (d *clusterPodMonitoringDefaulter) Default(ctx context.Context, o runtime.Object) error {
+func (d *clusterPodMonitoringDefaulter) Default(_ context.Context, o runtime.Object) error {
 	pm := o.(*monitoringv1.ClusterPodMonitoring)
 
 	if pm.Spec.TargetLabels.Metadata == nil {

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -406,6 +406,8 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := pmon.ScrapeConfigs(projectID, location, cluster)
 		if err != nil {
 			msg := "generating scrape config failed for PodMonitoring endpoint"
+			//TODO: Fix ineffectual assignment. Intended behavior is unclear.
+			//nolint:ineffassign
 			cond = &monitoringv1.MonitoringCondition{
 				Type:    monitoringv1.ConfigurationCreateSuccess,
 				Status:  corev1.ConditionFalse,
@@ -445,6 +447,8 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := cmon.ScrapeConfigs(projectID, location, cluster)
 		if err != nil {
 			msg := "generating scrape config failed for ClusterPodMonitoring endpoint"
+			//TODO: Fix ineffectual assignment. Intended behavior is unclear.
+			//nolint:ineffassign
 			cond = &monitoringv1.MonitoringCondition{
 				Type:    monitoringv1.ConfigurationCreateSuccess,
 				Status:  corev1.ConditionFalse,
@@ -492,6 +496,8 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := nm.ScrapeConfigs(projectID, location, cluster)
 		if err != nil {
 			msg := "generating scrape config failed for NodeMonitoring endpoint"
+			//TODO: Fix ineffectual assignment. Intended behavior is unclear.
+			//nolint:ineffassign
 			cond = &monitoringv1.MonitoringCondition{
 				Type:    monitoringv1.ConfigurationCreateSuccess,
 				Status:  corev1.ConditionFalse,

--- a/pkg/operator/collection_test.go
+++ b/pkg/operator/collection_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -76,7 +76,7 @@ func TestCollectionStatus(t *testing.T) {
 								LastScrapeDurationSeconds: "1.2",
 							},
 						},
-						Count: pointer.Int32(1),
+						Count: ptr.To(int32(1)),
 					},
 				},
 				CollectorsFraction: "1",

--- a/pkg/operator/collection_test.go
+++ b/pkg/operator/collection_test.go
@@ -145,15 +145,19 @@ func TestCollectionStatus(t *testing.T) {
 		Build()
 
 	collectionReconciler := newCollectionReconciler(kubeClient, opts)
-	collectionReconciler.Reconcile(ctx, reconcile.Request{
+	if _, err := collectionReconciler.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: opts.PublicNamespace,
 			Name:      NameOperatorConfig,
 		},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	var podMonitorings monitoringv1.PodMonitoringList
-	kubeClient.List(ctx, &podMonitorings)
+	if err := kubeClient.List(ctx, &podMonitorings); err != nil {
+		t.Fatal(err)
+	}
 	switch amount := len(podMonitorings.Items); amount {
 	case 1:
 		status := podMonitorings.Items[0].Status

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -131,7 +131,7 @@ type Options struct {
 	CollectorHTTPClient *http.Client
 }
 
-func (o *Options) defaultAndValidate(logger logr.Logger) error {
+func (o *Options) defaultAndValidate(_ logr.Logger) error {
 	if o.OperatorNamespace == "" {
 		o.OperatorNamespace = DefaultOperatorNamespace
 	}
@@ -163,6 +163,7 @@ func (o *Options) defaultAndValidate(logger logr.Logger) error {
 	return nil
 }
 
+// NewScheme creates a new Kubernetes runtime.Scheme for the GMP Operator
 func NewScheme() (*runtime.Scheme, error) {
 	sc := runtime.NewScheme()
 
@@ -504,19 +505,19 @@ func (o namespacedNamePredicate) Generic(e event.GenericEvent) bool {
 // enqueueConst always enqueues the same request regardless of the event.
 type enqueueConst reconcile.Request
 
-func (e enqueueConst) Create(ctx context.Context, _ event.CreateEvent, q workqueue.RateLimitingInterface) {
+func (e enqueueConst) Create(_ context.Context, _ event.CreateEvent, q workqueue.RateLimitingInterface) {
 	q.Add(reconcile.Request(e))
 }
 
-func (e enqueueConst) Update(ctx context.Context, _ event.UpdateEvent, q workqueue.RateLimitingInterface) {
+func (e enqueueConst) Update(_ context.Context, _ event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	q.Add(reconcile.Request(e))
 }
 
-func (e enqueueConst) Delete(ctx context.Context, _ event.DeleteEvent, q workqueue.RateLimitingInterface) {
+func (e enqueueConst) Delete(_ context.Context, _ event.DeleteEvent, q workqueue.RateLimitingInterface) {
 	q.Add(reconcile.Request(e))
 }
 
-func (e enqueueConst) Generic(ctx context.Context, _ event.GenericEvent, q workqueue.RateLimitingInterface) {
+func (e enqueueConst) Generic(_ context.Context, _ event.GenericEvent, q workqueue.RateLimitingInterface) {
 	q.Add(reconcile.Request(e))
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -145,10 +145,10 @@ func (o *Options) defaultAndValidate(_ logr.Logger) error {
 	// ProjectID and Cluster must be always be set. Collectors and rule-evaluator can
 	// auto-discover them but we need them in the operator to scope generated rules.
 	if o.ProjectID == "" {
-		return errors.New("ProjectID must be set")
+		return errors.New("projectID must be set")
 	}
 	if o.Cluster == "" {
-		return errors.New("Cluster must be set")
+		return errors.New("cluster must be set")
 	}
 
 	if o.TargetPollConcurrency == 0 {

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -741,9 +741,8 @@ func getConfigMapKeyBytes(ctx context.Context, c client.Reader, namespace string
 		return []byte(s), nil
 	} else if b, ok := cm.BinaryData[sel.Key]; ok {
 		return b, nil
-	} else {
-		return b, fmt.Errorf("key %q in secret %q not found", sel.Key, sel.Name)
 	}
+	return b, fmt.Errorf("key %q in secret %q not found", sel.Key, sel.Name)
 }
 
 // pathForSelector cretes the filepath for the provided NamespacedSecretOrConfigMap.
@@ -828,7 +827,7 @@ type operatorConfigValidator struct {
 	namespace string
 }
 
-func (v *operatorConfigValidator) ValidateCreate(ctx context.Context, o runtime.Object) (admission.Warnings, error) {
+func (v *operatorConfigValidator) ValidateCreate(_ context.Context, o runtime.Object) (admission.Warnings, error) {
 	oc := o.(*monitoringv1.OperatorConfig)
 
 	if oc.Namespace != v.namespace || oc.Name != NameOperatorConfig {
@@ -856,6 +855,6 @@ func (v *operatorConfigValidator) ValidateUpdate(ctx context.Context, _, o runti
 	return v.ValidateCreate(ctx, o)
 }
 
-func (v *operatorConfigValidator) ValidateDelete(ctx context.Context, o runtime.Object) (admission.Warnings, error) {
+func (v *operatorConfigValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -25,7 +25,6 @@ import (
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
 	"github.com/go-logr/logr"
 	promcommonconfig "github.com/prometheus/common/config"
-	"github.com/prometheus/common/model"
 	prommodel "github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -523,7 +522,7 @@ func (r *operatorConfigReconciler) makeAlertmanagerConfigs(ctx context.Context, 
 			cfg.ServiceDiscoveryConfigs = discovery.Configs{
 				discovery.StaticConfig{
 					&targetgroup.Group{
-						Targets: []model.LabelSet{{model.AddressLabel: model.LabelValue(svcDNSName)}},
+						Targets: []prommodel.LabelSet{{prommodel.AddressLabel: prommodel.LabelValue(svcDNSName)}},
 					},
 				},
 			}

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -22,7 +22,6 @@ import (
 	yaml "gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -157,7 +156,7 @@ func (r *rulesReconciler) scaleRuleConsumers(ctx context.Context) error {
 	}
 
 	var alertManagerStatefulSet appsv1.StatefulSet
-	if err := r.client.Get(ctx, client.ObjectKey{Namespace: r.opts.OperatorNamespace, Name: "alertmanager"}, &alertManagerStatefulSet); errors.IsNotFound(err) {
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: r.opts.OperatorNamespace, Name: "alertmanager"}, &alertManagerStatefulSet); apierrors.IsNotFound(err) {
 		msg := fmt.Sprintf("Alertmanager StatefulSet not found, cannot scale to %d. In-cluster Alertmanager will not function.", desiredReplicas)
 		logger.Error(err, msg)
 	} else if err != nil {
@@ -171,7 +170,7 @@ func (r *rulesReconciler) scaleRuleConsumers(ctx context.Context) error {
 	}
 
 	var ruleEvaluatorDeployment appsv1.Deployment
-	if err := r.client.Get(ctx, client.ObjectKey{Namespace: r.opts.OperatorNamespace, Name: "rule-evaluator"}, &ruleEvaluatorDeployment); errors.IsNotFound(err) {
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: r.opts.OperatorNamespace, Name: "rule-evaluator"}, &ruleEvaluatorDeployment); apierrors.IsNotFound(err) {
 		msg := fmt.Sprintf("Rule Evaluator Deployment not found, cannot scale to %d. In-cluster Rule Evaluator will not function.", desiredReplicas)
 		logger.Error(err, msg)
 	} else if err != nil {

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -348,7 +348,7 @@ type rulesValidator struct {
 	opts Options
 }
 
-func (v *rulesValidator) ValidateCreate(ctx context.Context, o runtime.Object) (admission.Warnings, error) {
+func (v *rulesValidator) ValidateCreate(_ context.Context, o runtime.Object) (admission.Warnings, error) {
 	_, err := generateRules(o.(*monitoringv1.Rules), "test_project", "test_location", "test_cluster")
 	return nil, err
 }
@@ -357,7 +357,7 @@ func (v *rulesValidator) ValidateUpdate(ctx context.Context, _, o runtime.Object
 	return v.ValidateCreate(ctx, o)
 }
 
-func (v *rulesValidator) ValidateDelete(ctx context.Context, o runtime.Object) (admission.Warnings, error) {
+func (v *rulesValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
@@ -365,7 +365,7 @@ type clusterRulesValidator struct {
 	opts Options
 }
 
-func (v *clusterRulesValidator) ValidateCreate(ctx context.Context, o runtime.Object) (admission.Warnings, error) {
+func (v *clusterRulesValidator) ValidateCreate(_ context.Context, o runtime.Object) (admission.Warnings, error) {
 	_, err := generateClusterRules(o.(*monitoringv1.ClusterRules), "test_project", "test_location", "test_cluster")
 	return nil, err
 }
@@ -374,13 +374,13 @@ func (v *clusterRulesValidator) ValidateUpdate(ctx context.Context, _, o runtime
 	return v.ValidateCreate(ctx, o)
 }
 
-func (v *clusterRulesValidator) ValidateDelete(ctx context.Context, o runtime.Object) (admission.Warnings, error) {
+func (v *clusterRulesValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 type globalRulesValidator struct{}
 
-func (v *globalRulesValidator) ValidateCreate(ctx context.Context, o runtime.Object) (admission.Warnings, error) {
+func (v *globalRulesValidator) ValidateCreate(_ context.Context, o runtime.Object) (admission.Warnings, error) {
 	_, err := generateGlobalRules(o.(*monitoringv1.GlobalRules))
 	return nil, err
 }
@@ -389,6 +389,6 @@ func (v *globalRulesValidator) ValidateUpdate(ctx context.Context, _, o runtime.
 	return v.ValidateCreate(ctx, o)
 }
 
-func (v *globalRulesValidator) ValidateDelete(ctx context.Context, o runtime.Object) (admission.Warnings, error) {
+func (v *globalRulesValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -357,7 +357,7 @@ func TestScaleRuleConsumers(t *testing.T) {
 				t.Error(err)
 			}
 			if ruleEvaluator.Spec.Replicas != nil && *ruleEvaluator.Spec.Replicas != tc.want {
-				t.Errorf("want: %d, got: %d", tc.want, *&ruleEvaluator.Spec.Replicas)
+				t.Errorf("want: %d, got: %d", tc.want, ruleEvaluator.Spec.Replicas)
 			}
 		})
 	}

--- a/pkg/operator/target_status.go
+++ b/pkg/operator/target_status.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -450,7 +450,7 @@ func getPrometheusPort(container *corev1.Container) *int32 {
 		// In the future, we could fall back to reading the command line args.
 		if containerPort.Name == CollectorPrometheusContainerPortName {
 			// Make a copy.
-			return pointer.Int32(containerPort.ContainerPort)
+			return ptr.To(containerPort.ContainerPort)
 		}
 	}
 	return nil

--- a/pkg/operator/target_status.go
+++ b/pkg/operator/target_status.go
@@ -160,7 +160,7 @@ func shouldPoll(ctx context.Context, cfgNamespacedName types.NamespacedName, kub
 
 // Reconcile polls the collector pods, fetches and aggregates target status and
 // upserts into each PodMonitoring's Status field.
-func (r *targetStatusReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+func (r *targetStatusReconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	timer := r.clock.NewTimer(minPollDuration)
 
 	now := time.Now()
@@ -406,7 +406,7 @@ func getPrometheusPods(ctx context.Context, kubeClient client.Client, opts Optio
 	return podsFiltered, nil
 }
 
-func getTarget(ctx context.Context, logger logr.Logger, httpClient *http.Client, port int32, pod *corev1.Pod) (*prometheusv1.TargetsResult, error) {
+func getTarget(ctx context.Context, _ logr.Logger, httpClient *http.Client, port int32, pod *corev1.Pod) (*prometheusv1.TargetsResult, error) {
 	if pod.Status.PodIP == "" {
 		return nil, errors.New("pod does not have IP allocated")
 	}

--- a/pkg/operator/target_status_test.go
+++ b/pkg/operator/target_status_test.go
@@ -85,18 +85,18 @@ func expand(testCases []updateTargetStatusTestCase) []updateTargetStatusTestCase
 			clusterTargets = append(clusterTargets, targetClusterPodMonitoring)
 		}
 		for _, pm := range tc.podMonitorings {
-			copy := pm.DeepCopy()
+			pmCopy := pm.DeepCopy()
 			cpm := monitoringv1.ClusterPodMonitoring{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: copy.Name,
+					Name: pmCopy.Name,
 				},
 				Spec: monitoringv1.ClusterPodMonitoringSpec{
-					Selector:     copy.Spec.Selector,
-					Endpoints:    copy.Spec.Endpoints,
-					TargetLabels: copy.Spec.TargetLabels,
-					Limits:       copy.Spec.Limits,
+					Selector:     pmCopy.Spec.Selector,
+					Endpoints:    pmCopy.Spec.Endpoints,
+					TargetLabels: pmCopy.Spec.TargetLabels,
+					Limits:       pmCopy.Spec.Limits,
 				},
-				Status: copy.Status,
+				Status: pmCopy.Status,
 			}
 			for idx, status := range cpm.Status.EndpointStatuses {
 				cpm.Status.EndpointStatuses[idx].Name = podMonitoringScrapePoolToClusterPodMonitoringScrapePool(status.Name)
@@ -1092,14 +1092,14 @@ func TestUpdateTargetStatus(t *testing.T) {
 		t.Run(fmt.Sprintf("target-status-conversion-%s", testCase.desc), func(t *testing.T) {
 			clientBuilder := newFakeClientBuilder()
 			for _, podMonitoring := range testCase.podMonitorings {
-				copy := podMonitoring.DeepCopy()
-				copy.GetPodMonitoringStatus().EndpointStatuses = nil
-				clientBuilder.WithObjects(copy)
+				pmCopy := podMonitoring.DeepCopy()
+				pmCopy.GetPodMonitoringStatus().EndpointStatuses = nil
+				clientBuilder.WithObjects(pmCopy)
 			}
 			for _, clusterPodMonitoring := range testCase.clusterPodMonitorings {
-				copy := clusterPodMonitoring.DeepCopy()
-				copy.GetPodMonitoringStatus().EndpointStatuses = nil
-				clientBuilder.WithObjects(copy)
+				pmCopy := clusterPodMonitoring.DeepCopy()
+				pmCopy.GetPodMonitoringStatus().EndpointStatuses = nil
+				clientBuilder.WithObjects(pmCopy)
 			}
 
 			kubeClient := clientBuilder.Build()

--- a/pkg/operator/target_status_test.go
+++ b/pkg/operator/target_status_test.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	tclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -226,7 +226,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 												LastScrapeDurationSeconds: "1.2",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 								},
 								CollectorsFraction: "1",
@@ -291,7 +291,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 												LastScrapeDurationSeconds: "1.2",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 								},
 								CollectorsFraction: "0.4",
@@ -324,7 +324,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 												LastScrapeDurationSeconds: "2.4",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 								},
 								CollectorsFraction: "0.4",
@@ -410,7 +410,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 												LastScrapeDurationSeconds: "1.2",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 								},
 								CollectorsFraction: "1",
@@ -463,14 +463,14 @@ func TestUpdateTargetStatus(t *testing.T) {
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "up",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "a",
 												},
 												LastScrapeDurationSeconds: "1.2",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 								},
 								CollectorsFraction: "1",
@@ -515,14 +515,14 @@ func TestUpdateTargetStatus(t *testing.T) {
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "a",
 												},
 												LastScrapeDurationSeconds: "1.2",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 								},
 								CollectorsFraction: "1",
@@ -574,14 +574,14 @@ func TestUpdateTargetStatus(t *testing.T) {
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "b",
 												},
 												LastScrapeDurationSeconds: "1.2",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 									{
 										SampleTargets: []monitoringv1.SampleTarget{
@@ -593,7 +593,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 												LastScrapeDurationSeconds: "4.3",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 								},
 								CollectorsFraction: "1",
@@ -664,27 +664,27 @@ func TestUpdateTargetStatus(t *testing.T) {
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "a",
 												},
 												LastScrapeDurationSeconds: "5.3",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 									{
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err y"),
+												LastError: ptr.To("err y"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "b",
 												},
 												LastScrapeDurationSeconds: "7",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 								},
 								CollectorsFraction: "1",
@@ -699,7 +699,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "c",
 												},
@@ -707,14 +707,14 @@ func TestUpdateTargetStatus(t *testing.T) {
 											},
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "d",
 												},
 												LastScrapeDurationSeconds: "3.6",
 											},
 										},
-										Count: pointer.Int32(2),
+										Count: ptr.To(int32(2)),
 									},
 								},
 								CollectorsFraction: "1",
@@ -799,7 +799,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "b",
 												},
@@ -807,7 +807,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 											},
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "e",
 												},
@@ -815,33 +815,33 @@ func TestUpdateTargetStatus(t *testing.T) {
 											},
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "f",
 												},
 												LastScrapeDurationSeconds: "1.2",
 											},
 										},
-										Count: pointer.Int32(3),
+										Count: ptr.To(int32(3)),
 									},
 									{
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err y"),
+												LastError: ptr.To("err y"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "c",
 												},
 												LastScrapeDurationSeconds: "2.4",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 									{
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err z"),
+												LastError: ptr.To("err z"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "a",
 												},
@@ -849,14 +849,14 @@ func TestUpdateTargetStatus(t *testing.T) {
 											},
 											{
 												Health:    "down",
-												LastError: pointer.String("err z"),
+												LastError: ptr.To("err z"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "d",
 												},
 												LastScrapeDurationSeconds: "4.7",
 											},
 										},
-										Count: pointer.Int32(2),
+										Count: ptr.To(int32(2)),
 									},
 								},
 								CollectorsFraction: "1",
@@ -973,7 +973,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "a",
 												},
@@ -981,7 +981,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 											},
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "b",
 												},
@@ -989,7 +989,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 											},
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "c",
 												},
@@ -997,7 +997,7 @@ func TestUpdateTargetStatus(t *testing.T) {
 											},
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "d",
 												},
@@ -1005,33 +1005,33 @@ func TestUpdateTargetStatus(t *testing.T) {
 											},
 											{
 												Health:    "down",
-												LastError: pointer.String("err x"),
+												LastError: ptr.To("err x"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "e",
 												},
 												LastScrapeDurationSeconds: "4.1",
 											},
 										},
-										Count: pointer.Int32(7),
+										Count: ptr.To(int32(7)),
 									},
 									{
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err y"),
+												LastError: ptr.To("err y"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "c",
 												},
 												LastScrapeDurationSeconds: "2.4",
 											},
 										},
-										Count: pointer.Int32(1),
+										Count: ptr.To(int32(1)),
 									},
 									{
 										SampleTargets: []monitoringv1.SampleTarget{
 											{
 												Health:    "down",
-												LastError: pointer.String("err z"),
+												LastError: ptr.To("err z"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "a",
 												},
@@ -1039,14 +1039,14 @@ func TestUpdateTargetStatus(t *testing.T) {
 											},
 											{
 												Health:    "down",
-												LastError: pointer.String("err z"),
+												LastError: ptr.To("err z"),
 												Labels: map[model.LabelName]model.LabelValue{
 													"instance": "d",
 												},
 												LastScrapeDurationSeconds: "4.7",
 											},
 										},
-										Count: pointer.Int32(2),
+										Count: ptr.To(int32(2)),
 									},
 								},
 								CollectorsFraction: "1",
@@ -1315,11 +1315,11 @@ func TestPolling(t *testing.T) {
 							Labels: map[model.LabelName]model.LabelValue{
 								"instance": "a",
 							},
-							LastError:                 pointer.String("err x"),
+							LastError:                 ptr.To("err x"),
 							LastScrapeDurationSeconds: "1.2",
 						},
 					},
-					Count: pointer.Int32(1),
+					Count: ptr.To(int32(1)),
 				},
 			},
 			CollectorsFraction: "1",
@@ -1349,11 +1349,11 @@ func TestPolling(t *testing.T) {
 							Labels: map[model.LabelName]model.LabelValue{
 								"instance": "a",
 							},
-							LastError:                 pointer.String("err y"),
+							LastError:                 ptr.To("err y"),
 							LastScrapeDurationSeconds: "5.4",
 						},
 					},
-					Count: pointer.Int32(1),
+					Count: ptr.To(int32(1)),
 				},
 			},
 			CollectorsFraction: "1",
@@ -1382,11 +1382,11 @@ func TestPolling(t *testing.T) {
 							Labels: map[model.LabelName]model.LabelValue{
 								"instance": "a",
 							},
-							LastError:                 pointer.String("err z"),
+							LastError:                 ptr.To("err z"),
 							LastScrapeDurationSeconds: "8.3",
 						},
 					},
-					Count: pointer.Int32(1),
+					Count: ptr.To(int32(1)),
 				},
 			},
 			CollectorsFraction: "1",

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -39,10 +39,12 @@ func TestScope(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("Unexpected input errors: %s", errs)
 	}
-	err := Scope(groups, map[string]string{
+	if err := Scope(groups, map[string]string{
 		"l1": "v1",
 		"l2": "v2",
-	})
+	}); err != nil {
+		t.Error(err)
+	}
 	want := `groups:
     - name: test
       rules:

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -57,7 +57,9 @@ func Handler(externalURL *url.URL) http.Handler {
 			idx = bytes.ReplaceAll(idx, []byte("CONSOLES_LINK_PLACEHOLDER"), []byte(""))
 			idx = bytes.ReplaceAll(idx, []byte("TITLE_PLACEHOLDER"), []byte("Google Cloud Managed Service for Prometheus"))
 
-			w.Write(idx)
+			if _, err := w.Write(idx); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
 		})
 	}
 


### PR DESCRIPTION
Consolidated fixes after running linters on operator package.

Summary:

- Unused arguments changed to `_`
- `k8s.io/utils/pointer` is deprecated. Replace with `k8s.io/utils/ptr`.
- error messages start with lowercase letter.
- Exported functions have comments
- Packages are only imported once (including aliases).
- "if block ends with a return statement, so drop else and outdent its block"

Resolved or ignored (by line) linter errors and enabled default linters for golangci-lint, plus gofmt linter.

Enabled `make lint` in CI.