### PR TITLE
chore: fix dependabot commit scopes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,48 +5,48 @@ updates:
   schedule:
     interval: weekly
   commit-message:
-    prefix: fix(deps)
-    prefix-development: chore(deps)
+    prefix: fix
+    prefix-development: chore
     include: scope
 - package-ecosystem: docker
   directory: /cmd/rule-evaluator
   schedule:
     interval: weekly
   commit-message:
-    prefix: fix(deps)
-    prefix-development: chore(deps)
+    prefix: fix
+    prefix-development: chore
     include: scope
 - package-ecosystem: docker
   directory: /cmd/operator
   schedule:
     interval: weekly
   commit-message:
-    prefix: fix(deps)
-    prefix-development: chore(deps)
+    prefix: fix
+    prefix-development: chore
     include: scope
 - package-ecosystem: docker
   directory: /cmd/frontend
   schedule:
     interval: weekly
   commit-message:
-    prefix: fix(deps)
-    prefix-development: chore(deps)
+    prefix: fix
+    prefix-development: chore
     include: scope
 - package-ecosystem: docker
   directory: /cmd/config-reloader
   schedule:
     interval: weekly
   commit-message:
-    prefix: fix(deps)
-    prefix-development: chore(deps)
+    prefix: fix
+    prefix-development: chore
     include: scope
 - package-ecosystem: gomod
   directory: /
   schedule:
     interval: weekly
   commit-message:
-    prefix: fix(deps)
-    prefix-development: chore(deps)
+    prefix: fix
+    prefix-development: chore
     include: scope
   groups:
     # Group dep updates into one PR as single update already updates co-located deps.


### PR DESCRIPTION
Basically, dependabot tries to be smart. It detects the previous commit message, and then extrapolates based on that to determine how to to create the next one.

With `include: scope` on, we should not include the scope in the prefix, because [it will be included again](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb#L110).