### PR TITLE
style: enable revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,6 @@ linters:
     - prealloc
     - promlinter
     - protogetter
-    - revive
     - scopelint # Deprecated
     - structcheck # Deprecated
     - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,7 +83,150 @@ linters-settings:
       alias: metav1
     - pkg: "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
       alias: monitoringv1
+  revive:
+    enable-all-rules: true
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
+      - name: add-constant
+        severity: warning
+        disabled: true
+        arguments:
+          - maxLitCount: "3"
+            allowStrs: '""'
+            allowInts: "0,1,2"
+            allowFloats: "0.0,0.,1.0,1.,2.0,2."
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bare-return
+      - name: bare-return
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cognitive-complexity
+      - name: cognitive-complexity
+        severity: warning
+        disabled: true
+        arguments: [7]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comment-spacings
+      - name: comment-spacings
+        severity: warning
+        disabled: true
+        arguments:
+          - mypragma
+          - otherpragma
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-naming
+      - name: confusing-naming
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cyclomatic
+      - name: cyclomatic
+        severity: warning
+        disabled: true
+        arguments: [3]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#defer
+      - name: defer
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
+      - name: duplicated-imports
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
+      - name: exported
+        severity: warning
+        disabled: true
+        arguments:
+          - "checkPrivateReceivers"
+          - "disableStutteringCheck"
+          - "sayRepetitiveInsteadOfStutters"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#flag-parameter
+      - name: flag-parameter
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-length
+      - name: function-length
+        severity: warning
+        disabled: true
+        arguments: [10, 0]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-result-limit
+      - name: function-result-limit
+        severity: warning
+        disabled: true
+        arguments: [2]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
+      - name: if-return
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-alias-naming
+      - name: import-alias-naming
+        severity: warning
+        disabled: true
+        arguments:
+          - "^[a-z][a-z0-9]{0,}$"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-shadowing
+      - name: import-shadowing
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#line-length-limit
+      - name: line-length-limit
+        severity: warning
+        disabled: true
+        arguments: [80]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-public-structs
+      - name: max-public-structs
+        severity: warning
+        disabled: true
+        arguments: [3]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#package-comments
+      - name: package-comments
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-address
+      - name: range-val-address
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-import-alias
+      - name: redundant-import-alias
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
+      - name: struct-tag
+        arguments:
+          - "json,inline"
+          - "bson,outline,gnu"
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-equal
+      - name: time-equal
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unchecked-type-assertion
+      - name: unchecked-type-assertion
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
+      - name: unhandled-error
+        severity: warning
+        disabled: true
+        arguments:
+          - "fmt.Printf"
+          - "myFunction"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
+      - name: unused-receiver
+        severity: warning
+        disabled: true
+        arguments:
+          - allowRegex: "^_"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#use-any
+      - name: use-any
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
+      - name: useless-break
+        severity: warning
+        disabled: true
 issues:
+  exclude-use-default: false
+  exclude:
+    # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
   exclude-rules:
   - path: _test\.go
     linters:

--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -149,7 +149,7 @@ func main() {
 				}
 				return nil
 			},
-			func(err error) {
+			func(error) {
 				close(cancel)
 			},
 		)
@@ -162,7 +162,7 @@ func main() {
 			//nolint:errcheck
 			level.Info(logger).Log("msg", "Starting web server for metrics", "listen", *listenAddress)
 			return server.ListenAndServe()
-		}, func(err error) {
+		}, func(error) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			if err := server.Shutdown(ctx); err != nil {
 				//nolint:errcheck

--- a/cmd/datasource-syncer/main.go
+++ b/cmd/datasource-syncer/main.go
@@ -258,7 +258,7 @@ func buildUpdateDataSourceRequest(dataSource grafana.DataSource, token string) (
 			found = true
 			break
 		}
-		x += 1
+		x++
 	}
 
 	if !found {

--- a/cmd/datasource-syncer/main_test.go
+++ b/cmd/datasource-syncer/main_test.go
@@ -192,15 +192,15 @@ func TestBuildUpdateDataSourceRequest(t *testing.T) {
 				}
 				return
 			}
-			gotJson, err := json.Marshal(got)
+			gotJSON, err := json.Marshal(got)
 			if err != nil {
 				t.Fatalf("unmarshal gotJson failed with error: %v", err)
 			}
-			wantJson, err := json.Marshal(tt.want)
+			wantJSON, err := json.Marshal(tt.want)
 			if err != nil {
 				t.Fatalf("unmarshal wantJson failed with error: %v", err)
 			}
-			if diff := cmp.Diff(string(wantJson), string(gotJson)); diff != "" {
+			if diff := cmp.Diff(string(wantJSON), string(gotJSON)); diff != "" {
 				t.Fatalf("unexpected json config (-want, +got): %s", diff)
 			}
 		})

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -115,7 +115,7 @@ func main() {
 				}
 				return nil
 			},
-			func(err error) {
+			func(error) {
 				close(cancel)
 			},
 		)
