### PR TITLE
chore: enable nilerr linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,6 @@ linters:
     - maligned # Deprecated
     - misspell
     - nestif
-    - nilerr
     - nilnil
     - nlreturn
     - noctx

--- a/pkg/operator/target_status_test.go
+++ b/pkg/operator/target_status_test.go
@@ -1380,7 +1380,7 @@ func TestPolling(t *testing.T) {
 		if pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 			var podMonitorings monitoringv1.PodMonitoringList
 			if err := kubeClient.List(ctx, &podMonitorings); err != nil {
-				return false, nil
+				return false, err
 			}
 			switch amount := len(podMonitorings.Items); amount {
 			case 0:


### PR DESCRIPTION
nilerr: `Finds the code that returns nil even if it checks that the error is not nil.`