### PR TITLE
chore: add main to allowed commit scopes

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -41,6 +41,7 @@ policies:
         scopes:
           - configs
           - deps
+          - main
           - operator
           - prometheus
         descriptionLength: 72


### PR DESCRIPTION
Add `main` as allowed commit message scope for Conform rules.