@@ -138,11 +138,11 @@ func main() {
 		http.Handle("/metrics", promhttp.HandlerFor(metrics, promhttp.HandlerOpts{Registry: metrics}))
 		http.Handle("/api/", authenticate(forward(logger, targetURL, transport)))
 
-		http.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
+		http.HandleFunc("/-/healthy", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintf(w, "Prometheus frontend is Healthy.\n")
 		})
-		http.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
+		http.HandleFunc("/-/ready", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintf(w, "Prometheus frontend is Ready.\n")
 		})
@@ -153,7 +153,7 @@ func main() {
 			//nolint:errcheck
 			level.Info(logger).Log("msg", "Starting web server for metrics", "listen", *listenAddress)
 			return server.ListenAndServe()
-		}, func(err error) {
+		}, func(error) {
 			ctx, cancel = context.WithTimeout(ctx, time.Minute)
 			if err := server.Shutdown(ctx); err != nil {
 				//nolint:errcheck

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -130,7 +130,7 @@ func main() {
 				}
 				return nil
 			},
-			func(err error) {
+			func(error) {
 				close(cancel)
 			},
 		)
@@ -141,7 +141,7 @@ func main() {
 		http.Handle("/metrics", promhttp.HandlerFor(metrics, promhttp.HandlerOpts{Registry: metrics}))
 		g.Add(func() error {
 			return server.ListenAndServe()
-		}, func(err error) {
+		}, func(error) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			if err := server.Shutdown(ctx); err != nil {
 				logger.Error(err, "Server failed to shut down gracefully.")
@@ -154,7 +154,7 @@ func main() {
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {
 			return op.Run(ctx, metrics)
-		}, func(err error) {
+		}, func(error) {
 			cancel()
 		})
 	}

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -292,7 +292,7 @@ func main() {
 				}
 				return nil
 			},
-			func(err error) {
+			func(error) {
 				close(cancel)
 			},
 		)
@@ -314,7 +314,7 @@ func main() {
 			level.Info(logger).Log("msg", "Notification manager stopped")
 			return nil
 		},
-			func(err error) {
+			func(error) {
 				notificationManager.Stop()
 			},
 		)
@@ -328,7 +328,7 @@ func main() {
 				level.Info(logger).Log("msg", "Discovery manager stopped")
 				return err
 			},
-			func(err error) {
+			func(error) {
 				//nolint:errcheck
 				level.Info(logger).Log("msg", "Stopping Discovery manager...")
 				cancelDiscover()
@@ -366,10 +366,10 @@ func main() {
 				http.Error(w, "Only POST requests allowed.", http.StatusMethodNotAllowed)
 			}
 		})
-		http.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
+		http.HandleFunc("/-/healthy", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
-		http.HandleFunc("/-/ready", func(w http.ResponseWriter, r *http.Request) {
+		http.HandleFunc("/-/ready", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintf(w, "rule-evaluator is Ready.\n")
 		})
@@ -377,7 +377,7 @@ func main() {
 			//nolint:errcheck
 			level.Info(logger).Log("msg", "Starting web server", "listen", *listenAddress)
 			return server.ListenAndServe()
-		}, func(err error) {
+		}, func(error) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			if err := server.Shutdown(ctx); err != nil {
 				//nolint:errcheck
@@ -413,7 +413,7 @@ func main() {
 					}
 				}
 			},
-			func(err error) {
+			func(error) {
 				// Wait for any in-progress reloads to complete to avoid
 				// reloading things after they have been shutdown.
 				cancel <- struct{}{}
@@ -447,7 +447,7 @@ func QueryFunc(ctx context.Context, q string, t time.Time, v1api v1.API) (parser
 
 // sendAlerts returns the rules.NotifyFunc for a Notifier.
 func sendAlerts(s *notifier.Manager, externalURL string) rules.NotifyFunc {
-	return func(ctx context.Context, expr string, alerts ...*rules.Alert) {
+	return func(_ context.Context, expr string, alerts ...*rules.Alert) {
 		var res []*notifier.Alert
 		for _, alert := range alerts {
 			a := &notifier.Alert{

--- a/cmd/rule-evaluator/main_test.go
+++ b/cmd/rule-evaluator/main_test.go
@@ -86,7 +86,7 @@ func TestSelect(t *testing.T) {
 			db: &queryAccess{
 				mint: 1000,
 				maxt: 2000,
-				query: func(ctx context.Context, q string, timeValue time.Time, v1api v1.API) (parser.Value, v1.Warnings, error) {
+				query: func(_ context.Context, q string, timeValue time.Time, _ v1.API) (parser.Value, v1.Warnings, error) {
 					maxt := time.Unix(2000, 0)
 					expectedQuery := "{__name__=\"testLabel\"}[1000s]"
 					if q != expectedQuery {
@@ -112,7 +112,7 @@ func TestSelect(t *testing.T) {
 			db: &queryAccess{
 				mint: 1000,
 				maxt: 2000,
-				query: func(ctx context.Context, q string, timeValue time.Time, v1api v1.API) (parser.Value, v1.Warnings, error) {
+				query: func(context.Context, string, time.Time, v1.API) (parser.Value, v1.Warnings, error) {
 					return nil, nil, errors.New("Query Error")
 				},
 			},
@@ -132,7 +132,7 @@ func TestSelect(t *testing.T) {
 			description: "queryfunc returns a vector instead of a matrix",
 			db: &queryAccess{
 				maxt: 1000,
-				query: func(ctx context.Context, q string, timeValue time.Time, v1api v1.API) (parser.Value, v1.Warnings, error) {
+				query: func(context.Context, string, time.Time, v1.API) (parser.Value, v1.Warnings, error) {
 					return promql.Vector{}, nil, nil
 				},
 			},
@@ -146,7 +146,7 @@ func TestSelect(t *testing.T) {
 			db: &queryAccess{
 				mint: 0,
 				maxt: 1000,
-				query: func(ctx context.Context, q string, timeValue time.Time, v1api v1.API) (parser.Value, v1.Warnings, error) {
+				query: func(context.Context, string, time.Time, v1.API) (parser.Value, v1.Warnings, error) {
 					return promql.Matrix{}, v1.Warnings{"warning test"}, nil
 				},
 			},

--- a/e2e/alertmanager_test.go
+++ b/e2e/alertmanager_test.go
@@ -44,7 +44,7 @@ func TestAlertmanager(t *testing.T) {
 	t.Run("alertmanager-operatorconfig", testAlertmanagerOperatorConfig(ctx, t, kubeClient, opClient))
 }
 
-func testAlertmanagerDeployed(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface) func(*testing.T) {
+func testAlertmanagerDeployed(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("checking alertmanager is running")
 
@@ -95,7 +95,7 @@ func testAlertmanagerDeployed(ctx context.Context, t *testing.T, kubeClient kube
 	}
 }
 
-func testAlertmanagerOperatorConfig(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, opClient versioned.Interface) func(*testing.T) {
+func testAlertmanagerOperatorConfig(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface, opClient versioned.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("checking alertmanager is configured")
 

--- a/e2e/authorization_test.go
+++ b/e2e/authorization_test.go
@@ -530,7 +530,7 @@ func TestOAuth2ClusterPodMonitoring(t *testing.T) {
 	t.Run("oauth2-clusterpodmonitoring-failure", testEnsureClusterPodMonitoringFailure(ctx, t, opClient, cpmFail, "server returned HTTP status 401 Unauthorized"))
 }
 
-func testPatchExampleAppArgs(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, args []string) func(*testing.T) {
+func testPatchExampleAppArgs(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface, args []string) func(*testing.T) {
 	return func(t *testing.T) {
 		deploy, err := kubeClient.AppsV1().Deployments("default").Get(ctx, "go-synthetic", metav1.GetOptions{})
 		if err != nil {

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -142,7 +142,7 @@ func TestCollectorKubeletScraping(t *testing.T) {
 
 // testCollectorDeployed does a high-level verification on whether the
 // collector is deployed to the cluster.
-func testCollectorDeployed(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface) func(*testing.T) {
+func testCollectorDeployed(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("checking collector is running")
 
@@ -181,7 +181,7 @@ func testCollectorDeployed(ctx context.Context, t *testing.T, kubeClient kuberne
 	}
 }
 
-func testCollectorOperatorConfig(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, opClient versioned.Interface) func(*testing.T) {
+func testCollectorOperatorConfig(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface, opClient versioned.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("checking collector is configured")
 
@@ -257,7 +257,7 @@ func testEnsurePodMonitoringReady(ctx context.Context, t *testing.T, opClient ve
 
 // testEnsurePodMonitoringStatus sets up a PodMonitoring and runs validations against
 // its status with the provided function.
-func testEnsurePodMonitoringStatus(ctx context.Context, t *testing.T, opClient versioned.Interface, pm *monitoringv1.PodMonitoring, validate statusFn) func(*testing.T) {
+func testEnsurePodMonitoringStatus(ctx context.Context, _ *testing.T, opClient versioned.Interface, pm *monitoringv1.PodMonitoring, validate statusFn) func(*testing.T) {
 	// The operator should configure the collector to scrape itself and its metrics
 	// should show up in Cloud Monitoring shortly after.
 	return func(t *testing.T) {
@@ -317,7 +317,7 @@ func testEnsureClusterPodMonitoringReady(ctx context.Context, t *testing.T, opCl
 
 // testEnsureClusterPodMonitoringStatus sets up a ClusterPodMonitoring and runs
 // validations against its status with the provided function.
-func testEnsureClusterPodMonitoringStatus(ctx context.Context, t *testing.T, opClient versioned.Interface, cpm *monitoringv1.ClusterPodMonitoring, validate statusFn) func(*testing.T) {
+func testEnsureClusterPodMonitoringStatus(ctx context.Context, _ *testing.T, opClient versioned.Interface, cpm *monitoringv1.ClusterPodMonitoring, validate statusFn) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("ensuring ClusterPodMonitoring is created and ready")
 
@@ -370,7 +370,7 @@ func testEnsureClusterPodMonitoringStatus(ctx context.Context, t *testing.T, opC
 	}
 }
 
-func testEnableTargetStatus(ctx context.Context, t *testing.T, opClient versioned.Interface) func(*testing.T) {
+func testEnableTargetStatus(ctx context.Context, _ *testing.T, opClient versioned.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("enabling target status reporting")
 
@@ -389,7 +389,7 @@ func testEnableTargetStatus(ctx context.Context, t *testing.T, opClient versione
 	}
 }
 
-func testEnableKubeletScraping(ctx context.Context, t *testing.T, opClient versioned.Interface) func(*testing.T) {
+func testEnableKubeletScraping(ctx context.Context, _ *testing.T, opClient versioned.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("enabling kubelet scraping")
 
@@ -413,7 +413,7 @@ func testEnableKubeletScraping(ctx context.Context, t *testing.T, opClient versi
 
 // testValidateCollectorUpMetrics checks whether the scrape-time up metrics for all collector
 // pods can be queried from GCM.
-func testValidateCollectorUpMetrics(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, job string) func(*testing.T) {
+func testValidateCollectorUpMetrics(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface, job string) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("checking for metrics in Cloud Monitoring")
 
@@ -489,7 +489,7 @@ func testValidateCollectorUpMetrics(ctx context.Context, t *testing.T, kubeClien
 }
 
 // testCollectorScrapeKubelet verifies that kubelet metric endpoints are successfully scraped.
-func testCollectorScrapeKubelet(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface) func(*testing.T) {
+func testCollectorScrapeKubelet(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("checking for metrics in Cloud Monitoring")
 

--- a/e2e/ruler_test.go
+++ b/e2e/ruler_test.go
@@ -61,7 +61,7 @@ func TestRuleEvaluator(t *testing.T) {
 	}
 }
 
-func testRuleEvaluatorDeployed(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface) func(*testing.T) {
+func testRuleEvaluatorDeployed(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("checking rule-evaluator is running")
 
@@ -92,7 +92,7 @@ func testRuleEvaluatorDeployed(ctx context.Context, t *testing.T, kubeClient kub
 	}
 }
 
-func testRuleEvaluatorOperatorConfig(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, opClient versioned.Interface) func(*testing.T) {
+func testRuleEvaluatorOperatorConfig(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface, opClient versioned.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("checking rule-evaluator is configured")
 
@@ -149,7 +149,7 @@ func testRuleEvaluatorOperatorConfig(ctx context.Context, t *testing.T, kubeClie
 	}
 }
 
-func testRuleEvaluatorSecrets(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, opClient versioned.Interface) func(*testing.T) {
+func testRuleEvaluatorSecrets(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface, opClient versioned.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		cert, key, err := cert.GenerateSelfSignedCertKey("test", nil, nil)
 		if err != nil {
@@ -223,7 +223,7 @@ func testRuleEvaluatorSecrets(ctx context.Context, t *testing.T, kubeClient kube
 	}
 }
 
-func testRuleEvaluatorConfiguration(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface) func(*testing.T) {
+func testRuleEvaluatorConfiguration(ctx context.Context, _ *testing.T, kubeClient kubernetes.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		replace := func(s string) string {
 			return strings.NewReplacer(
@@ -301,7 +301,7 @@ rule_files:
 	}
 }
 
-func testCreateRules(ctx context.Context, t *testing.T, opClient versioned.Interface) func(*testing.T) {
+func testCreateRules(ctx context.Context, _ *testing.T, opClient versioned.Interface) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("creating rules")
 
@@ -332,7 +332,7 @@ func testCreateRules(ctx context.Context, t *testing.T, opClient versioned.Inter
 	}
 }
 
-func testValidateRuleEvaluationMetrics(ctx context.Context, t *testing.T) func(*testing.T) {
+func testValidateRuleEvaluationMetrics(ctx context.Context, _ *testing.T) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Log("checking for metrics in Cloud Monitoring")
 

--- a/pkg/export/bench/app/example_app.go
+++ b/pkg/export/bench/app/example_app.go
@@ -180,7 +180,7 @@ func main() {
 				}
 				return nil
 			},
-			func(err error) {
+			func(error) {
 				close(cancel)
 			},
 		)
@@ -191,7 +191,7 @@ func main() {
 
 		g.Add(func() error {
 			return server.ListenAndServe()
-		}, func(err error) {
+		}, func(error) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			if err := server.Shutdown(ctx); err != nil {
 				log.Printf("Server failed to shut down gracefully: %s", err)
@@ -205,7 +205,7 @@ func main() {
 			func() error {
 				return burnCPU(ctx, *cpuBurnOps)
 			},
-			func(err error) {
+			func(error) {
 				cancel()
 			},
 		)
@@ -216,7 +216,7 @@ func main() {
 			func() error {
 				return updateMetrics(ctx)
 			},
-			func(err error) {
+			func(error) {
 				cancel()
 			},
 		)
@@ -242,6 +242,7 @@ func burnCPU(ctx context.Context, ops int) error {
 		// Burn some CPU proportional to the input ops.
 		// This must be fixed work, i.e. we cannot spin for a fraction of scheduling will
 		// greatly affect how many times we spin, even without high CPU utilization.
+		//nolint:revive // Intentionally empty block
 		for i := 0; i < ops*20000000; i++ {
 		}
 

--- a/pkg/export/bench/server.go
+++ b/pkg/export/bench/server.go
@@ -67,7 +67,7 @@ type server struct {
 	latency time.Duration
 }
 
-func (srv *server) CreateTimeSeries(_ context.Context, req *monitoring_pb.CreateTimeSeriesRequest) (*emptypb.Empty, error) {
+func (srv *server) CreateTimeSeries(context.Context, *monitoring_pb.CreateTimeSeriesRequest) (*emptypb.Empty, error) {
 	time.Sleep(srv.latency)
 	return &emptypb.Empty{}, nil
 }

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -258,7 +258,7 @@ func (alwaysLease) Run(ctx context.Context) {
 	<-ctx.Done()
 }
 
-func (alwaysLease) OnLeaderChange(f func()) {
+func (alwaysLease) OnLeaderChange(func()) {
 	// We never lose the lease as it's always owned.
 }
 

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -114,7 +114,7 @@ func TestBatchFillFromShardsAndSend(t *testing.T) {
 
 	// When sending the batch we should see the right number of samples and all shards we pass should
 	// be notified at the end.
-	sendOne := func(ctx context.Context, req *monitoring_pb.CreateTimeSeriesRequest, opts ...gax.CallOption) error {
+	sendOne := func(_ context.Context, req *monitoring_pb.CreateTimeSeriesRequest, _ ...gax.CallOption) error {
 		mtx.Lock()
 		receivedSamples += len(req.TimeSeries)
 		mtx.Unlock()
@@ -331,7 +331,7 @@ type testMetricService struct {
 	samples                           []*monitoring_pb.TimeSeries
 }
 
-func (srv *testMetricService) CreateTimeSeries(ctx context.Context, req *monitoring_pb.CreateTimeSeriesRequest) (*empty_pb.Empty, error) {
+func (srv *testMetricService) CreateTimeSeries(_ context.Context, req *monitoring_pb.CreateTimeSeriesRequest) (*empty_pb.Empty, error) {
 	srv.samples = append(srv.samples, req.TimeSeries...)
 	return &empty_pb.Empty{}, nil
 }
@@ -369,7 +369,7 @@ func TestExporter_drainBacklog(t *testing.T) {
 	}
 	e.metricClient = metricClient
 
-	e.SetLabelsByIDFunc(func(i storage.SeriesRef) labels.Labels {
+	e.SetLabelsByIDFunc(func(storage.SeriesRef) labels.Labels {
 		return labels.FromStrings("project_id", "test", "location", "test")
 	})
 

--- a/pkg/export/gce_token_source.go
+++ b/pkg/export/gce_token_source.go
@@ -48,7 +48,7 @@ type AltTokenSource struct {
 func (a *AltTokenSource) Token() (*oauth2.Token, error) {
 	r := a.throttle.Reserve()
 	if !r.OK() {
-		return nil, fmt.Errorf("Rate limiter (rate: %f, burst: %d) cannot provide the requested token.",
+		return nil, fmt.Errorf("rate limiter (rate: %f, burst: %d) cannot provide the requested token",
 			a.throttle.Limit(), a.throttle.Burst())
 	}
 	time.Sleep(r.Delay())

--- a/pkg/export/gcm/promtest/promtest.go
+++ b/pkg/export/gcm/promtest/promtest.go
@@ -79,6 +79,8 @@ type backend struct {
 //
 // NOTE(bwplotka): All test functionality fails tests on error (instead of returning
 // error).
+//
+//nolint:revive // Intentional unexported return
 func NewIngestionTest(t testing.TB, backends []Backend) *ingestionTest {
 	t.Helper()
 

--- a/pkg/export/gcm/promtest/skip.go
+++ b/pkg/export/gcm/promtest/skip.go
@@ -29,13 +29,15 @@ func (n noopBackend) Ref() string {
 	return "noop"
 }
 
-func (n noopBackend) start(t testing.TB, env e2e.Environment) (api v1.API, extraLset map[string]string) {
+func (n noopBackend) start(testing.TB, e2e.Environment) (api v1.API, extraLset map[string]string) {
 	return
 }
 
-func (n noopBackend) injectScrapes(t testing.TB, scrapeRecordings [][]*dto.MetricFamily, timeout time.Duration) {
+func (n noopBackend) injectScrapes(testing.TB, [][]*dto.MetricFamily, time.Duration) {
 }
 
 // NoopBackend creates noop backend, useful when you want to skip one backend for
 // local debugging purpose without changing test significantly.
+//
+//nolint:revive // Intentional unexported return
 func NoopBackend() noopBackend { return noopBackend{} }

--- a/pkg/export/storage.go
+++ b/pkg/export/storage.go
@@ -88,7 +88,7 @@ func (s *Storage) clearLabels(samples []record.RefSample) {
 }
 
 // Appender returns a new Appender.
-func (s *Storage) Appender(ctx context.Context) storage.Appender {
+func (s *Storage) Appender(context.Context) storage.Appender {
 	return &storageAppender{
 		storage: s,
 		samples: make([]record.RefSample, 0, 64),

--- a/pkg/export/transform.go
+++ b/pkg/export/transform.go
@@ -246,10 +246,10 @@ func (d *distribution) reset() {
 
 func (d *distribution) inputSampleCount() (c int) {
 	if d.hasSum {
-		c += 1
+		c++
 	}
 	if d.hasCount {
-		c += 1
+		c++
 	}
 	return c + len(d.values)
 }
@@ -375,7 +375,7 @@ func isHistogramSeries(metric, name string) bool {
 // It returns the reset timestamp along with the distribution and the remaining samples.
 func (b *sampleBuilder) buildDistribution(
 	metric string,
-	matchLset labels.Labels,
+	_ labels.Labels,
 	samples []record.RefSample,
 	exemplars map[storage.SeriesRef]record.RefExemplar,
 	externalLabels labels.Labels,

--- a/pkg/operator/generated/clientset/versioned/typed/monitoring/v1/fake/fake_monitoring_client.go
+++ b/pkg/operator/generated/clientset/versioned/typed/monitoring/v1/fake/fake_monitoring_client.go
@@ -38,8 +38,8 @@ func (c *FakeMonitoringV1) GlobalRules() v1.GlobalRulesInterface {
 	return &FakeGlobalRules{c}
 }
 
-func (c *FakeMonitoringV1) NodeMonitorings(namespace string) v1.NodeMonitoringInterface {
-	return &FakeNodeMonitorings{c, namespace}
+func (c *FakeMonitoringV1) NodeMonitorings() v1.NodeMonitoringInterface {
+	return &FakeNodeMonitorings{c}
 }
 
 func (c *FakeMonitoringV1) OperatorConfigs(namespace string) v1.OperatorConfigInterface {

--- a/pkg/operator/generated/clientset/versioned/typed/monitoring/v1/fake/fake_nodemonitoring.go
+++ b/pkg/operator/generated/clientset/versioned/typed/monitoring/v1/fake/fake_nodemonitoring.go
@@ -30,7 +30,6 @@ import (
 // FakeNodeMonitorings implements NodeMonitoringInterface
 type FakeNodeMonitorings struct {
 	Fake *FakeMonitoringV1
-	ns   string
 }
 
 var nodemonitoringsResource = v1.SchemeGroupVersion.WithResource("nodemonitorings")
@@ -40,8 +39,7 @@ var nodemonitoringsKind = v1.SchemeGroupVersion.WithKind("NodeMonitoring")
 // Get takes name of the nodeMonitoring, and returns the corresponding nodeMonitoring object, and an error if there is any.
 func (c *FakeNodeMonitorings) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.NodeMonitoring, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(nodemonitoringsResource, c.ns, name), &v1.NodeMonitoring{})
-
+		Invokes(testing.NewRootGetAction(nodemonitoringsResource, name), &v1.NodeMonitoring{})
 	if obj == nil {
 		return nil, err
 	}
@@ -51,8 +49,7 @@ func (c *FakeNodeMonitorings) Get(ctx context.Context, name string, options meta
 // List takes label and field selectors, and returns the list of NodeMonitorings that match those selectors.
 func (c *FakeNodeMonitorings) List(ctx context.Context, opts metav1.ListOptions) (result *v1.NodeMonitoringList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(nodemonitoringsResource, nodemonitoringsKind, c.ns, opts), &v1.NodeMonitoringList{})
-
+		Invokes(testing.NewRootListAction(nodemonitoringsResource, nodemonitoringsKind, opts), &v1.NodeMonitoringList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -73,15 +70,13 @@ func (c *FakeNodeMonitorings) List(ctx context.Context, opts metav1.ListOptions)
 // Watch returns a watch.Interface that watches the requested nodeMonitorings.
 func (c *FakeNodeMonitorings) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(nodemonitoringsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(nodemonitoringsResource, opts))
 }
 
 // Create takes the representation of a nodeMonitoring and creates it.  Returns the server's representation of the nodeMonitoring, and an error, if there is any.
 func (c *FakeNodeMonitorings) Create(ctx context.Context, nodeMonitoring *v1.NodeMonitoring, opts metav1.CreateOptions) (result *v1.NodeMonitoring, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(nodemonitoringsResource, c.ns, nodeMonitoring), &v1.NodeMonitoring{})
-
+		Invokes(testing.NewRootCreateAction(nodemonitoringsResource, nodeMonitoring), &v1.NodeMonitoring{})
 	if obj == nil {
 		return nil, err
 	}
@@ -91,8 +86,7 @@ func (c *FakeNodeMonitorings) Create(ctx context.Context, nodeMonitoring *v1.Nod
 // Update takes the representation of a nodeMonitoring and updates it. Returns the server's representation of the nodeMonitoring, and an error, if there is any.
 func (c *FakeNodeMonitorings) Update(ctx context.Context, nodeMonitoring *v1.NodeMonitoring, opts metav1.UpdateOptions) (result *v1.NodeMonitoring, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(nodemonitoringsResource, c.ns, nodeMonitoring), &v1.NodeMonitoring{})
-
+		Invokes(testing.NewRootUpdateAction(nodemonitoringsResource, nodeMonitoring), &v1.NodeMonitoring{})
 	if obj == nil {
 		return nil, err
 	}
@@ -103,8 +97,7 @@ func (c *FakeNodeMonitorings) Update(ctx context.Context, nodeMonitoring *v1.Nod
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeNodeMonitorings) UpdateStatus(ctx context.Context, nodeMonitoring *v1.NodeMonitoring, opts metav1.UpdateOptions) (*v1.NodeMonitoring, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(nodemonitoringsResource, "status", c.ns, nodeMonitoring), &v1.NodeMonitoring{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(nodemonitoringsResource, "status", nodeMonitoring), &v1.NodeMonitoring{})
 	if obj == nil {
 		return nil, err
 	}
@@ -114,14 +107,13 @@ func (c *FakeNodeMonitorings) UpdateStatus(ctx context.Context, nodeMonitoring *
 // Delete takes name of the nodeMonitoring and deletes it. Returns an error if one occurs.
 func (c *FakeNodeMonitorings) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(nodemonitoringsResource, c.ns, name, opts), &v1.NodeMonitoring{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(nodemonitoringsResource, name, opts), &v1.NodeMonitoring{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeNodeMonitorings) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(nodemonitoringsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(nodemonitoringsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1.NodeMonitoringList{})
 	return err
@@ -130,8 +122,7 @@ func (c *FakeNodeMonitorings) DeleteCollection(ctx context.Context, opts metav1.
 // Patch applies the patch and returns the patched nodeMonitoring.
 func (c *FakeNodeMonitorings) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.NodeMonitoring, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(nodemonitoringsResource, c.ns, name, pt, data, subresources...), &v1.NodeMonitoring{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(nodemonitoringsResource, name, pt, data, subresources...), &v1.NodeMonitoring{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/operator/generated/clientset/versioned/typed/monitoring/v1/monitoring_client.go
+++ b/pkg/operator/generated/clientset/versioned/typed/monitoring/v1/monitoring_client.go
@@ -52,8 +52,8 @@ func (c *MonitoringV1Client) GlobalRules() GlobalRulesInterface {
 	return newGlobalRules(c)
 }
 
-func (c *MonitoringV1Client) NodeMonitorings(namespace string) NodeMonitoringInterface {
-	return newNodeMonitorings(c, namespace)
+func (c *MonitoringV1Client) NodeMonitorings() NodeMonitoringInterface {
+	return newNodeMonitorings(c)
 }
 
 func (c *MonitoringV1Client) OperatorConfigs(namespace string) OperatorConfigInterface {

--- a/pkg/operator/generated/clientset/versioned/typed/monitoring/v1/nodemonitoring.go
+++ b/pkg/operator/generated/clientset/versioned/typed/monitoring/v1/nodemonitoring.go
@@ -31,7 +31,7 @@ import (
 // NodeMonitoringsGetter has a method to return a NodeMonitoringInterface.
 // A group's client should implement this interface.
 type NodeMonitoringsGetter interface {
-	NodeMonitorings(namespace string) NodeMonitoringInterface
+	NodeMonitorings() NodeMonitoringInterface
 }
 
 // NodeMonitoringInterface has methods to work with NodeMonitoring resources.
@@ -51,14 +51,12 @@ type NodeMonitoringInterface interface {
 // nodeMonitorings implements NodeMonitoringInterface
 type nodeMonitorings struct {
 	client rest.Interface
-	ns     string
 }
 
 // newNodeMonitorings returns a NodeMonitorings
-func newNodeMonitorings(c *MonitoringV1Client, namespace string) *nodeMonitorings {
+func newNodeMonitorings(c *MonitoringV1Client) *nodeMonitorings {
 	return &nodeMonitorings{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -66,7 +64,6 @@ func newNodeMonitorings(c *MonitoringV1Client, namespace string) *nodeMonitoring
 func (c *nodeMonitorings) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.NodeMonitoring, err error) {
 	result = &v1.NodeMonitoring{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("nodemonitorings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -83,7 +80,6 @@ func (c *nodeMonitorings) List(ctx context.Context, opts metav1.ListOptions) (re
 	}
 	result = &v1.NodeMonitoringList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("nodemonitorings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -100,7 +96,6 @@ func (c *nodeMonitorings) Watch(ctx context.Context, opts metav1.ListOptions) (w
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("nodemonitorings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -111,7 +106,6 @@ func (c *nodeMonitorings) Watch(ctx context.Context, opts metav1.ListOptions) (w
 func (c *nodeMonitorings) Create(ctx context.Context, nodeMonitoring *v1.NodeMonitoring, opts metav1.CreateOptions) (result *v1.NodeMonitoring, err error) {
 	result = &v1.NodeMonitoring{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("nodemonitorings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(nodeMonitoring).
@@ -124,7 +118,6 @@ func (c *nodeMonitorings) Create(ctx context.Context, nodeMonitoring *v1.NodeMon
 func (c *nodeMonitorings) Update(ctx context.Context, nodeMonitoring *v1.NodeMonitoring, opts metav1.UpdateOptions) (result *v1.NodeMonitoring, err error) {
 	result = &v1.NodeMonitoring{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("nodemonitorings").
 		Name(nodeMonitoring.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -139,7 +132,6 @@ func (c *nodeMonitorings) Update(ctx context.Context, nodeMonitoring *v1.NodeMon
 func (c *nodeMonitorings) UpdateStatus(ctx context.Context, nodeMonitoring *v1.NodeMonitoring, opts metav1.UpdateOptions) (result *v1.NodeMonitoring, err error) {
 	result = &v1.NodeMonitoring{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("nodemonitorings").
 		Name(nodeMonitoring.Name).
 		SubResource("status").
@@ -153,7 +145,6 @@ func (c *nodeMonitorings) UpdateStatus(ctx context.Context, nodeMonitoring *v1.N
 // Delete takes name of the nodeMonitoring and deletes it. Returns an error if one occurs.
 func (c *nodeMonitorings) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("nodemonitorings").
 		Name(name).
 		Body(&opts).
@@ -168,7 +159,6 @@ func (c *nodeMonitorings) DeleteCollection(ctx context.Context, opts metav1.Dele
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("nodemonitorings").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -181,7 +171,6 @@ func (c *nodeMonitorings) DeleteCollection(ctx context.Context, opts metav1.Dele
 func (c *nodeMonitorings) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.NodeMonitoring, err error) {
 	result = &v1.NodeMonitoring{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("nodemonitorings").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -213,7 +213,7 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 			BindAddress: "0",
 		},
 		// Manage cluster-wide and namespace resources at the same time.
-		NewCache: cache.NewCacheFunc(func(config *rest.Config, options cache.Options) (cache.Cache, error) {
+		NewCache: cache.NewCacheFunc(func(_ *rest.Config, options cache.Options) (cache.Cache, error) {
 			return cache.New(clientConfig, cache.Options{
 				Scheme: options.Scheme,
 

--- a/pkg/operator/target_status.go
+++ b/pkg/operator/target_status.go
@@ -116,7 +116,7 @@ func setupTargetStatusPoller(op *Operator, registry prometheus.Registerer, httpC
 	}
 
 	// Start the controller only once.
-	if err := op.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
+	if err := op.manager.Add(manager.RunnableFunc(func(context.Context) error {
 		reconciler.ch <- event.GenericEvent{
 			Object: &appsv1.DaemonSet{},
 		}

--- a/pkg/operator/target_status_test.go
+++ b/pkg/operator/target_status_test.go
@@ -137,7 +137,7 @@ func podMonitoringScrapePoolToClusterPodMonitoringScrapePool(podMonitoringScrape
 }
 
 func targetFetchFromMap(m map[string]*prometheusv1.TargetsResult) getTargetFn {
-	return func(_ context.Context, _ logr.Logger, httpClient *http.Client, port int32, pod *corev1.Pod) (*prometheusv1.TargetsResult, error) {
+	return func(_ context.Context, _ logr.Logger, _ *http.Client, port int32, pod *corev1.Pod) (*prometheusv1.TargetsResult, error) {
 		key := getPodKey(pod, port)
 		targetsResult, ok := m[key]
 		if !ok {

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -41,7 +41,7 @@ func Handler(externalURL *url.URL) http.Handler {
 		"/graph",
 	}
 	for _, p := range reactRouterPaths {
-		mux.HandleFunc(p, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(p, func(w http.ResponseWriter, _ *http.Request) {
 			f, err := Assets.Open("/static/react/index.html")
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Revive is a meta-linter with many available rules, fixes were made in accordance with these default rules:

- empty-block
- error-strings
- increment-decrement
- indent-error-flow
- receiver-naming
- unexported-return
- unused-parameter
- var-naming

See [Revive Available Rules](https://github.com/mgechev/revive?tab=readme-ov-file#available-rules) for details.

Then, enabled all revive rules. Disabled all currently failing rules, to be evaluated on a case-by-case basis for future inclusion.