### PR TITLE
chore: enable cgo and use google buildbase

### DIFF
--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-bullseye AS buildbase
+FROM google-go.pkg.dev/golang:1.22.1@sha256:4463a06a8378eddc4efa36de9a5310ff087c03d3cc4278c87059209d3d95e4c0 as buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -21,8 +21,9 @@ COPY pkg pkg
 COPY vendor vendor
 
 FROM buildbase as appbase
-RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -mod=vendor -o config-reloader cmd/config-reloader/*.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=boringcrypto \
+    go build -tags boring -mod=vendor -o config-reloader cmd/config-reloader/*.go
 
-FROM gcr.io/distroless/static-debian11:latest
+FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20240307.00_p0@sha256:4f834e207f2721977094aeec4c9daee7032c5daec2083c0be97760f4306e4f88
 COPY --from=appbase /app/config-reloader /bin/config-reloader
 ENTRYPOINT ["/bin/config-reloader"]

--- a/cmd/config-reloader/boring.go
+++ b/cmd/config-reloader/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build boring
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22-bullseye AS buildbase
+FROM google-go.pkg.dev/golang:1.22.1@sha256:4463a06a8378eddc4efa36de9a5310ff087c03d3cc4278c87059209d3d95e4c0 as buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -21,8 +21,9 @@ COPY pkg pkg
 COPY vendor vendor
 
 FROM buildbase as appbase
-RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -mod=vendor -o operator cmd/operator/*.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=boringcrypto \
+    go build -tags boring -mod=vendor -o operator cmd/operator/*.go
 
-FROM gcr.io/distroless/static-debian11:latest
+FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20240307.00_p0@sha256:4f834e207f2721977094aeec4c9daee7032c5daec2083c0be97760f4306e4f88
 COPY --from=appbase /app/operator /bin/operator
 ENTRYPOINT ["/bin/operator"]

--- a/cmd/operator/boring.go
+++ b/cmd/operator/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build boring
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22-bullseye AS buildbase
+FROM google-go.pkg.dev/golang:1.22.1@sha256:4463a06a8378eddc4efa36de9a5310ff087c03d3cc4278c87059209d3d95e4c0 as buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -21,8 +21,9 @@ COPY pkg pkg
 COPY vendor vendor
 
 FROM buildbase as appbase
-RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -mod=vendor -o rule-evaluator cmd/rule-evaluator/*.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=boringcrypto \
+    go build -tags boring -mod=vendor -o rule-evaluator cmd/rule-evaluator/*.go
 
-FROM gcr.io/distroless/static-debian11:latest
+FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20240307.00_p0@sha256:4f834e207f2721977094aeec4c9daee7032c5daec2083c0be97760f4306e4f88
 COPY --from=appbase /app/rule-evaluator /bin/rule-evaluator
 ENTRYPOINT ["/bin/rule-evaluator"]

--- a/cmd/rule-evaluator/boring.go
+++ b/cmd/rule-evaluator/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build boring
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)


### PR DESCRIPTION
cgo needs to be enabled to link against boringcrypto, so we add that here.

In addition, we use the google-go.pkg.dev/golang image as the Go buildbase to ensure build-time requirements, like boringcrypto, are enabled.

We also use gke.gcr.io/gke-distroless/libc as our runtime image.

We add the "cryp/tls/fipsonly" import to ensure boringcrypto is linking properly at build time. We guard this with a build tag "boring" in a dedicated file.