### PR TITLE
fix: configurable vpa

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -415,8 +415,10 @@ func (o *Operator) Run(ctx context.Context, registry prometheus.Registerer) erro
 	if err := setupOperatorConfigControllers(o); err != nil {
 		return fmt.Errorf("setup rule-evaluator controllers: %w", err)
 	}
-	if err := setupScalingController(o); err != nil {
-		return fmt.Errorf("setup scaling controllers: %w", err)
+	if o.vpaAvailable {
+		if err := setupScalingController(o); err != nil {
+			return fmt.Errorf("setup scaling controllers: %w", err)
+		}
 	}
 	if err := setupTargetStatusPoller(o, registry, o.opts.CollectorHTTPClient); err != nil {
 		return fmt.Errorf("setup target status processor: %w", err)


### PR DESCRIPTION
Only load the scaling controller when VPA is enabled in the cluster.