### PR TITLE
fix: retry watch forbidden secrets

### DIFF
--- a/pkg/secrets/kubernetes.go
+++ b/pkg/secrets/kubernetes.go
@@ -50,7 +50,11 @@ func getValue(s *corev1.Secret, key string) (string, error) {
 	if value, ok := s.StringData[key]; ok {
 		return value, nil
 	}
-	return "", fmt.Errorf("secret %s/%s does not contain key: %s", s.Namespace, s.Name, key)
+	return "", errKeyNotFound(s.Namespace, s.Name, key)
+}
+
+func errKeyNotFound(namespace, name, key string) error {
+	return fmt.Errorf("secret %s/%s does not contain key: %s", namespace, name, key)
 }
 
 // ClientConfig configures access to the Kubernetes API server.


### PR DESCRIPTION
The configuration reload fails if the caller (the Prometheus collector) does not have permission to view the secret. This change allows the configuration reload to pass, and retries the secret watch until the caller gives permission. A new unit test was added to support this change.