### PR TITLE
chore: automate export.go version bump

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+    "extra-files": [
+        "pkg/export/export.go"
+    ]
+}

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -530,7 +530,7 @@ const (
 	ClientName = "prometheus-engine-export"
 	// mainModuleVersion is the version of the main module. Align with git tag.
 	// TODO(TheSpiritXIII): Remove with https://github.com/golang/go/issues/50603
-	mainModuleVersion = "v0.10.0-rc.1"
+	mainModuleVersion = "v0.10.0-rc.1" // x-release-please-version
 	// mainModuleName is the name of the main module. Align with go.mod.
 	mainModuleName = "github.com/GoogleCloudPlatform/prometheus-engine"
 )
@@ -569,11 +569,6 @@ func Version() (string, error) {
 			version = strings.TrimSpace(stdout.String())
 		}
 
-		if version != mainModuleVersion {
-			return "", fmt.Errorf("export version %q does not match tag %q", mainModuleVersion, version)
-		}
-
-		// To prevent breaking in unit tests.
 		return version, nil
 	}
 


### PR DESCRIPTION
Automatically bump the version in `export.go` with release-please.