### PR TITLE
fix: fix config reloader panics if the response is nil

### DIFF
--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -92,11 +92,14 @@ func main() {
 				os.Exit(0)
 			case <-ticker.C:
 				resp, err := http.DefaultClient.Do(req)
-				defer resp.Body.Close()
 				if err != nil {
 					//nolint:errcheck
 					level.Error(logger).Log("msg", "polling ready-url", "err", err)
 					os.Exit(1)
+				}
+				if err := resp.Body.Close(); err != nil {
+					//nolint:errcheck
+					level.Warn(logger).Log("msg", "unable to close response body", "err", err)
 				}
 				if resp.StatusCode == http.StatusOK {
 					//nolint:errcheck


### PR DESCRIPTION
This bug was introduced in https://github.com/GoogleCloudPlatform/prometheus-engine/pull/788

The issue is we always try to close the response body, but the response body is `nil` if there is an error (e.g. service is unavailable). 

`defer` is also incorrect because `defer` executes when the surrounding function returns. Because this method runs in a loop, it will keep gathering more and more responses to close. As such, I just close the body all the time now since we never even use the body.

Discovered while testing https://github.com/GoogleCloudPlatform/prometheus-engine/pull/892