### PR TITLE
feat: export write from collectors to central prometheus example

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_operatorconfigs.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_operatorconfigs.yaml
@@ -39,7 +39,9 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           collection:
-            description: Collection specifies how the operator configures collection.
+            description: |-
+              Collection specifies how the operator configures collection including
+              integrated exports to Google Cloud Monitoring.
             properties:
               compression:
                 description: Compression enables compression of metrics collection
@@ -78,11 +80,12 @@ spec:
                   type: string
                 description: |-
                   ExternalLabels specifies external labels that are attached to all scraped
-                  data before being written to Cloud Monitoring. The precedence behavior matches that
-                  of Prometheus.
+                  data before being written to Google Cloud Monitoring or any other additional exports
+                  specified in the OperatorConfig. The precedence behavior matches that of Prometheus.
                 type: object
               filter:
-                description: Filter limits which metric data is sent to Cloud Monitoring.
+                description: Filter limits which metric data is sent to Cloud Monitoring(Doesn't
+                  apply to additional exports).
                 properties:
                   matchOneOf:
                     description: |-
@@ -109,6 +112,19 @@ spec:
                 - interval
                 type: object
             type: object
+          exports:
+            description: |-
+              Exports specifies additional exporting mechanism on top of Google Cloud Monitoring collection.
+              Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in Collection.
+            items:
+              properties:
+                url:
+                  description: The URL of the endpoint to export samples to.
+                  type: string
+              required:
+              - url
+              type: object
+            type: array
           features:
             description: Features holds configuration for optional managed-collection
               features.

--- a/charts/operator/crds/monitoring.googleapis.com_operatorconfigs.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_operatorconfigs.yaml
@@ -40,8 +40,8 @@ spec:
             type: string
           collection:
             description: |-
-              Collection specifies how the operator configures collection including
-              integrated exports to Google Cloud Monitoring.
+              Collection specifies how the operator configures collection, including
+              scraping and an integrated export to Google Cloud Monitoring.
             properties:
               compression:
                 description: Compression enables compression of metrics collection
@@ -84,8 +84,8 @@ spec:
                   specified in the OperatorConfig. The precedence behavior matches that of Prometheus.
                 type: object
               filter:
