### PR TITLE
refactor: prevent collector pod restarts on startup

### DIFF
--- a/charts/operator/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/operator/templates/mutatingwebhookconfiguration.yaml
@@ -66,3 +66,26 @@ webhooks:
     - CREATE
     - UPDATE
   sideEffects: None
+- name: default.operatorconfigs.gmp-operator.gmp-system.monitoring.googleapis.com
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    # caBundle populated by operator.
+    service:
+      name: gmp-operator
+      namespace: {{.Values.namespace.system}}
+      port: 443
+      path: /default/monitoring.googleapis.com/v1/operatorconfigs
+  # Since this is re-applied at runtime by the operator's controllers
+  # we can safely ignore any transient issues with the webhook server.
+  failurePolicy: Ignore
+  rules:
+  - resources:
+    - operatorconfigs
+    apiGroups:
+    - monitoring.googleapis.com
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+  sideEffects: None

--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -130,7 +130,7 @@ rules:
 - resources:
   - operatorconfigs
   apiGroups: ["monitoring.googleapis.com"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "update", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -25,9 +25,9 @@ images:
     image: gke.gcr.io/prometheus-engine/alertmanager
     tag: v0.25.1-gmp.2-gke.0
   prometheus:
-    # TODO(bwplotka): Change to "v2.45.3-gmp.4-gke.0" once tags are cloned.
+    # TODO(bwplotka): Change to "v2.45.3-gmp.6-gke.0" once tags are cloned.
     image: gke.gcr.io/prometheus-engine/prometheus@sha256
-    tag: 7473d52f4a3e563e6377f8a6183091f25192b1e0705dd0933903e800bd69b7b2
+    tag: 01fd523f6dfa54b229b04974195632c8268fbd3d51e66ad076b5d31366210c54
   configReloader:
     image: gke.gcr.io/prometheus-engine/config-reloader
     tag: v0.9.0-gke.1

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -249,9 +249,6 @@ func testCollectorOperatorConfig(ctx context.Context, kubeClient client.Client) 
 				// We're mainly interested in the dynamic flags but checking the entire set including
 				// the static ones is ultimately simpler.
 				wantArgs := []string{
-					fmt.Sprintf("--export.label.project-id=%q", projectID),
-					fmt.Sprintf("--export.label.location=%q", location),
-					fmt.Sprintf("--export.label.cluster=%q", cluster),
 					fmt.Sprintf("--export.match=%q", projectFilter),
 					fmt.Sprintf("--export.match=%q", locationFilter),
 					fmt.Sprintf("--export.match=%q", kubeletFilter)}

--- a/e2e/ruler_test.go
+++ b/e2e/ruler_test.go
@@ -173,9 +173,6 @@ func testRuleEvaluatorOperatorConfig(ctx context.Context, kubeClient client.Clie
 				// We're mainly interested in the dynamic flags but checking the entire set including
 				// the static ones is ultimately simpler.
 				wantArgs := []string{
-					fmt.Sprintf("--export.label.project-id=%q", projectID),
-					fmt.Sprintf("--export.label.location=%q", location),
-					fmt.Sprintf("--export.label.cluster=%q", cluster),
 					fmt.Sprintf("--query.project-id=%q", projectID),
 					fmt.Sprintf("--query.generator-url=%q", "http://example.com/"),
 				}
@@ -278,13 +275,19 @@ func testRuleEvaluatorConfiguration(ctx context.Context, kubeClient client.Clien
 			return strings.NewReplacer(
 				"{namespace}", operator.DefaultOperatorNamespace,
 				"{pubNamespace}", operator.DefaultPublicNamespace,
+				"{projectID}", projectID,
+				"{location}", location,
+				"{cluster}", cluster,
 			).Replace(s)
 		}
 
 		want := map[string]string{
 			"config.yaml": replace(`global:
     external_labels:
+        cluster: {cluster}
         external_key: external_val
+        location: {location}
+        project_id: {projectID}
 alerting:
     alertmanagers:
         - follow_redirects: true

--- a/examples/collector-max-throughput.yaml
+++ b/examples/collector-max-throughput.yaml
@@ -91,7 +91,7 @@ spec:
             privileged: false
             readOnlyRootFilesystem: true
         - name: prometheus
-          image: gke.gcr.io/prometheus-engine/prometheus@sha256:7473d52f4a3e563e6377f8a6183091f25192b1e0705dd0933903e800bd69b7b2
+          image: gke.gcr.io/prometheus-engine/prometheus@sha256:01fd523f6dfa54b229b04974195632c8268fbd3d51e66ad076b5d31366210c54
           args:
             - --config.file=/prometheus/config_out/config.yaml
             - --enable-feature=exemplar-storage

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -253,7 +253,7 @@ rules:
 - resources:
   - operatorconfigs
   apiGroups: ["monitoring.googleapis.com"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "update", "list", "watch"]
 ---
 # Source: operator/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -403,7 +403,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: prometheus
-        image: gke.gcr.io/prometheus-engine/prometheus@sha256:7473d52f4a3e563e6377f8a6183091f25192b1e0705dd0933903e800bd69b7b2
+        image: gke.gcr.io/prometheus-engine/prometheus@sha256:01fd523f6dfa54b229b04974195632c8268fbd3d51e66ad076b5d31366210c54
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage
@@ -995,6 +995,29 @@ webhooks:
     - v1
     operations:
     - CREATE
+    - UPDATE
+  sideEffects: None
+- name: default.operatorconfigs.gmp-operator.gmp-system.monitoring.googleapis.com
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    # caBundle populated by operator.
+    service:
+      name: gmp-operator
+      namespace: gmp-system
+      port: 443
+      path: /default/monitoring.googleapis.com/v1/operatorconfigs
+  # Since this is re-applied at runtime by the operator's controllers
+  # we can safely ignore any transient issues with the webhook server.
+  failurePolicy: Ignore
+  rules:
+  - resources:
+    - operatorconfigs
+    apiGroups:
+    - monitoring.googleapis.com
+    apiVersions:
+    - v1
+    operations:
     - UPDATE
   sideEffects: None
 ---

--- a/pkg/operator/labels.go
+++ b/pkg/operator/labels.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import "github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
+
+// resolveLabels compares the project, location, and cluster labels used by the operator
+// against those in externalLabels. If any are found in the latter, they take precedence.
+// The higher-precedence labels are then returned.
+//
+// This is to be consistent with our export layer's priorities and avoid confusion if users
+// specify a project_id, location, and cluster in the OperatorConfig's external labels but
+// not in flags passed to the operator - since on GKE environments, these values are
+// auto-populated without user intervention.
+func resolveLabels(defaultProjectID, defaultLocation, defaultCluster string, externalLabels map[string]string) (projectID, location, cluster string) {
+	if externalLabels == nil {
+		return defaultProjectID, defaultLocation, defaultCluster
+	}
+
+	var ok bool
+	if projectID, ok = externalLabels[export.KeyProjectID]; !ok {
+		projectID = defaultProjectID
+	}
+	if location, ok = externalLabels[export.KeyLocation]; !ok {
+		location = defaultLocation
+	}
+	if cluster, ok = externalLabels[export.KeyCluster]; !ok {
+		cluster = defaultCluster
+	}
+	return
+}

--- a/pkg/operator/labels_test.go
+++ b/pkg/operator/labels_test.go
@@ -1,0 +1,106 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"testing"
+)
+
+func TestResolveLabels(t *testing.T) {
+	for _, tc := range []struct {
+		desc                                  string
+		projectID, location, cluster          string
+		expProjectID, expLocation, expCluster string
+		externalLabels                        map[string]string
+		expExternalLabels                     map[string]string
+	}{
+		{
+			desc:      "no overwrite",
+			projectID: "proj-a",
+			location:  "loc-a",
+			cluster:   "clu-a",
+			externalLabels: map[string]string{
+				"project_id": "proj-b",
+				"location":   "loc-b",
+				"cluster":    "clu-b",
+			},
+			expProjectID: "proj-b",
+			expLocation:  "loc-b",
+			expCluster:   "clu-b",
+		},
+		{
+			desc:      "overwrite projectID",
+			projectID: "proj-a",
+			location:  "loc-a",
+			cluster:   "clu-a",
+			externalLabels: map[string]string{
+				"location": "loc-b",
+				"cluster":  "clu-b",
+			},
+			expProjectID: "proj-a",
+			expLocation:  "loc-b",
+			expCluster:   "clu-b",
+		},
+		{
+			desc:      "overwrite location",
+			projectID: "proj-a",
+			location:  "loc-a",
+			cluster:   "clu-a",
+			externalLabels: map[string]string{
+				"project_id": "proj-b",
+				"cluster":    "clu-b",
+			},
+			expProjectID: "proj-b",
+			expLocation:  "loc-a",
+			expCluster:   "clu-b",
+		},
+		{
+			desc:      "overwrite cluster",
+			projectID: "proj-a",
+			location:  "loc-a",
+			cluster:   "clu-a",
+			externalLabels: map[string]string{
+				"project_id": "proj-b",
+				"location":   "loc-b",
+			},
+			expProjectID: "proj-b",
+			expLocation:  "loc-b",
+			expCluster:   "clu-a",
+		},
+		{
+			desc:           "overwrite all",
+			projectID:      "proj-a",
+			location:       "loc-a",
+			cluster:        "clu-a",
+			externalLabels: map[string]string{},
+			expProjectID:   "proj-a",
+			expLocation:    "loc-a",
+			expCluster:     "clu-a",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			projectID, location, cluster := resolveLabels(tc.projectID, tc.location, tc.cluster, tc.externalLabels)
+			if projectID != tc.expProjectID {
+				t.Error("projectIDs do not match")
+			}
+			if location != tc.expLocation {
+				t.Error("locations do not match")
+			}
+			if cluster != tc.expCluster {
+				t.Error("clusters do not match")
+			}
+		})
+	}
+}

--- a/pkg/operator/operator_config_test.go
+++ b/pkg/operator/operator_config_test.go
@@ -1,0 +1,207 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
+	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestEnsureOperatorConfig(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+	operatorOpts := Options{
+		ProjectID: "test-project",
+		Location:  "us-central1-c",
+		Cluster:   "test-cluster",
+	}
+	defaultObjectMeta := v1.ObjectMeta{
+		Namespace: DefaultPublicNamespace,
+		Name:      NameOperatorConfig,
+	}
+	defaultOperatorConfig := monitoringv1.OperatorConfig{
+		ObjectMeta: defaultObjectMeta,
+		Collection: monitoringv1.CollectionSpec{
+			ExternalLabels: map[string]string{
+				export.KeyProjectID: operatorOpts.ProjectID,
+				export.KeyLocation:  operatorOpts.Location,
+				export.KeyCluster:   operatorOpts.Cluster,
+			},
+		},
+		Rules: monitoringv1.RuleEvaluatorSpec{
+			ExternalLabels: map[string]string{
+				export.KeyProjectID: operatorOpts.ProjectID,
+				export.KeyLocation:  operatorOpts.Location,
+				export.KeyCluster:   operatorOpts.Cluster,
+			},
+		},
+	}
+	defaultOperatorConfigWithExtraLabels := monitoringv1.OperatorConfig{
+		ObjectMeta: defaultObjectMeta,
+		Collection: monitoringv1.CollectionSpec{
+			ExternalLabels: map[string]string{
+				export.KeyProjectID: operatorOpts.ProjectID,
+				export.KeyLocation:  operatorOpts.Location,
+				export.KeyCluster:   operatorOpts.Cluster,
+				"foo":               "bar",
+			},
+		},
+		Rules: monitoringv1.RuleEvaluatorSpec{
+			ExternalLabels: map[string]string{
+				export.KeyProjectID: operatorOpts.ProjectID,
+				export.KeyLocation:  operatorOpts.Location,
+				export.KeyCluster:   operatorOpts.Cluster,
+				"abc":               "xyz",
+			},
+		},
+	}
+
+	testCases := []struct {
+		desc     string
+		existing *monitoringv1.OperatorConfig
+		expected *monitoringv1.OperatorConfig
+	}{
+		{
+			desc: "empty",
+			existing: &monitoringv1.OperatorConfig{
+				ObjectMeta: defaultObjectMeta,
+			},
+			expected: &defaultOperatorConfig,
+		},
+		{
+			desc:     "does not exist",
+			existing: nil,
+			expected: &defaultOperatorConfig,
+		},
+		{
+			desc:     "matches config",
+			existing: &defaultOperatorConfigWithExtraLabels,
+			expected: &defaultOperatorConfigWithExtraLabels,
+		},
+		{
+			desc: "missing project",
+			existing: &monitoringv1.OperatorConfig{
+				ObjectMeta: defaultObjectMeta,
+				Collection: monitoringv1.CollectionSpec{
+					ExternalLabels: map[string]string{
+						export.KeyLocation: operatorOpts.Location,
+						export.KeyCluster:  operatorOpts.Cluster,
+						"foo":              "bar",
+					},
+				},
+				Rules: monitoringv1.RuleEvaluatorSpec{
+					ExternalLabels: map[string]string{
+						export.KeyLocation: operatorOpts.Location,
+						export.KeyCluster:  operatorOpts.Cluster,
+						"abc":              "xyz",
+					},
+				},
+			},
+			expected: &defaultOperatorConfigWithExtraLabels,
+		},
+		{
+			desc: "override project",
+			existing: &monitoringv1.OperatorConfig{
+				ObjectMeta: defaultObjectMeta,
+				Collection: monitoringv1.CollectionSpec{
+					ExternalLabels: map[string]string{
+						export.KeyProjectID: "project-other",
+						export.KeyLocation:  operatorOpts.Location,
+						export.KeyCluster:   operatorOpts.Cluster,
+						"foo":               "bar",
+					},
+				},
+				Rules: monitoringv1.RuleEvaluatorSpec{
+					ExternalLabels: map[string]string{
+						export.KeyProjectID: "project-other",
+						export.KeyLocation:  operatorOpts.Location,
+						export.KeyCluster:   operatorOpts.Cluster,
+						"abc":               "xyz",
+					},
+				},
+			},
+			expected: &monitoringv1.OperatorConfig{
+				ObjectMeta: defaultObjectMeta,
+				Collection: monitoringv1.CollectionSpec{
+					ExternalLabels: map[string]string{
+						export.KeyProjectID: "project-other",
+						export.KeyLocation:  operatorOpts.Location,
+						export.KeyCluster:   operatorOpts.Cluster,
+						"foo":               "bar",
+					},
+				},
+				Rules: monitoringv1.RuleEvaluatorSpec{
+					ExternalLabels: map[string]string{
+						export.KeyProjectID: "project-other",
+						export.KeyLocation:  operatorOpts.Location,
+						export.KeyCluster:   operatorOpts.Cluster,
+						"abc":               "xyz",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			clientBuilder := newFakeClientBuilder()
+			if tc.existing != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.existing.DeepCopy())
+			}
+			kubeClient := clientBuilder.Build()
+
+			reconciler := newOperatorConfigReconciler(kubeClient, operatorOpts)
+			operatorConfig, err := reconciler.ensureOperatorConfig(ctx, logger, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: DefaultPublicNamespace,
+					Name:      NameOperatorConfig,
+				},
+			})
+			if err != nil {
+				t.Fatalf("ensure operator config: %s", err)
+			}
+
+			// Normalize before comparisons.
+			operatorConfig.ResourceVersion = ""
+
+			if diff := cmp.Diff(operatorConfig, tc.expected); diff != "" {
+				t.Fatalf("unexpected operator config: %s", diff)
+			}
+
+			// Make sure the object is updated in case of defaulting.
+			if tc.existing != nil {
+				existingLatest := monitoringv1.OperatorConfig{}
+				if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(tc.existing), &existingLatest); err != nil {
+					t.Fatalf("get operator config: %s", err)
+				}
+
+				// Normalize before comparisons.
+				existingLatest.ResourceVersion = ""
+
+				if diff := cmp.Diff(&existingLatest, tc.expected); diff != "" {
+					t.Fatalf("operator config expected update: %s", diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -119,7 +119,7 @@ func (r *rulesReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 		return reconcile.Result{}, fmt.Errorf("get operatorconfig for incoming: %q: %w", req.String(), err)
 	}
 
-	var projectID, location, cluster = resolveLabels(r.opts, config.Rules.ExternalLabels)
+	var projectID, location, cluster = resolveLabels(r.opts.ProjectID, r.opts.Location, r.opts.Cluster, config.Rules.ExternalLabels)
 
 	if err := r.ensureRuleConfigs(ctx, projectID, location, cluster, config.Features.Config.Compression); err != nil {
 		return reconcile.Result{}, fmt.Errorf("ensure rule configmaps: %w", err)


### PR DESCRIPTION
Pass GKE metadata through the Prometheus configuration rather than using flags.

See original attempt: https://github.com/GoogleCloudPlatform/prometheus-engine/pull/920

Prerequisites:
1. prometheus-engine: https://github.com/GoogleCloudPlatform/prometheus-engine/pull/977
2. prometheus: https://github.com/GoogleCloudPlatform/prometheus/pull/162