### PR TITLE
chore: enable boringcrypto

### DIFF
--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . ./
 
 FROM buildbase as appbase
-RUN CGO_ENABLED=0 go build -mod=vendor -o config-reloader cmd/config-reloader/*.go
+RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -mod=vendor -o config-reloader cmd/config-reloader/*.go
 
 FROM gcr.io/distroless/static-debian11:latest
 COPY --from=appbase /app/config-reloader /bin/config-reloader

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=assets /app/pkg/ui/static pkg/ui/static
 FROM buildbase AS appbase
 WORKDIR /app
 COPY --from=assets /app ./
-RUN CGO_ENABLED=0 go build -tags builtinassets -mod=vendor -o frontend ./cmd/frontend/*.go
+RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -tags builtinassets -mod=vendor -o frontend ./cmd/frontend/*.go
 
 FROM gcr.io/distroless/static-debian11:latest
 COPY --from=appbase /app/frontend /bin/frontend

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . ./
 
 FROM buildbase as appbase
-RUN CGO_ENABLED=0 go build -mod=vendor -o operator cmd/operator/*.go
+RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -mod=vendor -o operator cmd/operator/*.go
 
 FROM gcr.io/distroless/static-debian11:latest
 COPY --from=appbase /app/operator /bin/operator

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . ./
 
 FROM buildbase as appbase
-RUN CGO_ENABLED=0 go build -mod=vendor -o rule-evaluator cmd/rule-evaluator/*.go
+RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -mod=vendor -o rule-evaluator cmd/rule-evaluator/*.go
 
 FROM gcr.io/distroless/static-debian11:latest
 COPY --from=appbase /app/rule-evaluator /bin/rule-evaluator

--- a/examples/instrumentation/go-synthetic/Dockerfile
+++ b/examples/instrumentation/go-synthetic/Dockerfile
@@ -4,7 +4,7 @@ COPY . ./
 
 FROM buildbase as appbase
 
-RUN CGO_ENABLED=0 go build -o go-synthetic ./examples/instrumentation/go-synthetic
+RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -o go-synthetic ./examples/instrumentation/go-synthetic
 
 FROM gcr.io/distroless/static-debian11:latest
 COPY --from=appbase /app/go-synthetic /bin/go-synthetic


### PR DESCRIPTION
Enable boringcrypto flag for Go builds.

Cherry-picked https://github.com/GoogleCloudPlatform/prometheus-engine/commit/748b809569fccb5e556c1870b7870d0ff843fe5d