### PR TITLE
fix: cleanup security validation warnings

### DIFF
--- a/charts/operator/templates/alertmanager.yaml
+++ b/charts/operator/templates/alertmanager.yaml
@@ -68,6 +68,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       containers:
       - name: alertmanager
         image: {{.Values.images.alertmanager.image}}:{{.Values.images.alertmanager.tag}}
@@ -99,6 +100,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       - name: config-reloader
         image: {{.Values.images.configReloader.image}}:{{.Values.images.configReloader.tag}}
         args:
@@ -129,6 +131,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       volumes:
       - name: config
         secret:

--- a/charts/operator/templates/collector.yaml
+++ b/charts/operator/templates/collector.yaml
@@ -54,6 +54,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
         image: {{.Values.images.configReloader.image}}:{{.Values.images.configReloader.tag}}
@@ -85,6 +86,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       - name: prometheus
         image: {{.Values.images.prometheus.image}}:{{.Values.images.prometheus.tag}}
         args:
@@ -143,6 +145,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       volumes:
       - name: storage
         emptyDir: {}

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -68,6 +68,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -82,6 +83,9 @@ spec:
             # Default is 18081.
             port: 18081
             scheme: HTTP
+        volumeMounts:
+        - name: certs
+          mountPath: /etc/tls/private
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -111,4 +115,7 @@ spec:
         runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+      - name: certs
+        emptyDir: {}
 {{- end }}

--- a/charts/operator/templates/rule-evaluator.yaml
+++ b/charts/operator/templates/rule-evaluator.yaml
@@ -54,6 +54,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
         image: {{.Values.images.configReloader.image}}:{{.Values.images.configReloader.tag}}
@@ -90,6 +91,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       - name: evaluator
         image: {{.Values.images.ruleEvaluator.image}}:{{.Values.images.ruleEvaluator.tag}}
         args:
@@ -126,6 +128,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       volumes:
       - name: config
         configMap:

--- a/charts/rule-evaluator/templates/deployment.yaml
+++ b/charts/rule-evaluator/templates/deployment.yaml
@@ -70,6 +70,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       - name: evaluator
         image: {{.Values.images.ruleEvaluator.image}}:{{.Values.images.ruleEvaluator.tag}}
         args:
@@ -102,6 +103,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       volumes:
       - name: config
         configMap:
@@ -140,3 +142,5 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -38,6 +38,10 @@ import (
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator"
 )
 
+const (
+	defaultTLSDir = "/etc/tls/private"
+)
+
 func main() {
 	var (
 		defaultProjectID string
@@ -67,6 +71,7 @@ func main() {
 		tlsCert     = flag.String("tls-cert-base64", "", "The base64-encoded TLS certificate.")
 		tlsKey      = flag.String("tls-key-base64", "", "The base64-encoded TLS key.")
 		caCert      = flag.String("ca-cert-base64", "", "The base64-encoded certificate authority.")
+		certDir     = flag.String("cert-dir", defaultTLSDir, "The directory which contains TLS certificates for webhook server.")
 		webhookAddr = flag.String("webhook-addr", ":10250",
 			"Address to listen to for incoming kube admission webhook connections.")
 		probeAddr   = flag.String("probe-addr", ":18081", "Address to outputs probe statuses (e.g. /readyz and /healthz)")
@@ -108,6 +113,7 @@ func main() {
 		TLSCert:           *tlsCert,
 		TLSKey:            *tlsKey,
 		CACert:            *caCert,
+		CertDir:           *certDir,
 		ListenAddr:        *webhookAddr,
 		CleanupAnnotKey:   *cleanupAnnotKey,
 	})

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -354,6 +354,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
@@ -390,6 +391,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       - name: prometheus
         image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.1-gke.0
         args:
@@ -453,6 +455,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       volumes:
       - name: storage
         emptyDir: {}
@@ -550,6 +553,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -564,6 +568,9 @@ spec:
             # Default is 18081.
             port: 18081
             scheme: HTTP
+        volumeMounts:
+        - name: certs
+          mountPath: /etc/tls/private
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -593,6 +600,9 @@ spec:
         runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+      - name: certs
+        emptyDir: {}
 ---
 # Source: operator/templates/rule-evaluator.yaml
 apiVersion: apps/v1
@@ -634,6 +644,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
@@ -675,6 +686,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.9.0-gke.1
         args:
@@ -716,6 +728,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       volumes:
       - name: config
         configMap:
@@ -800,6 +813,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       containers:
       - name: alertmanager
         image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.2-gke.0
@@ -836,6 +850,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
         args:
@@ -871,6 +886,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       volumes:
       - name: config
         secret:

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -152,6 +152,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.9.0-gke.1
         args:
@@ -189,6 +190,7 @@ spec:
             drop:
             - all
           privileged: false
+          readOnlyRootFilesystem: true
       volumes:
       - name: config
         configMap:
@@ -227,3 +229,5 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -125,6 +125,8 @@ type Options struct {
 	TLSKey string
 	// Certificate authority in base 64.
 	CACert string
+	// CertDir is the path to a directory containing TLS certificates for the webhook server
+	CertDir string
 	// Webhook serving address.
 	ListenAddr string
 	// Cleanup resources without this annotation.
@@ -188,11 +190,6 @@ func NewScheme() (*runtime.Scheme, error) {
 func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator, error) {
 	if err := opts.defaultAndValidate(logger); err != nil {
 		return nil, fmt.Errorf("invalid options: %w", err)
-	}
-	// Create temporary directory to store webhook serving cert files.
-	certDir, err := os.MkdirTemp("", "operator-cert")
-	if err != nil {
-		return nil, fmt.Errorf("create temporary certificate dir: %w", err)
 	}
 
 	sc, err := NewScheme()
@@ -287,7 +284,7 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Host:    host,
 			Port:    port,
-			CertDir: certDir,
+			CertDir: opts.CertDir,
 		}),
 		// Don't run a metrics server with the manager. Metrics are being served.
 		// explicitly in the main routine.


### PR DESCRIPTION
See internal go/k8s-security-validation-service-user-guide

Two changes:
- The `readOnlyRootFilesystem` flag prevents an attacker from overriding the binary. For the GMP operator, I moved the certificate creation into an empty directory to avoid writing into the root filesystem.
- We were missing `seccompProfile` for rule-evaluator, but we have it everywhere else.

Other warnings are more involved (such as trimming update RBAC permissions).