### PR TITLE
feat: support decompressing config directories in config-reloader

### DIFF
--- a/charts/operator/templates/rule-evaluator.yaml
+++ b/charts/operator/templates/rule-evaluator.yaml
@@ -60,7 +60,8 @@ spec:
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
-        - --watched-dir=/etc/rules
+        - --config-dir=/etc/rules
+        - --config-dir-output=/prometheus/rules_out
         - --watched-dir=/etc/secrets
         - --reload-url=http://127.0.0.1:19092/-/reload
         - --ready-url=http://127.0.0.1:19092/-/ready
@@ -78,6 +79,8 @@ spec:
         - name: rules
           readOnly: true
           mountPath: /etc/rules
+        - name: rules-out
+          mountPath: /prometheus/rules_out
         - name: rules-secret
           readOnly: true
           mountPath: /etc/secrets
@@ -101,7 +104,7 @@ spec:
         - name: config-out
           readOnly: true
           mountPath: /prometheus/config_out
-        - name: rules
+        - name: rules-out
           readOnly: true
           mountPath: /etc/rules
         - name: rules-secret
@@ -134,6 +137,8 @@ spec:
         configMap:
           name: rules-generated
           defaultMode: 420
+      - name: rules-out
+        emptyDir: {}
       - name: rules-secret
         secret:
           defaultMode: 420

--- a/charts/rule-evaluator/templates/deployment.yaml
+++ b/charts/rule-evaluator/templates/deployment.yaml
@@ -43,7 +43,8 @@ spec:
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
-        - --watched-dir=/etc/rules
+        - --config-dir=/etc/rules
+        - --config-dir-output=/prometheus/rules_out
         - --reload-url=http://127.0.0.1:9092/-/reload
         - --ready-url=http://127.0.0.1:9092/-/ready
         - --listen-address=:9093
@@ -61,6 +62,8 @@ spec:
         - name: rules
           readOnly: true
           mountPath: /etc/rules
+        - name: rules-out
+          mountPath: /prometheus/rules_out
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -80,7 +83,7 @@ spec:
         - name: config-out
           readOnly: true
           mountPath: /prometheus/config_out
-        - name: rules
+        - name: rules-out
           readOnly: true
           mountPath: /etc/rules
         livenessProbe:
@@ -108,6 +111,8 @@ spec:
       - name: rules
         configMap:
           name: rules
+      - name: rules-out
+        emptyDir: {}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/prometheus/common/assets v0.2.0
 	github.com/prometheus/prometheus v1.8.2-0.20211119115433-692a54649ed7
 	github.com/stretchr/testify v1.8.4
-	github.com/thanos-io/thanos v0.34.1
+	github.com/thanos-io/thanos v0.34.2-0.20240314081355-f731719f9515
 	go.uber.org/zap v1.26.0
 	golang.org/x/mod v0.15.0
 	golang.org/x/oauth2 v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
-github.com/google/pprof v0.0.0-20231205033806-a5a03c77bf08 h1:PxlBVtIFHR/mtWk2i0gTEdCz+jBnqiuHNSki0epDbVs=
-github.com/google/pprof v0.0.0-20231205033806-a5a03c77bf08/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
+github.com/google/pprof v0.0.0-20240117000934-35fc243c5815 h1:WzfWbQz/Ze8v6l++GGbGNFZnUShVpP/0xffCPLL+ax8=
+github.com/google/pprof v0.0.0-20240117000934-35fc243c5815/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
@@ -374,8 +374,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
-github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
+github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
+github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -481,8 +481,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/thanos-io/thanos v0.34.1 h1:f0RYvqtcoR13lrSThBmXFEBkHvqx3FhCkQz30z47BEE=
-github.com/thanos-io/thanos v0.34.1/go.mod h1:MoIYuWI9XZW3or+Tn73qV8FK9VTbAmUTiFxLtNNQafY=
+github.com/thanos-io/thanos v0.34.2-0.20240314081355-f731719f9515 h1:ua9li61Ke2KuN88BWuZN6UKuJSNM1xa6JW2PdQEnozA=
+github.com/thanos-io/thanos v0.34.2-0.20240314081355-f731719f9515/go.mod h1:bXHn+l9BZHRRz+pcUnRSNNg5FyWEkbofxmNgXM+A5J4=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
 github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -615,7 +615,8 @@ spec:
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
-        - --watched-dir=/etc/rules
+        - --config-dir=/etc/rules
+        - --config-dir-output=/prometheus/rules_out
         - --watched-dir=/etc/secrets
         - --reload-url=http://127.0.0.1:19092/-/reload
         - --ready-url=http://127.0.0.1:19092/-/ready
