### PR TITLE
fix: allow datasource-syncer to run on arm64 nodes

### DIFF
--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -34,6 +34,20 @@ spec:
         - "--grafana-api-token=$GRAFANA_API_TOKEN"
         - "--project-id=$PROJECT_ID"
       restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - arm64
+                - amd64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
 ---
 # Source: datasource-syncer/templates/cronjob.yaml
 apiVersion: batch/v1
@@ -58,3 +72,17 @@ spec:
             - "--grafana-api-token=$GRAFANA_API_TOKEN"
             - "--project-id=$PROJECT_ID"
           restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - arm64
+                    - amd64
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                    - linux


### PR DESCRIPTION
The GCP [Configure and authenticate the Grafana data source](https://cloud.google.com/stackdriver/docs/managed-prometheus/query#grafana-oauth) documentation instructs users to apply this `datasource-syncer.yaml` to deploy datasource syncer to their Kubernetes cluster.

However, there is a default taint `kubernetes.io/arch=arm64:NoSchedule` on every ARM node launched from GKE clusters, preventing the syncer jobs from being scheduled.

I referred to the linked `grafana.yaml` below from this repository to add affinity configurations, allowing the jobs to be scheduled on ARM nodes. I tested it in my GKE cluster and it works.
https://github.com/GoogleCloudPlatform/prometheus-engine/blob/2ca623dfb091dbec98344bf98ab43c917b7cdfe4/examples/grafana.yaml#L29-L42
