### PR TITLE
refactor: cleanup operator Helm chart

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v2
 name: prometheus-engine
 description: Google Managed Service for Prometheus (GMP) Operator
 type: application
-version: "0.1.0"
-appVersion: "0.9.0"
+version: 0.1.0
+appVersion: 0.9.0

--- a/charts/operator/templates/_helpers.tpl
+++ b/charts/operator/templates/_helpers.tpl
@@ -48,11 +48,14 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "prometheus-engine.labels" -}}
-{{ include "prometheus-engine.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- if not .Values.noCommonLabels -}}
+app.kubernetes.io/name: {{ include "prometheus-engine.name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ eq .Release.Name "release-name" | ternary (printf "%s-%s" ( include "prometheus-engine.name" . ) .Chart.AppVersion) .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/part-of: {{ eq .Release.Name "release-name" | ternary "gmp" .Release.Name }}
+helm.sh/chart: {{ include "prometheus-engine.chart" . }}
+  {{- end }}
 {{- end }}
 
 {{/*
@@ -63,12 +66,128 @@ app.kubernetes.io/name: {{ include "prometheus-engine.name" . }}
 {{- end }}
 
 {{/*
-Create the name of the service account to use
+Operator labels
 */}}
-{{- define "prometheus-engine.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "prometheus-engine.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- define "prometheus-engine.operator.labels" -}}
+app: managed-prometheus-operator
+app.kubernetes.io/component: operator
+app.kubernetes.io/name: gmp-operator
+  {{- if not .Values.noCommonLabels }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ eq .Release.Name "release-name" | ternary (printf "%s-%s" ( include "prometheus-engine.name" . ) .Chart.AppVersion) .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  {{- end }}
+app.kubernetes.io/part-of: {{ eq .Release.Name "release-name" | ternary "gmp" .Release.Name }}
+  {{- if not .Values.noCommonLabels }}
+helm.sh/chart: {{ include "prometheus-engine.chart" . }}
+  {{- end }}
 {{- end }}
+
+{{/*
+Operator selector labels
+*/}}
+{{- define "prometheus-engine.operator.selectorLabels" -}}
+app.kubernetes.io/component: operator
+app.kubernetes.io/name: gmp-operator
+app.kubernetes.io/part-of: {{ eq .Release.Name "release-name" | ternary "gmp" .Release.Name }}
+{{- end }}
+
+{{/*
+Operator template labels
+*/}}
+{{- define "prometheus-engine.operator.templateLabels" -}}
+app: managed-prometheus-operator
+{{ include "prometheus-engine.operator.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Collector labels
+*/}}
+{{- define "prometheus-engine.collector.labels" -}}
+{{ include "prometheus-engine.labels" . }}
+{{- end }}
+
+{{/*
+Collector selector labels
+*/}}
+{{- define "prometheus-engine.collector.selectorLabels" -}}
+app.kubernetes.io/name: collector
+{{- end }}
+
+{{/*
+Collector template labels
+*/}}
+{{- define "prometheus-engine.collector.templateLabels" -}}
+app: managed-prometheus-collector
+{{ include "prometheus-engine.collector.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Rule-evaluator labels
+*/}}
+{{- define "prometheus-engine.rule-evaluator.labels" -}}
+{{ include "prometheus-engine.labels" . }}
+{{- end }}
+
+{{/*
+Rule-evaluator selector labels
+*/}}
+{{- define "prometheus-engine.rule-evaluator.selectorLabels" -}}
+app.kubernetes.io/name: rule-evaluator
+{{- end }}
+
+{{/*
+Rule-evaluator template labels
+*/}}
+{{- define "prometheus-engine.rule-evaluator.templateLabels" -}}
+{{ include "prometheus-engine.rule-evaluator.selectorLabels" . }}
+app: managed-prometheus-rule-evaluator
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Alertmanager labels
+*/}}
+{{- define "prometheus-engine.alertmanager.labels" -}}
+{{ include "prometheus-engine.labels" . }}
+{{- end }}
+
+{{/*
+Alertmanager selector labels
+*/}}
+{{- define "prometheus-engine.alertmanager.selectorLabels" -}}
+app: managed-prometheus-alertmanager
+app.kubernetes.io/name: alertmanager
+{{- end }}
+
+{{/*
+Alertmanager template labels
+*/}}
+{{- define "prometheus-engine.alertmanager.templateLabels" -}}
+{{ include "prometheus-engine.alertmanager.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Create the name of the collector service account to use
+*/}}
+{{- define "prometheus-engine.collector.serviceAccountName" -}}
+  {{- if .Values.collector.serviceAccount.create }}
+    {{- default "collector" .Values.collector.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.collector.serviceAccount.name }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Create the name of the operator service account to use
+*/}}
+{{- define "prometheus-engine.operator.serviceAccountName" -}}
+  {{- if .Values.operator.serviceAccount.create }}
+    {{- default "operator" .Values.operator.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.operator.serviceAccount.name }}
+  {{- end }}
 {{- end }}

--- a/charts/operator/templates/alertmanager.yaml
+++ b/charts/operator/templates/alertmanager.yaml
@@ -18,11 +18,13 @@ kind: Service
 metadata:
   name: alertmanager
   namespace: {{.Values.namespace.system}}
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
-    app.kubernetes.io/name: alertmanager
+    {{- include "prometheus-engine.alertmanager.selectorLabels" . | nindent 4 }}
   ports:
   - name: alertmanager
     port: 9093
@@ -34,19 +36,20 @@ kind: StatefulSet
 metadata:
   name: alertmanager
   namespace: {{.Values.namespace.system}}
+  {{- if not .Values.noCommonLabels }}
   labels:
-    {{- include "prometheus-engine.labels" . | nindent 4 }}
+    {{- include "prometheus-engine.alertmanager.labels" . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
-      app: managed-prometheus-alertmanager
-      app.kubernetes.io/name: alertmanager
+      # DO NOT MODIFY - label selectors are immutable by the Kubernetes API.
+      # see: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector.
+      {{- include "prometheus-engine.alertmanager.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: managed-prometheus-alertmanager
-        app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.9.0
+        {{- include "prometheus-engine.alertmanager.templateLabels" . | nindent 8 }}
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus

--- a/charts/operator/templates/collector.yaml
+++ b/charts/operator/templates/collector.yaml
@@ -18,27 +18,27 @@ kind: DaemonSet
 metadata:
   name: collector
   namespace: {{.Values.namespace.system}}
+  {{- if not .Values.noCommonLabels }}
   labels:
-    {{- include "prometheus-engine.labels" . | nindent 4 }}
+    {{- include "prometheus-engine.collector.labels" . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
       # DO NOT MODIFY - label selectors are immutable by the Kubernetes API.
-      # see: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector
-      app.kubernetes.io/name: collector
+      # see: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector.
+      {{- include "prometheus-engine.collector.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: managed-prometheus-collector
-        app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.9.0
+        {{- include "prometheus-engine.collector.templateLabels" . | nindent 8 }}
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
     spec:
-      serviceAccountName: collector
+      serviceAccountName: {{ include "prometheus-engine.collector.serviceAccountName" . }}
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       initContainers:

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -20,26 +20,20 @@ metadata:
   name: gmp-operator
   namespace: {{.Values.namespace.system}}
   labels:
-    {{- include "prometheus-engine.labels" . | nindent 4 }}
-    app: managed-prometheus-operator
-    app.kubernetes.io/component: operator
+    {{- include "prometheus-engine.operator.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: operator
-      app.kubernetes.io/name: gmp-operator
-      app.kubernetes.io/part-of: gmp
+      # DO NOT MODIFY - label selectors are immutable by the Kubernetes API.
+      # see: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#label-selector-updates.
+      {{- include "prometheus-engine.operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: managed-prometheus-operator
-        app.kubernetes.io/component: operator
-        app.kubernetes.io/name: gmp-operator
-        app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.9.0
+        {{- include "prometheus-engine.operator.templateLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: operator
+      serviceAccountName: {{ include "prometheus-engine.operator.serviceAccountName" . }}
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:

--- a/charts/operator/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/operator/templates/mutatingwebhookconfiguration.yaml
@@ -17,8 +17,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: gmp-operator.gmp-system.monitoring.googleapis.com
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 webhooks:
 - name: default.podmonitorings.gmp-operator.gmp-system.monitoring.googleapis.com
   admissionReviewVersions:

--- a/charts/operator/templates/namespace.yaml
+++ b/charts/operator/templates/namespace.yaml
@@ -17,12 +17,16 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{.Values.namespace.system}}
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{.Values.namespace.public}}
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}

--- a/charts/operator/templates/priority-class.yaml
+++ b/charts/operator/templates/priority-class.yaml
@@ -17,8 +17,10 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: gmp-critical
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 # Maximum allowed user-defined. Only system-node-critical and system-cluster-critical
 # pods are higher.
 value: 1000000000

--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -13,12 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
+{{- if .Values.collector.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gmp-system:collector
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 rules:
 - resources:
   - endpoints
@@ -34,14 +37,20 @@ rules:
   verbs: ["get"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
+{{- end }}
+{{- if .Values.operator.rbac.create -}}
+  {{- if .Values.collector.rbac.create }}
 ---
+  {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: operator
   namespace: {{.Values.namespace.system}}
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 rules:
 - resources:
   - pods
@@ -95,6 +104,10 @@ kind: Role
 metadata:
   name: operator
   namespace: {{.Values.namespace.public}}
+  {{- if not .Values.noCommonLabels }}
+  labels:
+    {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 rules:
 - resources:
   - secrets
@@ -137,6 +150,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gmp-system:operator:webhook-admin
+  {{- if not .Values.noCommonLabels }}
+  labels:
+    {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 rules:
 # Permission to inject CA bundles into webhook configs of fixed name.
 - resources:
@@ -155,3 +172,4 @@ rules:
   resourceNames:
   - gmp-operator
   verbs: ["delete"]
+{{- end -}}

--- a/charts/operator/templates/rolebinding.yaml
+++ b/charts/operator/templates/rolebinding.yaml
@@ -13,12 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
+{{- if .Values.collector.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gmp-system:operator
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 roleRef:
   name: gmp-system:operator
   kind: ClusterRole
@@ -32,8 +35,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gmp-system:operator:webhook-admin
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 roleRef:
   name: gmp-system:operator:webhook-admin
   kind: ClusterRole
@@ -47,9 +52,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: operator
-  labels:
-    {{- include "prometheus-engine.labels" . | nindent 4 }}
   namespace: {{.Values.namespace.public}}
+  {{- if not .Values.noCommonLabels }}
+  labels:
+    {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 roleRef:
   name: operator
   kind: Role
@@ -64,8 +71,10 @@ kind: RoleBinding
 metadata:
   name: operator
   namespace: {{.Values.namespace.system}}
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 roleRef:
   name: operator
   kind: Role
@@ -73,13 +82,19 @@ roleRef:
 subjects:
 - name: operator
   kind: ServiceAccount
+{{- end }}
+{{- if .Values.collector.rbac.create -}}
+  {{- if .Values.operator.rbac.create }}
 ---
+  {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gmp-system:collector
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 roleRef:
   name: gmp-system:collector
   kind: ClusterRole
@@ -88,3 +103,4 @@ subjects:
 - name: collector
   namespace: {{.Values.namespace.system}}
   kind: ServiceAccount
+{{- end -}}

--- a/charts/operator/templates/rule-evaluator.yaml
+++ b/charts/operator/templates/rule-evaluator.yaml
@@ -18,20 +18,20 @@ kind: Deployment
 metadata:
   name: rule-evaluator
   namespace: {{.Values.namespace.system}}
+  {{- if not .Values.noCommonLabels }}
   labels:
-    {{- include "prometheus-engine.labels" . | nindent 4 }}
+    {{- include "prometheus-engine.rule-evaluator.labels" . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
       # DO NOT MODIFY - label selectors are immutable by the Kubernetes API.
       # see: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#label-selector-updates.
-      app.kubernetes.io/name: rule-evaluator
+      {{- include "prometheus-engine.rule-evaluator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: managed-prometheus-rule-evaluator
-        app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.9.0
+        {{- include "prometheus-engine.rule-evaluator.templateLabels" . | nindent 8 }}
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.

--- a/charts/operator/templates/service-account.yaml
+++ b/charts/operator/templates/service-account.yaml
@@ -13,18 +13,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 */}}
+{{- if .Values.collector.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: collector
+  name: {{ include "prometheus-engine.collector.serviceAccountName" . }}
   namespace: {{.Values.namespace.system}}
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.operator.serviceAccount.create }}
+  {{- if .Values.collector.serviceAccount.create }}
 ---
+  {{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: operator
+  name: {{ include "prometheus-engine.operator.serviceAccountName" . }}
   namespace: {{.Values.namespace.system}}
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/operator/templates/service.yaml
+++ b/charts/operator/templates/service.yaml
@@ -18,13 +18,13 @@ kind: Service
 metadata:
   name: gmp-operator
   namespace: {{.Values.namespace.system}}
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/name: gmp-operator
-    app.kubernetes.io/part-of: gmp
+    {{- include "prometheus-engine.operator.selectorLabels" . | nindent 4 }}
   ports:
   # This port does not do anything, but allows upgrades in the case
   # of server-side apply (SSA) conflicts.

--- a/charts/operator/templates/validatingwebhookconfiguration.yaml
+++ b/charts/operator/templates/validatingwebhookconfiguration.yaml
@@ -17,8 +17,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: gmp-operator.gmp-system.monitoring.googleapis.com
+  {{- if not .Values.noCommonLabels }}
   labels:
     {{- include "prometheus-engine.labels" . | nindent 4 }}
+  {{- end }}
 webhooks:
 - name: validate.podmonitorings.gmp-operator.gmp-system.monitoring.googleapis.com
   admissionReviewVersions:

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -77,3 +77,13 @@ tls:
     ca: null
     cert: null
     key: null
+collector:
+  rbac:
+    create: true
+  serviceAccount:
+    create: true
+operator:
+  rbac:
+    create: true
+  serviceAccount:
+    create: true

--- a/hack/presubmit.sh
+++ b/hack/presubmit.sh
@@ -35,6 +35,7 @@ warn() {
 }
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+CRD_DIR=${REPO_ROOT}/charts/operator/crds
 
 codegen_diff() {
   git fetch https://github.com/GoogleCloudPlatform/prometheus-engine
@@ -82,7 +83,6 @@ update_crdgen() {
   which controller-gen || go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 
   API_DIR=${REPO_ROOT}/pkg/operator/apis/...
-  CRD_DIR=${REPO_ROOT}/charts/operator/crds
 
   controller-gen crd paths=./$API_DIR output:crd:dir=$CRD_DIR
 
@@ -111,7 +111,7 @@ update_manifests() {
   echo ">>> regenerating example yamls"
 
   combine $CRD_DIR ${REPO_ROOT}/manifests/setup.yaml
-  ${HELM} template ${REPO_ROOT}/charts/operator > ${REPO_ROOT}/manifests/operator.yaml
+  ${HELM} template --set noCommonLabels=true "${REPO_ROOT}/charts/operator" > "${REPO_ROOT}/manifests/operator.yaml"
   ${HELM} template --set noCommonLabels=true "${REPO_ROOT}/charts/rule-evaluator" > "${REPO_ROOT}/manifests/rule-evaluator.yaml"
   ${ADDLICENSE} ${REPO_ROOT}/manifests/*.yaml
 }

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -18,10 +18,6 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: gmp-critical
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 # Maximum allowed user-defined. Only system-node-critical and system-cluster-critical
 # pods are higher.
 value: 1000000000
@@ -32,20 +28,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gmp-system
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 ---
 # Source: prometheus-engine/templates/namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: gmp-public
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 ---
 # Source: prometheus-engine/templates/service-account.yaml
 apiVersion: v1
@@ -53,10 +41,6 @@ kind: ServiceAccount
 metadata:
   name: collector
   namespace: gmp-system
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 ---
 # Source: prometheus-engine/templates/service-account.yaml
 apiVersion: v1
@@ -64,20 +48,12 @@ kind: ServiceAccount
 metadata:
   name: operator
   namespace: gmp-system
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 ---
 # Source: prometheus-engine/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gmp-system:collector
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 rules:
 - resources:
   - endpoints
@@ -152,10 +128,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gmp-system:operator
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 roleRef:
   name: gmp-system:operator
   kind: ClusterRole
@@ -170,10 +142,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gmp-system:operator:webhook-admin
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 roleRef:
   name: gmp-system:operator:webhook-admin
   kind: ClusterRole
@@ -188,10 +156,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gmp-system:collector
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 roleRef:
   name: gmp-system:collector
   kind: ClusterRole
@@ -207,10 +171,6 @@ kind: Role
 metadata:
   name: operator
   namespace: gmp-system
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 rules:
 - resources:
   - pods
@@ -280,10 +240,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: operator
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
   namespace: gmp-public
 roleRef:
   name: operator
@@ -300,10 +256,6 @@ kind: RoleBinding
 metadata:
   name: operator
   namespace: gmp-system
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 roleRef:
   name: operator
   kind: Role
@@ -318,12 +270,9 @@ kind: Service
 metadata:
   name: alertmanager
   namespace: gmp-system
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 spec:
   selector:
+    app: managed-prometheus-alertmanager
     app.kubernetes.io/name: alertmanager
   ports:
   - name: alertmanager
@@ -337,10 +286,6 @@ kind: Service
 metadata:
   name: gmp-operator
   namespace: gmp-system
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 spec:
   selector:
     app.kubernetes.io/component: operator
@@ -365,15 +310,11 @@ kind: DaemonSet
 metadata:
   name: collector
   namespace: gmp-system
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 spec:
   selector:
     matchLabels:
       # DO NOT MODIFY - label selectors are immutable by the Kubernetes API.
-      # see: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector
+      # see: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector.
       app.kubernetes.io/name: collector
   template:
     metadata:
@@ -544,15 +485,16 @@ metadata:
   name: gmp-operator
   namespace: gmp-system
   labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
     app: managed-prometheus-operator
     app.kubernetes.io/component: operator
+    app.kubernetes.io/name: gmp-operator
+    app.kubernetes.io/part-of: gmp
 spec:
   replicas: 1
   selector:
     matchLabels:
+      # DO NOT MODIFY - label selectors are immutable by the Kubernetes API.
+      # see: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#label-selector-updates.
       app.kubernetes.io/component: operator
       app.kubernetes.io/name: gmp-operator
       app.kubernetes.io/part-of: gmp
@@ -632,10 +574,6 @@ kind: Deployment
 metadata:
   name: rule-evaluator
   namespace: gmp-system
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 spec:
   selector:
     matchLabels:
@@ -645,8 +583,8 @@ spec:
   template:
     metadata:
       labels:
-        app: managed-prometheus-rule-evaluator
         app.kubernetes.io/name: rule-evaluator
+        app: managed-prometheus-rule-evaluator
         app.kubernetes.io/version: 0.9.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
@@ -800,13 +738,11 @@ kind: StatefulSet
 metadata:
   name: alertmanager
   namespace: gmp-system
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 spec:
   selector:
     matchLabels:
+      # DO NOT MODIFY - label selectors are immutable by the Kubernetes API.
+      # see: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector.
       app: managed-prometheus-alertmanager
       app.kubernetes.io/name: alertmanager
   template:
@@ -948,10 +884,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: gmp-operator.gmp-system.monitoring.googleapis.com
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 webhooks:
 - name: default.podmonitorings.gmp-operator.gmp-system.monitoring.googleapis.com
   admissionReviewVersions:
@@ -1005,19 +937,12 @@ metadata:
   name: config
   namespace: gmp-public
   labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 ---
 # Source: prometheus-engine/templates/validatingwebhookconfiguration.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: gmp-operator.gmp-system.monitoring.googleapis.com
-  labels:
-    app.kubernetes.io/name: prometheus-engine
-    app.kubernetes.io/version: "0.9.0"
-    app.kubernetes.io/part-of: gmp
 webhooks:
 - name: validate.podmonitorings.gmp-operator.gmp-system.monitoring.googleapis.com
   admissionReviewVersions:


### PR DESCRIPTION
## What?
Updated labels to match 1:1 to our last 0.10.0 version.

See comparison: https://github.com/GoogleCloudPlatform/prometheus-engine/blob/v0.10.0-rc.2/manifests/operator.yaml

## Why?
The concern is that users will start to depend on these new labels (e.g. scaling), which would make it difficult to remove them in the future.

## How?
- Added indentation to templates [as per best practices](https://helm.sh/docs/chart_best_practices/templates/#formatting-templates).
- Added standard labels to all resources [as per best practices](https://helm.sh/docs/chart_best_practices/labels/#standard-labels).
- Added a flag `noCommonLabels` which disables standard labels. Setting this flags to `true` gives you our original labels.
- Fixed our deployment pod now correctly uses the `AppVersion` variable.
- We're now using the previously-defined `serviceAccount` variables.
- Added a `rbac` variable [as per best practices](https://helm.sh/docs/chart_best_practices/rbac/#yaml-configuration).
- Fixed consistency around quoting our version. I decided for no quotes because:
  1. We're using SemVer, so YAML should never interpret the value as a floating point, and;
  2. We never used to quote it.
- Updated the rule-evaluator service to match the same selector as the Pod selector.