### PR TITLE
docs: add comment to remind maintainers to update cadvisor/kublet docs

### DIFF
--- a/examples/cadvisor-metrics.yaml
+++ b/examples/cadvisor-metrics.yaml
@@ -22,7 +22,7 @@ spec:
     interval: 30s
     scheme: https
     metricRelabeling:
-    # Ensure any changes made to the metrics are also reflected in https://cloud.google.com/kubernetes-engine/docs/how-to/cadvisor-kubelet-metrics#cadvisor-metrics
+    # Ensure any changes made to the metrics are also reflected in https://cloud.google.com/kubernetes-engine/docs/how-to/cadvisor-kubelet-metrics#cadvisor-metrics.
     - sourceLabels: [__name__]
       regex: >
         container_(cpu_cfs_periods_total|cpu_cfs_throttled_periods_total|cpu_usage_seconds_total|memory_rss|memory_working_set_bytes)|

--- a/examples/cadvisor-metrics.yaml
+++ b/examples/cadvisor-metrics.yaml
@@ -22,6 +22,7 @@ spec:
     interval: 30s
     scheme: https
     metricRelabeling:
+    # Ensure any changes made to the metrics are also reflected in https://cloud.google.com/kubernetes-engine/docs/how-to/cadvisor-kubelet-metrics#cadvisor-metrics
     - sourceLabels: [__name__]
       regex: >
         container_(cpu_cfs_periods_total|cpu_cfs_throttled_periods_total|cpu_usage_seconds_total|memory_rss|memory_working_set_bytes)|

--- a/examples/kubelet-metrics.yaml
+++ b/examples/kubelet-metrics.yaml
@@ -22,6 +22,7 @@ spec:
     interval: 30s
     scheme: https
     metricRelabeling:
+    # Ensure any changes made to the metrics are also reflected in https://cloud.google.com/kubernetes-engine/docs/how-to/cadvisor-kubelet-metrics#kubelet-pod-metrics.
     - sourceLabels: [__name__]
       regex: > 
             kubelet_(node_name|certificate_manager_server_ttl_seconds|pleg_relist_duration_seconds|pod_worker_duration_seconds|running_containers|running_pods|runtime_operations_total)|


### PR DESCRIPTION
Added a comment to remind maintainers to update the public documentation whenever changes are made to the metric collection configuration. This will help ensure that the documentation remains accurate and up-to-date.