### PR TITLE
refactor(e2e): use consistent tag name when building images at the same time

### DIFF
--- a/hack/kind-test.sh
+++ b/hack/kind-test.sh
@@ -22,7 +22,6 @@ set -o pipefail
 GO_TEST=$1
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-TAG_NAME=$(date "+gmp-%Y%d%m_%H%M")
 TEST_ARGS=""
 # Convert kind cluster name to required regex if necessary.
 # We need to ensure this name is not too long due to: https://github.com/kubernetes-sigs/kind/issues/623


### PR DESCRIPTION
tl;dr: this ensures that when you run `make e2e`, all Docker images are built with the same tag.

Another try for https://github.com/GoogleCloudPlatform/prometheus-engine/pull/845 (thanks @pintohutch)

## How this works
1. The problem is we call `$(MAKE)` which calls and forks `make` without carrying variables over. This is fixed by using `export`.
2. The second problem is that `make` has rules for variable expansion. `=` and `?=` are considered "recursively expansions" which you can think of as lazily evaluated. `:=` is considered "simply expanded" and is evaluated at declaration time. This is what we want to ensure it's only evaluated once.
3. Now that we export the value correctly to targets, we need to make sure we don't override it, so we add the conditional.
4. We still use the latest tag for e2e tests because we need this for the `e2e-only` target which does not rebuild all images. This needs to be conditional so I'll fix this in a separate PR.
5. I added nanoseconds to the tag which helps with testing but also better so we reduce the odds of mutating tags for older images.