### PR TITLE
chore: use gmp-bot token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,5 +29,5 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE }}
           release-type: go


### PR DESCRIPTION
This is expected to resolve the issue where the release-please PR is being created by the GitHub Actions bot, which is not approved for the CLA.