### PR TITLE
chore: enable predeclared linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,6 @@ linters:
     - paralleltest
     - perfsprint
     - prealloc
-    - predeclared
     - promlinter
     - protogetter
     - revive

--- a/pkg/export/transform_test.go
+++ b/pkg/export/transform_test.go
@@ -48,8 +48,8 @@ func testMetadataFunc(metadata metricMetadataMap) MetadataFunc {
 	}
 }
 
-func wrapAsAny(any proto.Message) *anypb.Any {
-	result, err := anypb.New(any)
+func wrapAsAny(msg proto.Message) *anypb.Any {
+	result, err := anypb.New(msg)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
predeclared: `Find code that shadows one of Go's predeclared identifiers.`