### PR TITLE
style: enable usestdlibvars linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,7 +69,6 @@ linters:
     - thelper
     - tparallel
     - unparam
-    - usestdlibvars
     - varcheck # Deprecated
     - varnamelen
     - wastedassign

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -356,7 +356,7 @@ func main() {
 
 		http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
 		http.HandleFunc("/-/reload", func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == "POST" {
+			if r.Method == http.MethodPost {
 				rc := make(chan error)
 				reloadCh <- rc
 				if err := <-rc; err != nil {

--- a/pkg/export/gce_token_source.go
+++ b/pkg/export/gce_token_source.go
@@ -55,7 +55,7 @@ func (a *AltTokenSource) Token() (*oauth2.Token, error) {
 	return a.token()
 }
 func (a *AltTokenSource) token() (*oauth2.Token, error) {
-	req, err := http.NewRequest("POST", a.tokenURL, strings.NewReader(a.tokenBody))
+	req, err := http.NewRequest(http.MethodPost, a.tokenURL, strings.NewReader(a.tokenBody))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
usestdlibvars: A linter that detect the possibility to use variables/constants from the Go standard library.