### PR TITLE
refactor: cleanup rule-evaluator Helm chart

### DIFF
--- a/charts/rule-evaluator/Chart.yaml
+++ b/charts/rule-evaluator/Chart.yaml
@@ -15,9 +15,6 @@
 apiVersion: v2
 name: rule-evaluator
 description: Prometheus Rule Evaluator
-
 type: application
-
 version: 0.1.0
-
-appVersion: "0.9.0"
+appVersion: 0.9.0

--- a/charts/rule-evaluator/templates/_helpers.tpl
+++ b/charts/rule-evaluator/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "rule-evaluator.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -11,35 +11,36 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "rule-evaluator.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+  {{- if .Values.fullnameOverride }}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "rule-evaluator.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
 {{- define "rule-evaluator.labels" -}}
-helm.sh/chart: {{ include "rule-evaluator.chart" . }}
-{{ include "rule-evaluator.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/name: {{ include "rule-evaluator.name" . }}
+  {{- if not .Values.noCommonLabels }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ eq .Release.Name "release-name" | ternary (printf "%s-%s" ( include "rule-evaluator.name" . ) .Chart.AppVersion) .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+helm.sh/chart: {{ include "rule-evaluator.chart" . }}
+  {{- end }}
 {{- end }}
 
 {{/*
@@ -47,16 +48,23 @@ Selector labels
 */}}
 {{- define "rule-evaluator.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "rule-evaluator.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Template labels
+*/}}
+{{- define "rule-evaluator.templateLabels" -}}
+{{- include "rule-evaluator.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
 {{- define "rule-evaluator.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "rule-evaluator.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+  {{- if .Values.serviceAccount.create }}
+    {{- default (include "rule-evaluator.fullname" .) .Values.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.serviceAccount.name }}
+  {{- end }}
 {{- end }}

--- a/charts/rule-evaluator/templates/configmaps.yaml
+++ b/charts/rule-evaluator/templates/configmaps.yaml
@@ -18,7 +18,7 @@ kind: ConfigMap
 metadata:
   name: rule-evaluator
   labels:
-    app.kubernetes.io/name: rule-evaluator
+    {{- include "rule-evaluator.labels" . | nindent 4 }}
 data:
   config.yaml: |
     global:
@@ -33,7 +33,7 @@ kind: ConfigMap
 metadata:
   name: rules
   labels:
-    app.kubernetes.io/name: rule-evaluator
+    {{- include "rule-evaluator.labels" . | nindent 4 }}
 data:
   rules.yaml: |
     groups:

--- a/charts/rule-evaluator/templates/deployment.yaml
+++ b/charts/rule-evaluator/templates/deployment.yaml
@@ -18,18 +18,17 @@ kind: Deployment
 metadata:
   name: rule-evaluator
   labels:
-    app.kubernetes.io/name: rule-evaluator
+    {{- include "rule-evaluator.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: rule-evaluator
+      {{- include "rule-evaluator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.9.0
+        {{- include "rule-evaluator.templateLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: rule-evaluator
+      serviceAccountName: {{ include "rule-evaluator.serviceAccountName" . }}
       automountServiceAccountToken: true
       initContainers:
       - name: config-init
@@ -52,12 +51,7 @@ spec:
         - name: cfg-rel-metrics
           protocol: TCP
           containerPort: 9093
-        resources:
-          limits:
-            memory: 32M
-          requests:
-            cpu: 1m
-            memory: 4M
+        resources: {{- toYaml $.Values.resources.configReloader | nindent 10}}
         volumeMounts:
         - name: config
           readOnly: true
@@ -81,12 +75,7 @@ spec:
         ports:
         - name: r-eval-metrics
           containerPort: 9092
-        resources:
-          limits:
-            memory: 1G
-          requests:
-            cpu: 1m
-            memory: 16M
+        resources: {{- toYaml $.Values.resources.ruleEvaluator | nindent 10}}
         volumeMounts:
         - name: config-out
           readOnly: true

--- a/charts/rule-evaluator/templates/role.yaml
+++ b/charts/rule-evaluator/templates/role.yaml
@@ -13,10 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: rule-evaluator
+  {{- if not .Values.noCommonLabels }}
+  labels:
+    {{- include "rule-evaluator.labels" . | nindent 4 }}
+  {{- end }}
 rules:
 - resources:
   - endpoints
@@ -32,3 +37,4 @@ rules:
   verbs: ["get"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
+{{- end -}}

--- a/charts/rule-evaluator/templates/rolebinding.yaml
+++ b/charts/rule-evaluator/templates/rolebinding.yaml
@@ -13,10 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: rule-evaluator
+  {{- if not .Values.noCommonLabels }}
+  labels:
+    {{- include "rule-evaluator.labels" . | nindent 4 }}
+  {{- end }}
 roleRef:
   name: rule-evaluator
   kind: ClusterRole
@@ -25,3 +30,4 @@ subjects:
 - name: rule-evaluator
   namespace: default
   kind: ServiceAccount
+{{- end -}}

--- a/charts/rule-evaluator/templates/service-account.yaml
+++ b/charts/rule-evaluator/templates/service-account.yaml
@@ -13,7 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rule-evaluator
+  name: {{ include "rule-evaluator.serviceAccountName" . }}
+  {{- if not .Values.noCommonLabels }}
+  labels:
+    {{- include "rule-evaluator.labels" . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/rule-evaluator/values.yaml
+++ b/charts/rule-evaluator/values.yaml
@@ -42,3 +42,8 @@ resources:
     requests:
       cpu: 1m
       memory: 16M
+rbac:
+  create: true
+serviceAccount:
+  create: true
+  name: rule-evaluator

--- a/hack/presubmit.sh
+++ b/hack/presubmit.sh
@@ -112,7 +112,7 @@ update_manifests() {
 
   combine $CRD_DIR ${REPO_ROOT}/manifests/setup.yaml
   ${HELM} template ${REPO_ROOT}/charts/operator > ${REPO_ROOT}/manifests/operator.yaml
-  ${HELM} template ${REPO_ROOT}/charts/rule-evaluator > ${REPO_ROOT}/manifests/rule-evaluator.yaml
+  ${HELM} template --set noCommonLabels=true "${REPO_ROOT}/charts/rule-evaluator" > "${REPO_ROOT}/manifests/rule-evaluator.yaml"
   ${ADDLICENSE} ${REPO_ROOT}/manifests/*.yaml
 }
 


### PR DESCRIPTION
See comparison: https://github.com/GoogleCloudPlatform/prometheus-engine/blob/v0.10.0-rc.2/manifests/rule-evaluator.yaml

- Added indentation to templates [as per best practices](https://helm.sh/docs/chart_best_practices/templates/#formatting-templates).
- Added standard labels to all resources [as per best practices](https://helm.sh/docs/chart_best_practices/labels/#standard-labels).
- Added a flag `noCommonLabels` which disables standard labels. Setting this flags to `true` gives you our original labels.
- Fixed our deployment pod now correctly uses the `AppVersion` variable.
- We're now using the previously-defined `serviceAccount` variables.
- Added a `rbac` variable [as per best practices](https://helm.sh/docs/chart_best_practices/rbac/#yaml-configuration).
- Fixed consistency around quoting our version. I decided for no quotes because:
  1. We're using SemVer, so YAML should never interpret the value as a floating point, and;
  2. We never used to quote it.