### PR TITLE
style: add additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,6 @@
 linters:
   enable:
-  - bodyclose
-  - dupl
   - dupword
-  - errname
   - godot
   - gofmt
   - loggercheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable:
   - dupword
+  - errname
   - godot
   - gofmt
   - loggercheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+  - bodyclose
   - dupword
   - errname
   - godot

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,15 @@
 linters:
   enable:
   - bodyclose
+  - dupl
   - dupword
   - errname
   - godot
   - gofmt
   - loggercheck
   - whitespace
+issues:
+  exclude-rules:
+  - path: _test\.go
+    linters:
+    - dupl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,8 +5,3 @@ linters:
   - gofmt
   - loggercheck
   - whitespace
-issues:
-  exclude-rules:
-  - path: _test\.go
-    linters:
-    - dupl

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -484,7 +484,7 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 	// Mark status updates in batch with single timestamp.
 	for _, nm := range NodeMons.Items {
 		if spec.KubeletScraping != nil && nm.Namespace == DefaultOperatorNamespace && (nm.Name == reservedKubeletJobName || nm.Name == reservedCAdvisorJobName) {
-			logger.Info("NodeMonitoring job %s was not applied because OperatorConfig.collector.kubeletScraping is enabled. kubeletScraping already includes the metrics in this job.", "name", nm.Name)
+			logger.Info("NodeMonitoring job was not applied because OperatorConfig.collector.kubeletScraping is enabled. kubeletScraping already includes the metrics in this job.", "name", nm.Name)
 			continue
 		}
 		// Reassign so we can safely get a pointer.

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -483,7 +483,7 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 	)
 	// Mark status updates in batch with single timestamp.
 	for _, nm := range NodeMons.Items {
-		if spec.KubeletScraping != nil && nm.Namespace == r.opts.OperatorNamespace && (nm.Name == reservedKubeletJobName || nm.Name == reservedCAdvisorJobName) {
+		if spec.KubeletScraping != nil && nm.Namespace == DefaultOperatorNamespace && (nm.Name == reservedKubeletJobName || nm.Name == reservedCAdvisorJobName) {
 			logger.Info("NodeMonitoring job %s was not applied because OperatorConfig.collector.kubeletScraping is enabled. kubeletScraping already includes the metrics in this job.", "name", nm.Name)
 			continue
 		}

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -483,7 +483,7 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 	)
 	// Mark status updates in batch with single timestamp.
 	for _, nm := range NodeMons.Items {
-		if spec.KubeletScraping != nil && nm.Namespace == DefaultOperatorNamespace && (nm.Name == reservedKubeletJobName || nm.Name == reservedCAdvisorJobName) {
+		if spec.KubeletScraping != nil && nm.Namespace == r.opts.OperatorNamespace && (nm.Name == reservedKubeletJobName || nm.Name == reservedCAdvisorJobName) {
 			logger.Info("NodeMonitoring job was not applied because OperatorConfig.collector.kubeletScraping is enabled. kubeletScraping already includes the metrics in this job.", "name", nm.Name)
 			continue
 		}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -207,7 +207,7 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 			Port:    port,
 			CertDir: certDir,
 		}),
-		// Don't run a metrics server with the manager. Metrics are being served.
+		// Don't run a metrics server with the manager. Metrics are being served explicitly in the main routine.
 		// explicitly in the main routine.
 		Metrics: metricsserver.Options{
 			BindAddress: "0",

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -207,7 +207,7 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 			Port:    port,
 			CertDir: certDir,
 		}),
-		// Don't run a metrics server with the manager. Metrics are being served explicitly in the main routine.
+		// Don't run a metrics server with the manager. Metrics are being served
 		// explicitly in the main routine.
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
@@ -386,7 +386,7 @@ func (o *Operator) Run(ctx context.Context, registry prometheus.Registerer) erro
 }
 
 func (o *Operator) cleanupOldResources(ctx context.Context) error {
-	// Delete old ValidatingWebhookConfiguration that was installed directly by the operator.
+	// Delete old ValidatingWebhookConfiguration that was installed directly by the operator
 	// in previous versions.
 	validatingWebhookConfig := arv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "gmp-operator"},


### PR DESCRIPTION
Add linters:

- loggercheck: Checks key value pairs for common logger libraries (kitlog,klog,logr,zap).
- godot: Check if comments end in a period.
- dupword: Checks for duplicate words in the source code.
- whitespace: Whitespace is a linter that checks for unnecessary newlines at the start and end of functions, if, for, etc.
- errname: Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error.
- bodyclose: Checks whether HTTP response body is closed successfully.
- dupl: Tool for code clone detection.