### PR TITLE
Add healthz and readyz to operator

### DIFF
--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -68,6 +68,20 @@ spec:
             drop:
             - all
           privileged: false
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            # Note this should match the --probe-addr flag passed in to the operator args.
+            # Default is 18081.
+            port: 18081
+            scheme: HTTP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            # Note this should match the --probe-addr flag passed in to the operator args.
+            # Default is 18081.
+            port: 18081
+            scheme: HTTP
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -69,6 +69,7 @@ func main() {
 		caCert      = flag.String("ca-cert-base64", "", "The base64-encoded certificate authority.")
 		webhookAddr = flag.String("webhook-addr", ":10250",
 			"Address to listen to for incoming kube admission webhook connections.")
+		probeAddr   = flag.String("probe-addr", ":18081", "Address to outputs probe statuses (e.g. /readyz and /healthz)")
 		metricsAddr = flag.String("metrics-addr", ":18080", "Address to emit metrics on.")
 
 		// Permit the operator to cleanup previously-managed resources that
@@ -103,6 +104,7 @@ func main() {
 		Cluster:           *cluster,
 		OperatorNamespace: *operatorNamespace,
 		PublicNamespace:   *publicNamespace,
+		ProbeAddr:         *probeAddr,
 		TLSCert:           *tlsCert,
 		TLSKey:            *tlsKey,
 		CACert:            *caCert,

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/prometheus-engine/e2e/deploy"
-	"github.com/GoogleCloudPlatform/prometheus-engine/e2e/kube"
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -60,21 +59,8 @@ func TestWebhooksNoRBAC(t *testing.T) {
 	}
 
 	t.Log("waiting for operator to be deployed")
-	if err := kube.WaitForDeploymentReady(ctx, kubeClient, operator.DefaultOperatorNamespace, operator.NameOperator); err != nil {
+	if err := deploy.WaitForOperatorReady(ctx, kubeClient); err != nil {
 		t.Fatalf("error waiting for operator deployment to be ready: %s", err)
-	}
-
-	t.Log("waiting for operator to be ready")
-	if err := wait.PollUntilContextCancel(ctx, 3*time.Second, true, func(ctx context.Context) (bool, error) {
-		logs, err := deploy.OperatorLogs(ctx, restConfig, kubeClient, operator.DefaultOperatorNamespace)
-		if err != nil {
-			t.Logf("unable to get operator logs: %s", err)
-			return false, nil
-		}
-		t.Logf("waiting for operator logs to contain start message")
-		return strings.Contains(logs, "starting GMP operator"), nil
-	}); err != nil {
-		t.Fatalf("unable to check operator ready: %s", err)
 	}
 
 	if err := wait.PollUntilContextCancel(ctx, 3*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -541,6 +541,20 @@ spec:
             drop:
             - all
           privileged: false
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            # Note this should match the --probe-addr flag passed in to the operator args.
+            # Default is 18081.
+            port: 18081
+            scheme: HTTP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            # Note this should match the --probe-addr flag passed in to the operator args.
+            # Default is 18081.
+            port: 18081
+            scheme: HTTP
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This PR improves the reliability of the operator.

This is useful for moving the operator to the control plane (if we ever do), for customers to avoid the 0-node problem themselves, and for us to simplify our e2e test logic (makes our guitar test more reliant too).