@@ -638,6 +639,8 @@ spec:
         - name: rules
           readOnly: true
           mountPath: /etc/rules
+        - name: rules-out
+          mountPath: /prometheus/rules_out
         - name: rules-secret
           readOnly: true
           mountPath: /etc/secrets
@@ -666,7 +669,7 @@ spec:
         - name: config-out
           readOnly: true
           mountPath: /prometheus/config_out
-        - name: rules
+        - name: rules-out
           readOnly: true
           mountPath: /etc/rules
         - name: rules-secret
@@ -699,6 +702,8 @@ spec:
         configMap:
           name: rules-generated
           defaultMode: 420
+      - name: rules-out
+        emptyDir: {}
       - name: rules-secret
         secret:
           defaultMode: 420

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -120,7 +120,8 @@ spec:
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
-        - --watched-dir=/etc/rules
+        - --config-dir=/etc/rules
+        - --config-dir-output=/prometheus/rules_out
         - --reload-url=http://127.0.0.1:9092/-/reload
         - --ready-url=http://127.0.0.1:9092/-/ready
         - --listen-address=:9093
@@ -143,6 +144,8 @@ spec:
         - name: rules
           readOnly: true
           mountPath: /etc/rules
+        - name: rules-out
+          mountPath: /prometheus/rules_out
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -167,7 +170,7 @@ spec:
         - name: config-out
           readOnly: true
           mountPath: /prometheus/config_out
-        - name: rules
+        - name: rules-out
           readOnly: true
           mountPath: /etc/rules
         livenessProbe:
@@ -195,6 +198,8 @@ spec:
       - name: rules
         configMap:
           name: rules
+      - name: rules-out
+        emptyDir: {}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/vendor/github.com/thanos-io/thanos/pkg/errutil/multierror.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/errutil/multierror.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"fmt"
 	"sync"
+
+	"github.com/pkg/errors"
 )
 
 // The MultiError type implements the error interface, and contains the
