### PR TITLE
chore: update to upload-artifact@v4

### DIFF
--- a/.github/workflows/auto-assign-pr-schedule.yml
+++ b/.github/workflows/auto-assign-pr-schedule.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         mkdir -p ./pr
         echo ${{ github.event.number }} > ./pr/NR
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: auto-assign-pr
         path: pr/


### PR DESCRIPTION
Upload-artifact@v3 uses deprecated Node.js 16.