### PR TITLE
fix: helm chart to run datasource-syncer to run on arm64 nodes

### DIFF
--- a/charts/datasource-syncer/templates/cronjob.yaml
+++ b/charts/datasource-syncer/templates/cronjob.yaml
@@ -26,6 +26,20 @@ spec:
           labels:
             app: datasource-syncer
         spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - arm64
+                    - amd64
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                    - linux
           containers:
           - name: datasource-syncer
             image: {{.Values.images.datasourceSyncer.image}}:{{.Values.images.datasourceSyncer.tag}}

--- a/charts/datasource-syncer/templates/job.yaml
+++ b/charts/datasource-syncer/templates/job.yaml
@@ -24,6 +24,20 @@ spec:
       labels:
         app: datasource-syncer-init
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - arm64
+                - amd64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - name: datasource-syncer-init
         image: {{.Values.images.datasourceSyncer.image}}:{{.Values.images.datasourceSyncer.tag}}

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -25,15 +25,6 @@ spec:
       labels:
         app: datasource-syncer-init
     spec:
-      containers:
-      - name: datasource-syncer-init
-        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.10.0-gke.3
-        args:
-        - "--datasource-uids=$DATASOURCE_UIDS"
-        - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
-        - "--grafana-api-token=$GRAFANA_API_TOKEN"
-        - "--project-id=$PROJECT_ID"
-      restartPolicy: Never
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -48,6 +39,15 @@ spec:
                 operator: In
                 values:
                 - linux
+      containers:
+      - name: datasource-syncer-init
+        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.10.0-gke.3
+        args:
+        - "--datasource-uids=$DATASOURCE_UIDS"
+        - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
+        - "--grafana-api-token=$GRAFANA_API_TOKEN"
+        - "--project-id=$PROJECT_ID"
+      restartPolicy: Never
 ---
 # Source: datasource-syncer/templates/cronjob.yaml
 apiVersion: batch/v1
@@ -63,15 +63,6 @@ spec:
           labels:
             app: datasource-syncer
         spec:
-          containers:
-          - name: datasource-syncer
-            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.10.0-gke.3
-            args:
-            - "--datasource-uids=$DATASOURCE_UIDS"
-            - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
-            - "--grafana-api-token=$GRAFANA_API_TOKEN"
-            - "--project-id=$PROJECT_ID"
-          restartPolicy: Never
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -86,3 +77,12 @@ spec:
                     operator: In
                     values:
                     - linux
+          containers:
+          - name: datasource-syncer
+            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.10.0-gke.3
+            args:
+            - "--datasource-uids=$DATASOURCE_UIDS"
+            - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
+            - "--grafana-api-token=$GRAFANA_API_TOKEN"
+            - "--project-id=$PROJECT_ID"
+          restartPolicy: Never


### PR DESCRIPTION
Change https://github.com/GoogleCloudPlatform/prometheus-engine/pull/960 was missing the helm change. 