### PR TITLE
chore: release from release branches

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
       - main
+      - release/**
 
 permissions:
   contents: write


### PR DESCRIPTION
In addition to releasing from `main`, release on release branches.