### PR TITLE
style: enable misspell linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ linters:
     - lll
     - maintidx
     - maligned # Deprecated
-    - misspell
     - nestif
     - nilerr
     - nilnil

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -201,7 +201,7 @@ func main() {
 		v, warnings, err := QueryFunc(ctx, q, t, v1api)
 		if len(warnings) > 0 {
 			//nolint:errcheck
-			level.Warn(logger).Log("msg", "Querying Promethues instance returned warnings", "warn", warnings)
+			level.Warn(logger).Log("msg", "Querying Prometheus instance returned warnings", "warn", warnings)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("execute query: %w", err)

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -409,8 +409,8 @@ func (e *Exporter) ApplyConfig(cfg *config.Config) (err error) {
 	lset := builder.Labels()
 
 	// At this point we expect location and project ID to be set. They are effectively only a default
-	// however as they may be overriden by metric labels.
-	// In production scenarios, "location" should most likely never be overriden as it means crossing
+	// however as they may be overridden by metric labels.
+	// In production scenarios, "location" should most likely never be overridden as it means crossing
 	// failure domains. Instead, each location should run a replica of the evaluator with the same rules.
 	if lset.Get(KeyProjectID) == "" {
 		return fmt.Errorf("no label %q set via external labels or flag", KeyProjectID)

--- a/pkg/export/pool_test.go
+++ b/pkg/export/pool_test.go
@@ -28,7 +28,7 @@ func TestPool(t *testing.T) {
 	ts1 := &monitoring_pb.TimeSeries{
 		Resource: &monitoredres_pb.MonitoredResource{
 			Labels: map[string]string{
-				"resouce_k1":  "resource_v1",
+				"resource_k1": "resource_v1",
 				"resource_k2": "resource_v2",
 			},
 		},

--- a/pkg/export/series_cache.go
+++ b/pkg/export/series_cache.go
@@ -125,7 +125,7 @@ func (e *seriesCacheEntry) shouldRefresh() bool {
 
 // setNextRefresh determines a timestamp for the next refresh.
 func (e *seriesCacheEntry) setNextRefresh() {
-	// Randomly offset the timestamp around the targeted average so a bulk of simultaniously
+	// Randomly offset the timestamp around the targeted average so a bulk of simultaneously
 	// created series are not invalidated all at once, causing potential CPU and allocation
 	// spikes.
 	jitter := time.Duration((rand.Float64() - 0.5) * float64(refreshJitter))

--- a/pkg/export/transform.go
+++ b/pkg/export/transform.go
@@ -372,7 +372,7 @@ func isHistogramSeries(metric, name string) bool {
 // buildDistribution consumes series from the input slice and populates the histogram cache with it.
 // It returns when a series is consumed which completes a full distribution.
 // Once all series for a single distribution have been observed, it returns it.
-// It returns the reset timestamp along with the distrubution and the remaining samples.
+// It returns the reset timestamp along with the distribution and the remaining samples.
 func (b *sampleBuilder) buildDistribution(
 	metric string,
 	matchLset labels.Labels,
@@ -510,7 +510,7 @@ func buildExemplars(exemplars []record.RefExemplar) []*distribution_pb.Distribut
 //
 // The rest of the LabelSet will go into the DroppedLabels attachment. If one of the above
 // fields is missing, we will put the entire LabelSet into a DroppedLabels attachment.
-// This is to maintain comptability with CloudTrace.
+// This is to maintain compatibility with CloudTrace.
 // Note that the project_id needs to be the project_id where the span was written.
 // This may not necessarily be the same project_id where the metric was written.
 func buildExemplarAttachments(lset labels.Labels) []*anypb.Any {

--- a/pkg/export/transform_test.go
+++ b/pkg/export/transform_test.go
@@ -467,7 +467,7 @@ func TestSampleBuilder(t *testing.T) {
 			},
 			wantSeries: []*monitoring_pb.TimeSeries{
 				// First sample skipped to initialize reset handling.
-				// Second sample occured before first, panic.
+				// Second sample occurred before first, panic.
 			},
 		}, {
 			doc: "convert summary",

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -103,7 +103,7 @@ func TestEnsureCertsExplicit(t *testing.T) {
 			if err != nil && tc.expectErr {
 				return
 			}
-			// Test outputed files.
+			// Test outputted files.
 			outCert, outKey := readKeyAndCertFiles(dir, t)
 			if string(outCert) != tc.expectCert {
 				t.Errorf("want cert: %v; got %v", tc.opts.TLSCert, string(outCert))


### PR DESCRIPTION
misspell: `Finds commonly misspelled English words.`