@@ -62,6 +64,33 @@ type NonNilMultiError MultiError
 
 // Returns a concatenated string of the contained errors.
 func (es NonNilMultiError) Error() string {
+	return multiErrorString(es)
+}
+
+func (es NonNilMultiError) Cause() error {
+	return es.getCause()
+}
+
+func (es NonNilMultiError) getCause() NonNilMultiRootError {
+	var causes []error
+	for _, err := range es {
+		if multiErr, ok := errors.Cause(err).(NonNilMultiError); ok {
+			causes = append(causes, multiErr.getCause()...)
+		} else {
+			causes = append(causes, errors.Cause(err))
+		}
+	}
+	return causes
+}
+
+type NonNilMultiRootError MultiError
+
+// Returns a concatenated string of the contained errors.
+func (es NonNilMultiRootError) Error() string {
+	return multiErrorString(es)
+}
+
+func multiErrorString(es []error) string {
 	var buf bytes.Buffer
 
 	if len(es) > 1 {

--- a/vendor/github.com/thanos-io/thanos/pkg/reloader/reloader.go
+++ b/vendor/github.com/thanos-io/thanos/pkg/reloader/reloader.go
@@ -59,6 +59,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -89,6 +90,7 @@ type Reloader struct {
 	logger        log.Logger
 	cfgFile       string
 	cfgOutputFile string
+	cfgDirs       []CfgDirOption
 	watchInterval time.Duration
 	retryInterval time.Duration
 	watchedDirs   []string
@@ -97,7 +99,9 @@ type Reloader struct {
 	tr TriggerReloader
 
 	lastCfgHash         []byte
+	lastCfgDirsHash     [][]byte
 	lastWatchedDirsHash []byte
+	lastCfgDirFiles     []map[string]struct{}
 	forceReload         bool
 
 	reloads                    prometheus.Counter
@@ -112,6 +116,22 @@ type Reloader struct {
 // TriggerReloader reloads the configuration of the process.
 type TriggerReloader interface {
 	TriggerReload(ctx context.Context) error
+}
+
+// CfgDirOption contains options for watching directories containing configurations. For example, a
+// directory could contain additional scrape config files or rule  files listed in the main
+// Prometheus configuration. Sub-directories are ignored.
+type CfgDirOption struct {
+	// Dir is the path containing the Prometheus configurations to watch.
+	Dir string
+
+	// OutputDir is a directory path to output configurations. If OutputDir is not empty,
+	// then all config files in the Dir directory are decompressed if needed, environment
+	// variables will be substituted and the output written into the given path. Prometheus
+	// should then use OutputDir as its config path.
+	OutputDir string
+
+	// TODO: https://github.com/thanos-io/thanos/issues/7201
 }
 
 // Options bundles options for the Reloader.
@@ -133,13 +153,15 @@ type Options struct {
 	// successful.
 	RuntimeInfoURL *url.URL
 
-	// CfgFile is a path to the prometheus config file to watch.
+	// CfgFile is a path to the Prometheus config file to watch.
 	CfgFile string
 	// CfgOutputFile is a path for the output config file.
 	// If cfgOutputFile is not empty the config file will be decompressed if needed, environment variables
 	// will be substituted and the output written into the given path. Prometheus should then use
 	// cfgOutputFile as its config file path.
 	CfgOutputFile string
+	// CfgDirs is an array of paths to directories containing Prometheus configs to watch.
+	CfgDirs []CfgDirOption
 	// WatchedDirs is a collection of paths for the reloader to watch over.
 	WatchedDirs []string
 	// DelayInterval controls how long the reloader will wait without receiving
@@ -161,13 +183,15 @@ func New(logger log.Logger, reg prometheus.Registerer, o *Options) *Reloader {
 		logger = log.NewNopLogger()
 	}
 	r := &Reloader{
-		logger:        logger,
-		cfgFile:       o.CfgFile,
-		cfgOutputFile: o.CfgOutputFile,
-		watcher:       newWatcher(logger, reg, o.DelayInterval),
-		watchedDirs:   o.WatchedDirs,
-		watchInterval: o.WatchInterval,
-		retryInterval: o.RetryInterval,
+		logger:          logger,
+		cfgFile:         o.CfgFile,
+		cfgOutputFile:   o.CfgOutputFile,
+		cfgDirs:         o.CfgDirs,
+		lastCfgDirFiles: make([]map[string]struct{}, len(o.CfgDirs)),
+		watcher:         newWatcher(logger, reg, o.DelayInterval),
+		watchedDirs:     o.WatchedDirs,
+		watchInterval:   o.WatchInterval,
+		retryInterval:   o.RetryInterval,
 
 		reloads: promauto.With(reg).NewCounter(
 			prometheus.CounterOpts{
@@ -234,7 +258,7 @@ func New(logger log.Logger, reg prometheus.Registerer, o *Options) *Reloader {
 // Because some edge cases might be missing, the reloader also relies on the
 // watch interval.
 func (r *Reloader) Watch(ctx context.Context) error {
-	if r.cfgFile == "" && len(r.watchedDirs) == 0 {
+	if r.cfgFile == "" && len(r.cfgDirs) == 0 && len(r.watchedDirs) == 0 {
 		level.Info(r.logger).Log("msg", "nothing to be watched")
 		<-ctx.Done()
 		return nil
@@ -260,6 +284,13 @@ func (r *Reloader) Watch(ctx context.Context) error {
 		}
 	}
 
+	for _, cfgDir := range r.cfgDirs {
+		dir := cfgDir.Dir
+		if err := r.watcher.addDirectory(dir); err != nil {
+			return errors.Wrapf(err, "add directory %s to watcher", dir)
+		}
+	}
+
 	if r.watchInterval == 0 {
 		// Skip watching the file-system.
 		return nil
@@ -279,9 +310,15 @@ func (r *Reloader) Watch(ctx context.Context) error {
 		wg.Done()
 	}()
 
+	cfgDirsNames := make([]string, 0, len(r.cfgDirs))
+	for _, cfgDir := range r.cfgDirs {
+		cfgDirsNames = append(cfgDirsNames, cfgDir.Dir)
+	}
+
 	level.Info(r.logger).Log(
 		"msg", "started watching config file and directories for changes",
 		"cfg", r.cfgFile,
+		"cfgDirs", strings.Join(cfgDirsNames, ","),
 		"out", r.cfgOutputFile,
 		"dirs", strings.Join(r.watchedDirs, ","))
 
@@ -311,6 +348,44 @@ func (r *Reloader) Watch(ctx context.Context) error {
 	}
 }
 
+func normalize(logger log.Logger, inputFile, outputFile string) error {
+	b, err := os.ReadFile(inputFile)
+	if err != nil {
+		return errors.Wrap(err, "read file")
+	}
+
+	// Detect and extract gzipped file.
+	if bytes.Equal(b[0:3], firstGzipBytes) {
+		zr, err := gzip.NewReader(bytes.NewReader(b))
+		if err != nil {
+			return errors.Wrap(err, "create gzip reader")
+		}
+		defer runutil.CloseWithLogOnErr(logger, zr, "gzip reader close")
+
+		b, err = io.ReadAll(zr)
+		if err != nil {
+			return errors.Wrap(err, "read compressed config file")
+		}
+	}
+
+	b, err = expandEnv(b)
+	if err != nil {
+		return errors.Wrap(err, "expand environment variables")
+	}
+
+	tmpFile := outputFile + ".tmp"
+	defer func() {
+		_ = os.Remove(tmpFile)
+	}()
+	if err := os.WriteFile(tmpFile, b, 0644); err != nil {
+		return errors.Wrap(err, "write file")
+	}
+	if err := os.Rename(tmpFile, outputFile); err != nil {
+		return errors.Wrap(err, "rename file")
+	}
+	return nil
+}
+
 // apply triggers Prometheus reload if rules or config changed. If cfgOutputFile is set, we also
 // expand env vars into config file before reloading.
 // Reload is retried in retryInterval until watchInterval.
@@ -327,40 +402,71 @@ func (r *Reloader) apply(ctx context.Context) error {
 		}
 		cfgHash = h.Sum(nil)
 		if r.cfgOutputFile != "" {
-			b, err := os.ReadFile(r.cfgFile)
+			if err := normalize(r.logger, r.cfgFile, r.cfgOutputFile); err != nil {
+				return err
+			}
+		}
+	}
+
+	cfgDirsHash := make([][]byte, len(r.cfgDirs))
+	cfgDirsChanged := len(r.lastCfgDirsHash) == 0 && len(r.cfgDirs) > 0
+	for i, cfgDir := range r.cfgDirs {
+		h := sha256.New()
+
+		walkDir, err := filepath.EvalSymlinks(cfgDir.Dir)
+		if err != nil {
+			return errors.Wrap(err, "dir symlink eval")
+		}
+		outDir, err := filepath.EvalSymlinks(cfgDir.OutputDir)
+		if err != nil {
+			return errors.Wrap(err, "dir symlink eval")
+		}
+
+		cfgDirFiles := map[string]struct{}{}
+		entries, err := os.ReadDir(walkDir)
+		if err != nil {
+			return errors.Wrapf(err, "read dir: %s", walkDir)
+		}
+		for _, entry := range entries {
+			path := filepath.Join(walkDir, entry.Name())
+
+			// Make sure to follow a symlink before checking if it is a directory.
+			targetFile, err := os.Stat(path)
 			if err != nil {
-				return errors.Wrap(err, "read file")
+				return errors.Wrapf(err, "stat file: %s", path)
 			}
 
-			// Detect and extract gzipped file.
-			if bytes.Equal(b[0:3], firstGzipBytes) {
-				zr, err := gzip.NewReader(bytes.NewReader(b))
-				if err != nil {
-					return errors.Wrap(err, "create gzip reader")
+			if targetFile.IsDir() {
+				continue
+			}
+
+			if err := hashFile(h, path); err != nil {
+				return errors.Wrapf(err, "build hash for file: %s", path)
+			}
+
+			outFile := filepath.Join(outDir, targetFile.Name())
+			cfgDirFiles[outFile] = struct{}{}
+			if err := normalize(r.logger, path, outFile); err != nil {
+				return errors.Wrapf(err, "move file: %s", path)
+			}
+		}
+		if r.lastCfgDirFiles[i] != nil {
+			if !maps.Equal(r.lastCfgDirFiles[i], cfgDirFiles) {
+				for outFile := range r.lastCfgDirFiles[i] {
+					if _, ok := cfgDirFiles[outFile]; !ok {
+						if err := os.Remove(outFile); err != nil {
+							return err
+						}
+					}
 				}
-				defer runutil.CloseWithLogOnErr(r.logger, zr, "gzip reader close")
+			}
+		}
+		r.lastCfgDirFiles[i] = cfgDirFiles
 
-				b, err = io.ReadAll(zr)
-				if err != nil {
-					return errors.Wrap(err, "read compressed config file")
-				}
-			}
-
-			b, err = expandEnv(b)
-			if err != nil {
-				return errors.Wrap(err, "expand environment variables")
-			}
-
-			tmpFile := r.cfgOutputFile + ".tmp"
-			defer func() {
-				_ = os.Remove(tmpFile)
-			}()
-			if err := os.WriteFile(tmpFile, b, 0644); err != nil {
-				return errors.Wrap(err, "write file")
-			}
-			if err := os.Rename(tmpFile, r.cfgOutputFile); err != nil {
-				return errors.Wrap(err, "rename file")
-			}
+		cfgDirsHash[i] = h.Sum(nil)
+		// Skip comparing bytes if we already set the flag.
+		if !cfgDirsChanged && !bytes.Equal(r.lastCfgDirsHash[i], cfgDirsHash[i]) {
+			cfgDirsChanged = true
 		}
 	}
 
@@ -401,7 +507,7 @@ func (r *Reloader) apply(ctx context.Context) error {
 		watchedDirsHash = h.Sum(nil)
 	}
 
-	if !r.forceReload && bytes.Equal(r.lastCfgHash, cfgHash) && bytes.Equal(r.lastWatchedDirsHash, watchedDirsHash) {
+	if !r.forceReload && !cfgDirsChanged && bytes.Equal(r.lastCfgHash, cfgHash) && bytes.Equal(r.lastWatchedDirsHash, watchedDirsHash) {
 		// Nothing to do.
 		return nil
 	}
@@ -420,11 +526,18 @@ func (r *Reloader) apply(ctx context.Context) error {
 
 		r.forceReload = false
 		r.lastCfgHash = cfgHash
+		r.lastCfgDirsHash = cfgDirsHash
 		r.lastWatchedDirsHash = watchedDirsHash
+
+		cfgDirsNames := make([]string, 0, len(r.cfgDirs))
+		for _, cfgDir := range r.cfgDirs {
+			cfgDirsNames = append(cfgDirsNames, cfgDir.Dir)
+		}
 		level.Info(r.logger).Log(
 			"msg", "Reload triggered",
 			"cfg_in", r.cfgFile,
 			"cfg_out", r.cfgOutputFile,
+			"cfg_dirs", strings.Join(cfgDirsNames, ", "),
 			"watched_dirs", strings.Join(r.watchedDirs, ", "))
 		r.lastReloadSuccess.Set(1)
 		r.lastReloadSuccessTimestamp.SetToCurrentTime()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -492,7 +492,7 @@ github.com/spf13/pflag
 ## explicit; go 1.20
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/thanos-io/thanos v0.34.1
+# github.com/thanos-io/thanos v0.34.2-0.20240314081355-f731719f9515
 ## explicit; go 1.21
 github.com/thanos-io/thanos/pkg/errutil
 github.com/thanos-io/thanos/pkg/reloader


### PR DESCRIPTION
This feature upgrades Thanos to support config directories.

~~This will be kept as a draft until the next Thanos release.~~
Update: Due to popular demand, we can release this before the next Thanos release. It should be okay since my patch should have been the only reloader change.

Depends on https://github.com/GoogleCloudPlatform/prometheus-engine/pull/895