### PR TITLE
fix(operator): add duplicate job name validation within PM, CPM and CNM

### DIFF
--- a/pkg/operator/apis/monitoring/v1/node_types.go
+++ b/pkg/operator/apis/monitoring/v1/node_types.go
@@ -130,7 +130,7 @@ func (c *ClusterNodeMonitoring) ScrapeConfigs(projectID, location, cluster strin
 		}
 		res = append(res, sc)
 	}
-	return res, nil
+	return res, validateDistinctJobNames(res)
 }
 
 func (c *ClusterNodeMonitoring) endpointScrapeConfig(ep *ScrapeNodeEndpoint, projectID, location, cluster string) (*promconfig.ScrapeConfig, error) {

--- a/pkg/operator/apis/monitoring/v1/node_types_test.go
+++ b/pkg/operator/apis/monitoring/v1/node_types_test.go
@@ -68,11 +68,28 @@ func TestValidateClusterNodeMonitoring(t *testing.T) {
 			fail:        true,
 			errContains: "scrape timeout 2s must not be greater than scrape interval 1s",
 		},
+		{
+			// Regression test for https://github.com/GoogleCloudPlatform/prometheus-engine/issues/479
+			desc: "Duplicated job name",
+			eps: []ScrapeNodeEndpoint{
+				{
+					Interval: "10s",
+				},
+				{
+					Interval: "10000ms",
+				},
+			},
+			fail:        true,
+			errContains: "/r1/metrics for endpoints with index 0 and 1;consider creating a separate custom resource (PodMonitoring, etc.) for endpoints that share the same resource name, namespace and port name",
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.desc+"", func(t *testing.T) {
 			nm := &ClusterNodeMonitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "r1",
+				},
 				Spec: ClusterNodeMonitoringSpec{
 					Endpoints: c.eps,
 				},

--- a/pkg/operator/apis/monitoring/v1/pod_types.go
+++ b/pkg/operator/apis/monitoring/v1/pod_types.go
@@ -163,7 +163,7 @@ func (c *ClusterPodMonitoring) ScrapeConfigs(projectID, location, cluster string
 		}
 		res = append(res, c)
 	}
-	return res, nil
+	return res, validateDistinctJobNames(res)
 }
 
 func (p *PodMonitoring) ValidateCreate() (admission.Warnings, error) {
@@ -195,7 +195,7 @@ func (p *PodMonitoring) ScrapeConfigs(projectID, location, cluster string) (res 
 		}
 		res = append(res, c)
 	}
-	return res, nil
+	return res, validateDistinctJobNames(res)
 }
 
 func (p *PodMonitoring) endpointScrapeConfig(index int, projectID, location, cluster string) (*promconfig.ScrapeConfig, error) {


### PR DESCRIPTION
Related to https://github.com/GoogleCloudPlatform/prometheus-engine/issues/479

Without this, certainly malformed CR could trigger Prometheus config parsing error, distrupting the whole cluster collection config changes.

Also to provide better fix to potentially #479 (vs creating separate CR) we could add e.g. JobNameSuffix field for endpoint, but that's for another PR.