### PR TITLE
chore: add requests and limits to initContainer

### DIFF
--- a/charts/operator/templates/alertmanager.yaml
+++ b/charts/operator/templates/alertmanager.yaml
@@ -68,6 +68,7 @@ spec:
             drop:
             - all
           privileged: false
+        resources: {{- toYaml $.Values.resources.bash | nindent 10}}
       containers:
       - name: alertmanager
         image: {{.Values.images.alertmanager.image}}:{{.Values.images.alertmanager.tag}}

--- a/charts/operator/templates/collector.yaml
+++ b/charts/operator/templates/collector.yaml
@@ -54,6 +54,7 @@ spec:
             drop:
             - all
           privileged: false
+        resources: {{- toYaml $.Values.resources.bash | nindent 10}}
       containers:
       - name: config-reloader
         image: {{.Values.images.configReloader.image}}:{{.Values.images.configReloader.tag}}
@@ -72,7 +73,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        resources: {{- toYaml $.Values.resources.bash | nindent 10}}
+        resources: {{- toYaml $.Values.resources.configReloader | nindent 10}}
         volumeMounts:
         - name: config
           readOnly: true
@@ -117,7 +118,7 @@ spec:
         env:
         - name: GOGC
           value: "25"
-        resources: {{- toYaml $.Values.resources.collector | nindent 10 }}
+        resources: {{- toYaml $.Values.resources.prometheus | nindent 10 }}
         volumeMounts:
         - name: storage
           mountPath: /prometheus/data

--- a/charts/operator/templates/rule-evaluator.yaml
+++ b/charts/operator/templates/rule-evaluator.yaml
@@ -54,6 +54,7 @@ spec:
             drop:
             - all
           privileged: false
+        resources: {{- toYaml $.Values.resources.bash | nindent 10 }}
       containers:
       - name: config-reloader
         image: {{.Values.images.configReloader.image}}:{{.Values.images.configReloader.tag}}

--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -49,11 +49,11 @@ resources:
       memory: 16M
   bash:
     limits:
-      memory: 32M
+      memory: 6M
     requests:
       cpu: 1m
-      memory: 4M
-  collector:
+      memory: 6M
+  prometheus:
     limits:
       memory: 2G
     requests:

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -354,6 +354,12 @@ spec:
             drop:
             - all
           privileged: false
+        resources:
+          limits:
+            memory: 6M
+          requests:
+            cpu: 1m
+            memory: 6M
       containers:
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
@@ -634,6 +640,12 @@ spec:
             drop:
             - all
           privileged: false
+        resources:
+          limits:
+            memory: 6M
+          requests:
+            cpu: 1m
+            memory: 6M
       containers:
       - name: config-reloader
         image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
@@ -800,6 +812,12 @@ spec:
             drop:
             - all
           privileged: false
+        resources:
+          limits:
+            memory: 6M
+          requests:
+            cpu: 1m
+            memory: 6M
       containers:
       - name: alertmanager
         image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.2-gke.0


### PR DESCRIPTION
Avoids issues with Gatekeeper policies rejecting workloads that do not specify resource requests.

Note - the scheduler should not be affected, as the maximum of initContainers and containers is [considered](https://github.com/kubernetes/enhancements/tree/6394dde76f9f6993293ee8c944da4550c6fdf9bd/keps/sig-node/753-sidecar-containers#exposing-pod-resource-requirements) the effective request amount.