### PR TITLE
ci: change make lint command

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -34,12 +34,18 @@ jobs:
         fetch-depth: 0
     - uses: siderolabs/conform@v0.1.0-alpha.27
       name: Conform Action
-  lint:
+  golangci-lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Lint code with golangci-lint
-      run: make lint
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.55.2
+        args: --timeout=5m
   validate:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ conform:
 lint:        ## Lint code.
              ##
 	@echo ">> linting code"
-	DOCKER_BUILDKIT=1 docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.54.2 golangci-lint run -v --timeout=5m
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2 run --verbose --timeout 5m
 
 $(GOCMDS):   ## Build go binary from cmd/ (e.g. 'operator').
              ## The following env variables configure the build, and are mutually exclusive:


### PR DESCRIPTION
Using `go run` instead of running the binary inside of Docker reduces the linting time considerably, from on the order of a minute with Docker to about 3-5 seconds using `go run`.