-                description: Filter limits which metric data is sent to Cloud Monitoring(Doesn't
-                  apply to additional exports).
+                description: Filter limits which metric data is sent to Cloud Monitoring
+                  (it doesn't apply to additional exports).
                 properties:
                   matchOneOf:
                     description: |-
@@ -114,12 +114,14 @@ spec:
             type: object
           exports:
             description: |-
-              Exports specifies additional exporting mechanism on top of Google Cloud Monitoring collection.
-              Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in Collection.
+              Exports is an EXPERIMENTAL feature that specifies additional, optional endpoints to export to,
+              on top of Google Cloud Monitoring collection.
+              Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in the "collection.filter" field.
             items:
               properties:
                 url:
-                  description: The URL of the endpoint to export samples to.
+                  description: The URL of the endpoint that supports Prometheus Remote
+                    Write to export samples to.
                   type: string
               required:
               - url

--- a/doc/api.md
+++ b/doc/api.md
@@ -754,7 +754,7 @@ ExportFilters
 </em>
 </td>
 <td>
-<p>Filter limits which metric data is sent to Cloud Monitoring(Doesn&rsquo;t apply to additional exports).</p>
+<p>Filter limits which metric data is sent to Cloud Monitoring (it doesn&rsquo;t apply to additional exports).</p>
 </td>
 </tr>
 <tr>
@@ -918,7 +918,7 @@ string
 </em>
 </td>
 <td>
-<p>The URL of the endpoint to export samples to.</p>
+<p>The URL of the endpoint that supports Prometheus Remote Write to export samples to.</p>
 </td>
 </tr>
 </tbody>
@@ -1526,8 +1526,8 @@ CollectionSpec
 </em>
 </td>
 <td>
-<p>Collection specifies how the operator configures collection including
-integrated exports to Google Cloud Monitoring.</p>
+<p>Collection specifies how the operator configures collection, including
+scraping and an integrated export to Google Cloud Monitoring.</p>
 </td>
 </tr>
 <tr>
@@ -1540,8 +1540,9 @@ integrated exports to Google Cloud Monitoring.</p>
 </em>
 </td>
 <td>
-<p>Exports specifies additional exporting mechanism on top of Google Cloud Monitoring collection.
-Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in Collection.</p>
+<p>Exports is an EXPERIMENTAL feature that specifies additional, optional endpoints to export to,
+on top of Google Cloud Monitoring collection.
+Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in the &ldquo;collection.filter&rdquo; field.</p>
 </td>
 </tr>
 <tr>

--- a/doc/api.md
+++ b/doc/api.md
@@ -38,6 +38,8 @@ Resource Types:
 </li><li>
 <a href="#monitoring.googleapis.com/v1.ExportFilters">ExportFilters</a>
 </li><li>
+<a href="#monitoring.googleapis.com/v1.ExportSpec">ExportSpec</a>
+</li><li>
 <a href="#monitoring.googleapis.com/v1.GlobalRules">GlobalRules</a>
 </li><li>
 <a href="#monitoring.googleapis.com/v1.HTTPClientConfig">HTTPClientConfig</a>
@@ -738,8 +740,8 @@ map[string]string
 </td>
 <td>
 <p>ExternalLabels specifies external labels that are attached to all scraped
-data before being written to Cloud Monitoring. The precedence behavior matches that
-of Prometheus.</p>
+data before being written to Google Cloud Monitoring or any other additional exports
+specified in the OperatorConfig. The precedence behavior matches that of Prometheus.</p>
 </td>
 </tr>
 <tr>
@@ -752,7 +754,7 @@ ExportFilters
 </em>
 </td>
 <td>
-<p>Filter limits which metric data is sent to Cloud Monitoring.</p>
+<p>Filter limits which metric data is sent to Cloud Monitoring(Doesn&rsquo;t apply to additional exports).</p>
 </td>
 </tr>
 <tr>
@@ -887,6 +889,36 @@ and/or PodMonitoring.</p>
 of the matchers to be exported. This field can be used equivalently to the match[]
 parameter of the Prometheus federation endpoint to selectively export data.
 Example: <code>[&quot;{job!='foobar'}&quot;, &quot;{__name__!~'container_foo.*|container_bar.*'}&quot;]</code></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="monitoring.googleapis.com/v1.ExportSpec">
+<span id="ExportSpec">ExportSpec
+</span>
+</h3>
+<p>
+(<em>Appears in: </em><a href="#monitoring.googleapis.com/v1.OperatorConfig">OperatorConfig</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>url</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The URL of the endpoint to export samples to.</p>
 </td>
 </tr>
 </tbody>
@@ -1494,7 +1526,22 @@ CollectionSpec
 </em>
 </td>
 <td>
-<p>Collection specifies how the operator configures collection.</p>
+<p>Collection specifies how the operator configures collection including
+integrated exports to Google Cloud Monitoring.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>exports</code><br/>
+<em>
+<a href="#monitoring.googleapis.com/v1.ExportSpec">
+[]ExportSpec
+</a>
+</em>
+</td>
+<td>
+<p>Exports specifies additional exporting mechanism on top of Google Cloud Monitoring collection.
+Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in Collection.</p>
 </td>
 </tr>
 <tr>

--- a/examples/export-write/README.md
+++ b/examples/export-write/README.md
@@ -1,0 +1,28 @@
+# Export write
+
+In this guide, GMP collectors are configured to send metrics to a central Prometheus receiver.
+This is an example of how to use GMP collectors to export to a remote endpoint.
+
+## Setup Prometheus Receiver
+
+<b>Launch the Receiver:</b> Run the following command to start a Prometheus receiver that accepts write requests:
+```bash
+kubectl apply -f prometheus-receiver.yaml -n prometheus
+```
+
+## Configure GMP Collectors for Export
+1. <b>Ensure Operator is using the latest code:</b>
+    ```bash
+    DOCKER_PUSH=1 make operator
+    kubectl apply -f manifests/setup.yaml
+    kubectl apply -f manifests/operator.yaml
+    ```
+2. <b>Edit the Operator Configuration:</b>
+    ```bash
+    kubectl -n gmp-public edit operatorconfig config
+    ```
+3. <b>Add Export Configuration:</b> Insert the following code block into your configuration file to specify the target destination for GMP collector write requests:
+    ```bash
+    exports:
+      - url: http://prometheus-receiver.prometheus.svc:9090/api/v1/write
+    ```

--- a/examples/export-write/prometheus-receiver.yaml
+++ b/examples/export-write/prometheus-receiver.yaml
@@ -1,0 +1,74 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-receiver
+  namespace: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-receiver
+  template:
+    metadata:
+      labels:
+        app: prometheus-receiver
+    spec:
+      containers:
+        - name: prometheus
+          image: quay.io/prometheus/prometheus
+          args:
+          - --web.enable-remote-write-receiver
+          - --config.file=/etc/prometheus/prometheus.yml
+          - --web.listen-address=:9090
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/prometheus
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus-cfg
+            defaultMode: 420
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-receiver
+  namespace: prometheus
+spec:
+  clusterIP: None
+  selector:
+    app: prometheus-receiver
+  ports:
+    - name: web
+      port: 9090
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-cfg
+  namespace: prometheus
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+    scrape_configs:
+      - job_name: 'prometheus'
+        static_configs:
+          - targets: ['localhost:9090']

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -1440,8 +1440,8 @@ spec:
               type: string
             collection:
               description: |-
-                Collection specifies how the operator configures collection including
-                integrated exports to Google Cloud Monitoring.
+                Collection specifies how the operator configures collection, including
+                scraping and an integrated export to Google Cloud Monitoring.
               properties:
                 compression:
                   description: Compression enables compression of metrics collection data
@@ -1482,7 +1482,7 @@ spec:
                     specified in the OperatorConfig. The precedence behavior matches that of Prometheus.
                   type: object
                 filter:
-                  description: Filter limits which metric data is sent to Cloud Monitoring(Doesn't apply to additional exports).
+                  description: Filter limits which metric data is sent to Cloud Monitoring (it doesn't apply to additional exports).
                   properties:
                     matchOneOf:
                       description: |-
@@ -1511,12 +1511,13 @@ spec:
               type: object
             exports:
               description: |-
-                Exports specifies additional exporting mechanism on top of Google Cloud Monitoring collection.
-                Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in Collection.
+                Exports is an EXPERIMENTAL feature that specifies additional, optional endpoints to export to,
+                on top of Google Cloud Monitoring collection.
+                Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in the "collection.filter" field.
               items:
                 properties:
                   url:
-                    description: The URL of the endpoint to export samples to.
+                    description: The URL of the endpoint that supports Prometheus Remote Write to export samples to.
                     type: string
                 required:
                   - url

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -1439,7 +1439,9 @@ spec:
                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             collection:
-              description: Collection specifies how the operator configures collection.
+              description: |-
+                Collection specifies how the operator configures collection including
+                integrated exports to Google Cloud Monitoring.
               properties:
                 compression:
                   description: Compression enables compression of metrics collection data
@@ -1476,11 +1478,11 @@ spec:
                     type: string
                   description: |-
                     ExternalLabels specifies external labels that are attached to all scraped
-                    data before being written to Cloud Monitoring. The precedence behavior matches that
-                    of Prometheus.
+                    data before being written to Google Cloud Monitoring or any other additional exports
+                    specified in the OperatorConfig. The precedence behavior matches that of Prometheus.
                   type: object
                 filter:
-                  description: Filter limits which metric data is sent to Cloud Monitoring.
+                  description: Filter limits which metric data is sent to Cloud Monitoring(Doesn't apply to additional exports).
                   properties:
                     matchOneOf:
                       description: |-
@@ -1507,6 +1509,19 @@ spec:
                     - interval
                   type: object
               type: object
+            exports:
+              description: |-
+                Exports specifies additional exporting mechanism on top of Google Cloud Monitoring collection.
+                Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in Collection.
+              items:
+                properties:
+                  url:
+                    description: The URL of the endpoint to export samples to.
+                    type: string
+                required:
+                  - url
+                type: object
+              type: array
             features:
               description: Features holds configuration for optional managed-collection features.
               properties:

--- a/pkg/operator/apis/monitoring/v1/operator_types.go
+++ b/pkg/operator/apis/monitoring/v1/operator_types.go
@@ -29,8 +29,12 @@ type OperatorConfig struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Rules specifies how the operator configures and deploys rule-evaluator.
 	Rules RuleEvaluatorSpec `json:"rules,omitempty"`
-	// Collection specifies how the operator configures collection.
+	// Collection specifies how the operator configures collection including
+	// integrated exports to Google Cloud Monitoring.
 	Collection CollectionSpec `json:"collection,omitempty"`
+	// Exports specifies additional exporting mechanism on top of Google Cloud Monitoring collection.
+	// Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in Collection.
+	Exports []ExportSpec `json:"exports,omitempty"`
 	// ManagedAlertmanager holds information for configuring the managed instance of Alertmanager.
 	// +kubebuilder:default={configSecret: {name: alertmanager, key: alertmanager.yaml}}
 	ManagedAlertmanager *ManagedAlertmanagerSpec `json:"managedAlertmanager,omitempty"`
@@ -73,10 +77,10 @@ type RuleEvaluatorSpec struct {
 // CollectionSpec specifies how the operator configures collection of metric data.
 type CollectionSpec struct {
 	// ExternalLabels specifies external labels that are attached to all scraped
-	// data before being written to Cloud Monitoring. The precedence behavior matches that
-	// of Prometheus.
+	// data before being written to Google Cloud Monitoring or any other additional exports
+	// specified in the OperatorConfig. The precedence behavior matches that of Prometheus.
 	ExternalLabels map[string]string `json:"externalLabels,omitempty"`
-	// Filter limits which metric data is sent to Cloud Monitoring.
+	// Filter limits which metric data is sent to Cloud Monitoring(Doesn't apply to additional exports).
 	Filter ExportFilters `json:"filter,omitempty"`
 	// A reference to GCP service account credentials with which Prometheus collectors
 	// are run. It needs to have metric write permissions for all project IDs to which
@@ -88,6 +92,11 @@ type CollectionSpec struct {
 	KubeletScraping *KubeletScraping `json:"kubeletScraping,omitempty"`
 	// Compression enables compression of metrics collection data
 	Compression CompressionType `json:"compression,omitempty"`
+}
+
+type ExportSpec struct {
+	// The URL of the endpoint to export samples to.
+	URL string `json:"url"`
 }
 
 // OperatorFeatures holds configuration for optional managed-collection features.

--- a/pkg/operator/apis/monitoring/v1/operator_types.go
+++ b/pkg/operator/apis/monitoring/v1/operator_types.go
@@ -95,7 +95,7 @@ type CollectionSpec struct {
 }
 
 type ExportSpec struct {
-	// The URL of the endpoint to export samples to.
+	// The URL of the endpoint that supports Prometheus Remote Write to export samples to.
 	URL string `json:"url"`
 }
 

--- a/pkg/operator/apis/monitoring/v1/operator_types.go
+++ b/pkg/operator/apis/monitoring/v1/operator_types.go
@@ -29,8 +29,8 @@ type OperatorConfig struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Rules specifies how the operator configures and deploys rule-evaluator.
 	Rules RuleEvaluatorSpec `json:"rules,omitempty"`
-	// Collection specifies how the operator configures collection including
-	// integrated exports to Google Cloud Monitoring.
+	// Collection specifies how the operator configures collection, including
+	// scraping and an integrated export to Google Cloud Monitoring.
 	Collection CollectionSpec `json:"collection,omitempty"`
 	// Exports specifies additional exporting mechanism on top of Google Cloud Monitoring collection.
 	// Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in Collection.

--- a/pkg/operator/apis/monitoring/v1/operator_types.go
+++ b/pkg/operator/apis/monitoring/v1/operator_types.go
@@ -32,8 +32,9 @@ type OperatorConfig struct {
 	// Collection specifies how the operator configures collection, including
 	// scraping and an integrated export to Google Cloud Monitoring.
 	Collection CollectionSpec `json:"collection,omitempty"`
-	// Exports specifies additional exporting mechanism on top of Google Cloud Monitoring collection.
-	// Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in Collection.
+	// Exports is an EXPERIMENTAL feature that specifies additional, optional endpoints to export to,
+	// on top of Google Cloud Monitoring collection.
+	// Note: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in the "collection.filter" field.
 	Exports []ExportSpec `json:"exports,omitempty"`
 	// ManagedAlertmanager holds information for configuring the managed instance of Alertmanager.
 	// +kubebuilder:default={configSecret: {name: alertmanager, key: alertmanager.yaml}}

--- a/pkg/operator/apis/monitoring/v1/operator_types.go
+++ b/pkg/operator/apis/monitoring/v1/operator_types.go
@@ -80,7 +80,7 @@ type CollectionSpec struct {
 	// data before being written to Google Cloud Monitoring or any other additional exports
 	// specified in the OperatorConfig. The precedence behavior matches that of Prometheus.
 	ExternalLabels map[string]string `json:"externalLabels,omitempty"`
-	// Filter limits which metric data is sent to Cloud Monitoring(Doesn't apply to additional exports).
+	// Filter limits which metric data is sent to Cloud Monitoring (it doesn't apply to additional exports).
 	Filter ExportFilters `json:"filter,omitempty"`
 	// A reference to GCP service account credentials with which Prometheus collectors
 	// are run. It needs to have metric write permissions for all project IDs to which


### PR DESCRIPTION
This is an example of how GMP collectors can be configured to send metrics to a central Prometheus receiver.

1. Added a URL flag to OperatorConfig, this flag is then used to set `remote_write` in the Prometheus config.
2. examples/export-write contains the manifest to launch a central Prometheus that accepts incoming write requests. 