### PR TITLE
chore: reference release-please manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,0 @@
-{
-    "extra-files": [
-        "pkg/export/export.go"
-    ]
-}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "go",
+  "include-component-in-tag": false,
+  "packages": {
+    ".": {
+      "extra-files": [
+        "pkg/export/export.go"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This should cause release-please to read the manifest file that specifies it should update the version in `export.go`.