### PR TITLE
fix: remove replica count for rule-evaluator

### DIFF
--- a/cmd/operator/deploy/operator/11-rule-evaluator.yaml
+++ b/cmd/operator/deploy/operator/11-rule-evaluator.yaml
@@ -18,7 +18,6 @@ metadata:
   name: rule-evaluator
   namespace: gmp-system
 spec:
-  replicas: 1
   selector:
     matchLabels:
       # DO NOT MODIFY - label selectors are immutable by the Kubernetes API.

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -729,7 +729,6 @@ metadata:
   name: rule-evaluator
   namespace: gmp-system
 spec:
-  replicas: 1
   selector:
     matchLabels:
       # DO NOT MODIFY - label selectors are immutable by the Kubernetes API.


### PR DESCRIPTION
This was missed in #690, and needs to be fixed for autoscaling the rule-evaluator to work correctly on GKE.