### PR TITLE
fix: match exact test on e2e test matrix

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: set-testruns
-      run: echo "testrun=$(go test ./e2e/... -list=. | grep -E 'Test*' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+      run: echo "testrun=$(go test ./e2e/... -list=. | grep -E 'Test*' | jq -R -s -c 'split("\n")[:-1] | map("^" + . + "$")')" >> $GITHUB_OUTPUT
   e2e-test:
     runs-on: ubuntu-latest
     needs: [e2e-testruns]

--- a/hack/kind-test.sh
+++ b/hack/kind-test.sh
@@ -29,7 +29,7 @@ TEST_ARGS=""
 # while still unique enough to avoid dups between similar test names when trimming.
 # So we omit the Test* prefix and add a hash at the end.
 KIND_CLUSTER_HASH=`echo $RANDOM | md5sum | head -c4`
-KIND_CLUSTER=`echo ${GO_TEST#"Test"} | sed -r 's/([A-Z])/-\L\1/g' | sed 's/^-//' | head -c28`
+KIND_CLUSTER=`echo ${GO_TEST#"Test"} | sed -r 's/[^[:alnum:]]//g' | sed -r 's/([A-Z])/-\L\1/g' | sed 's/^-//' | head -c28`
 KIND_CLUSTER=${KIND_CLUSTER}-${KIND_CLUSTER_HASH}
 KUBECTL="kubectl --context kind-${KIND_CLUSTER}"
 # Ensure a unique label on any test data sent to GCM.


### PR DESCRIPTION
This fixes two issues:
1. `TEST_RUN` takes in a regular expression. After the recent refactoring, this no longer works. This is because we create a kind cluster with a name based off of the TEST_RUN. If there any special characters (e.g. from regular expressions), this fails.
2. If we add a new text that's a prefix or suffix of the same test, that test will be ran twice on GitHub. For example, if we have `TestA` and `TestAVariant`, then when GitHub runs `TestA`, it will run both tests within that runner and then it will run `TestAVariant` again in a separate runner. This is because Go takes in a regular expression when filtering tests and `TestA` matches both tests. We fix this by adding symbols for start and end of string, e.g. we run `TestA` with `^TestA$` to ensure it only runs `TestA`.