### PR TITLE
fix: update self-pod-monitoring.yaml example to reduce ingestion of self-scraped metrics.

### DIFF
--- a/examples/self-pod-monitoring.yaml
+++ b/examples/self-pod-monitoring.yaml
@@ -26,9 +26,14 @@ spec:
       app.kubernetes.io/name: collector
   endpoints:
   - port: prom-metrics
-    interval: 10s
+    interval: 30s
+    metricRelabeling:
+    - sourceLabels: [__name__]
+      regex: > 
+            prometheus_target.*|prometheus_sd.*|net_conntrack_.*
+      action: drop
   - port: cfg-rel-metrics
-    interval: 10s
+    interval: 30s
 ---
 apiVersion: monitoring.googleapis.com/v1
 kind: PodMonitoring
@@ -44,6 +49,6 @@ spec:
       app.kubernetes.io/name: rule-evaluator
   endpoints:
   - port: r-eval-metrics
-    interval: 10s
+    interval: 30s
   - port: cfg-rel-metrics
-    interval: 10s
+    interval: 30s


### PR DESCRIPTION
This PR aims to reduce aim to reduct the amount of self-scraped metrics that are ingested.  

1. Increase the scrape interval to 30s.
2. Drop metrics with high cardinality.

Also resolves b/322791992 and part of https://github.com/GoogleCloudPlatform/prometheus-engine/issues/725