### PR TITLE
cleanup: use exact tags in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ DOCKER_HOST?=unix:///var/run/docker.sock
 DOCKER_VOLUME:=$(DOCKER_HOST:unix://%=%)
 
 IMAGE_REGISTRY?=gcr.io/$(PROJECT_ID)/prometheus-engine
-TAG_NAME?=$(shell date "+gmp-%Y%d%m_%H%M")
+TAG_NAME:=$(shell date "+gmp-%Y%d%m_%H%M")
 
 # If an individual test is not specified, run them all.
 TEST_RUN?=$(shell go test ./e2e/... -list=. | grep -E 'Test*')
@@ -46,7 +46,7 @@ SED?=$(shell which gsed 2>/dev/null || which sed)
 # TODO(pintohutch): this is a bit hacky, but can be useful when testing.
 # Ultimately this should be replaced with go templating.
 define update_manifests
-	find manifests examples -type f -name "*.yaml" -exec sed -i "s#image: .*/$(1):.*#image: ${IMAGE_REGISTRY}/$(1):${TAG_NAME}#g" {} \;
+	find manifests examples -type f -name "*.yaml" -exec sed -i "s#image: .*/$(1):.*#image: ${IMAGE_REGISTRY}/$(1):$(TAG_NAME)#g" {} \;
 endef
 
 define docker_build
@@ -113,9 +113,9 @@ ifeq ($(NO_DOCKER), 1)
 	CGO_ENABLED=0 go build -tags builtinassets -mod=vendor -o ./build/bin/$(BIN_GO_NAME) ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/*.go
 # If pushing, build and tag native arch image to GCR.
 else ifeq ($(DOCKER_PUSH), 1)
-	$(call docker_build, --tag gmp/$(BIN_GO_NAME) -f ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/Dockerfile .)
+	$(call docker_build, --tag gmp/$(BIN_GO_NAME):$(TAG_NAME) -f ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/Dockerfile .)
 	@echo ">> tagging and pushing images"
-	$(call docker_tag_push,gmp/$(BIN_GO_NAME),${IMAGE_REGISTRY}/$(BIN_GO_NAME):${TAG_NAME})
+	$(call docker_tag_push,gmp/$(BIN_GO_NAME):$(TAG_NAME),${IMAGE_REGISTRY}/$(BIN_GO_NAME):$(TAG_NAME))
 	@echo ">> updating manifests with pushed images"
 	$(call update_manifests,$(BIN_GO_NAME))
 # Run on cloudbuild and tag multi-arch image to GCR.
@@ -126,7 +126,7 @@ else ifeq ($(CLOUD_BUILD), 1)
 	$(call update_manifests,$(BIN_GO_NAME))
 # Just build it locally.
 else
-	$(call docker_build, --tag gmp/$(BIN_GO_NAME) -f ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/Dockerfile .)
+	$(call docker_build, --tag gmp/$(BIN_GO_NAME):$(TAG_NAME) -f ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/Dockerfile .)
 endif
 
 bin:         ## Build all go binaries from cmd/ and examples/instrumentation/.
@@ -221,6 +221,7 @@ e2e-only:    ## Run e2e test suite without rebuilding images. This assumes that
 		--env PROJECT_ID="$(PROJECT_ID)" \
 		--env GMP_LOCATION="$(GMP_LOCATION)" \
 		--env BINARIES="$(E2E_DEPS)" \
+		--env TAG_NAME=$(TAG_NAME) \
 		--env REGISTRY_NAME=$(REGISTRY_NAME) \
 		--env REGISTRY_PORT=$(REGISTRY_PORT) \
 		--network host \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ DOCKER_HOST?=unix:///var/run/docker.sock
 DOCKER_VOLUME:=$(DOCKER_HOST:unix://%=%)
 
 IMAGE_REGISTRY?=gcr.io/$(PROJECT_ID)/prometheus-engine
-TAG_NAME:=$(shell date "+gmp-%Y%d%m_%H%M")
+export TAG_NAME?=$(shell date "+gmp-%Y%d%m_%H%M")
 
 # If an individual test is not specified, run them all.
 TEST_RUN?=$(shell go test ./e2e/... -list=. | grep -E 'Test*')

--- a/examples/pod-monitoring.yaml
+++ b/examples/pod-monitoring.yaml
@@ -25,3 +25,9 @@ spec:
   endpoints:
   - port: metrics
     interval: 30s
+  targetLabels:
+    metadata:
+    # omitting workload_controller labels here will revert the change.
+    - pod
+    - container
+    - node

--- a/hack/kind-test.sh
+++ b/hack/kind-test.sh
@@ -22,7 +22,6 @@ set -o pipefail
 GO_TEST=$1
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-TAG_NAME=$(date "+gmp-%Y%d%m_%H%M")
 TEST_ARGS=""
 # Convert kind cluster name to required regex if necessary.
 # We need to ensure this name is not too long due to: https://github.com/kubernetes-sigs/kind/issues/623
@@ -132,7 +131,7 @@ docker_tag_push() {
   for bin in "$@"; do
     REGISTRY_TAG=localhost:${REGISTRY_PORT}/${bin}:${TAG_NAME}
     echo ">>> tagging and pushing image: ${bin}"
-    docker tag gmp/${bin} ${REGISTRY_TAG}
+    docker tag gmp/${bin}:${TAG_NAME} ${REGISTRY_TAG}
     docker push ${REGISTRY_TAG}
   done
 }


### PR DESCRIPTION
Before we were implicitly using the `latest` tags, which aren't guaranteed to be the same tags of the "currently built" images for the test (i.e. it's possible another process is building a `latest` tag). This is pretty rare in practice, but this tightens up the logic to avoid the situation entirely.