### PR TITLE
fix: scale alertmanager/rule-evaluator using patch

### DIFF
--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -162,8 +162,9 @@ func (r *rulesReconciler) scaleRuleConsumers(ctx context.Context) error {
 	} else if err != nil {
 		return err
 	} else if *alertManagerStatefulSet.Spec.Replicas != desiredReplicas {
+		patch := client.MergeFrom(alertManagerStatefulSet.DeepCopy())
 		*alertManagerStatefulSet.Spec.Replicas = desiredReplicas
-		if err := r.client.Update(ctx, &alertManagerStatefulSet); err != nil {
+		if err := r.client.Patch(ctx, &alertManagerStatefulSet, patch); err != nil {
 			return err
 		}
 	}
@@ -175,8 +176,9 @@ func (r *rulesReconciler) scaleRuleConsumers(ctx context.Context) error {
 	} else if err != nil {
 		return err
 	} else if *ruleEvaluatorDeployment.Spec.Replicas != desiredReplicas {
+		patch := client.MergeFrom(ruleEvaluatorDeployment.DeepCopy())
 		*ruleEvaluatorDeployment.Spec.Replicas = desiredReplicas
-		if err := r.client.Update(ctx, &ruleEvaluatorDeployment); err != nil {
+		if err := r.client.Patch(ctx, &ruleEvaluatorDeployment, patch); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When using a get followed by an update, controller-runtime attempts to apply the metadata again, resulting in an error. If we generate and apply a patch instead, it will only modify the field that has changed.