### PR TITLE
Limit size of kind cluster names

### DIFF
--- a/hack/kind-test.sh
+++ b/hack/kind-test.sh
@@ -25,7 +25,12 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 TAG_NAME=$(date "+gmp-%Y%d%m_%H%M")
 TEST_ARGS=""
 # Convert kind cluster name to required regex if necessary.
-KIND_CLUSTER=`echo ${GO_TEST} | sed -r 's/([A-Z])/-\L\1/g' | sed 's/^-//'`
+# We need to ensure this name is not too long due to: https://github.com/kubernetes-sigs/kind/issues/623
+# while still unique enough to avoid dups between similar test names when trimming.
+# So we omit the Test* prefix and add a hash at the end.
+KIND_CLUSTER_HASH=`echo $RANDOM | md5sum | head -c4`
+KIND_CLUSTER=`echo ${GO_TEST#"Test"} | sed -r 's/([A-Z])/-\L\1/g' | sed 's/^-//' | head -c28`
+KIND_CLUSTER=${KIND_CLUSTER}-${KIND_CLUSTER_HASH}
 KUBECTL="kubectl --context kind-${KIND_CLUSTER}"
 # Ensure a unique label on any test data sent to GCM.
 GMP_CLUSTER=$TAG_NAME


### PR DESCRIPTION
Due to https://github.com/kubernetes-sigs/kind/issues/623, we need to
ensure we do not violate the length of a kind cluster's name.

We have been ensuring unique cluster names by using the name of the go
test function as the cluster name. However, for longer functions, we run
into this issue.

This change fixes the length of the name to 32 characters and appends a
random hash to the end of the name to prevent collisions for
similarly-named tests.