### PR TITLE
feat(export): allow GMP collectors to startup without metadata

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -42,6 +42,7 @@ policies:
           - configs
           - deps
           - e2e
+          - export
           - main
           - operator
           - prometheus

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -171,7 +171,8 @@ func main() {
 		os.Exit(2)
 	}
 
-	exporter, err := newExporter(logger, reg)
+	ctxExporter := context.Background()
+	exporter, err := newExporter(ctxExporter, logger, reg)
 	if err != nil {
 		//nolint:errcheck
 		level.Error(logger).Log("msg", "Creating a Cloud Monitoring Exporter failed", "err", err)
@@ -179,7 +180,7 @@ func main() {
 	}
 	destination := export.NewStorage(exporter)
 
-	ctxRuleManger := context.Background()
+	ctxRuleManager := context.Background()
 	ctxDiscover, cancelDiscover := context.WithCancel(context.Background())
 
 	opts := []option.ClientOption{
@@ -195,7 +196,7 @@ func main() {
 			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		)
 	}
-	transport, err := apihttp.NewTransport(ctxRuleManger, http.DefaultTransport, opts...)
+	transport, err := apihttp.NewTransport(ctxRuleManager, http.DefaultTransport, opts...)
 	if err != nil {
 		//nolint:errcheck
 		level.Error(logger).Log("msg", "Creating proxy HTTP transport failed", "err", err)
@@ -239,7 +240,7 @@ func main() {
 	ruleManager := rules.NewManager(&rules.ManagerOptions{
 		ExternalURL: generatorURL,
 		QueryFunc:   queryFunc,
-		Context:     ctxRuleManger,
+		Context:     ctxRuleManager,
 		Appendable:  destination,
 		Queryable:   externalStorage,
 		Logger:      logger,

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -310,7 +310,7 @@ func newMetricClient(ctx context.Context, opts ExporterOpts) (*monitoring.Metric
 }
 
 // New returns a new Cloud Monitoring Exporter.
-func New(logger log.Logger, reg prometheus.Registerer, opts ExporterOpts) (*Exporter, error) {
+func New(ctx context.Context, logger log.Logger, reg prometheus.Registerer, opts ExporterOpts) (*Exporter, error) {
 	grpc_prometheus.EnableClientHandlingTimeHistogram(
 		grpc_prometheus.WithHistogramBuckets([]float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 30, 40, 50, 60}),
 	)
@@ -354,7 +354,7 @@ func New(logger log.Logger, reg prometheus.Registerer, opts ExporterOpts) (*Expo
 		opts.Lease = alwaysLease{}
 	}
 
-	metricClient, err := newMetricClient(context.Background(), opts)
+	metricClient, err := newMetricClient(ctx, opts)
 	if err != nil {
 		return nil, fmt.Errorf("create metric client: %w", err)
 	}
@@ -408,21 +408,30 @@ func (e *Exporter) ApplyConfig(cfg *config.Config) (err error) {
 	}
 	lset := builder.Labels()
 
-	// At this point we expect location and project ID to be set. They are effectively only a default
-	// however as they may be overridden by metric labels.
-	// In production scenarios, "location" should most likely never be overridden as it means crossing
-	// failure domains. Instead, each location should run a replica of the evaluator with the same rules.
-	if lset.Get(KeyProjectID) == "" {
-		return fmt.Errorf("no label %q set via external labels or flag", KeyProjectID)
+	// We don't need to validate if there's no scrape configs or rules, i.e. at startup.
+	hasScrapeConfigs := len(cfg.ScrapeConfigs) != 0 || len(cfg.ScrapeConfigFiles) != 0
+	hasRules := len(cfg.RuleFiles) != 0
+	if hasScrapeConfigs || hasRules {
+		// At this point we expect location and project ID to be set. They are effectively
+		// only a default however as they may be overridden by metric labels.
+		//
+		// In production scenarios, "location" should most likely never be overridden as it
+		// means crossing failure domains. Instead, each location should run a replica of
+		// the evaluator with the same rules.
+
+		if lset.Get(KeyProjectID) == "" {
+			return fmt.Errorf("no label %q set via external labels or flag", KeyProjectID)
+		}
+		if loc := lset.Get(KeyLocation); loc == "" {
+			return fmt.Errorf("no label %q set via external labels or flag", KeyLocation)
+		} else if loc == "global" {
+			return ErrLocationGlobal
+		}
+		if labels.Equal(e.externalLabels, lset) {
+			return nil
+		}
 	}
-	if loc := lset.Get(KeyLocation); loc == "" {
-		return fmt.Errorf("no label %q set via external labels or flag", KeyLocation)
-	} else if loc == "global" {
-		return ErrLocationGlobal
-	}
-	if labels.Equal(e.externalLabels, lset) {
-		return nil
-	}
+
 	// New external labels possibly invalidate the cached series conversions.
 	e.mtx.Lock()
 	e.externalLabels = lset

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -308,7 +308,8 @@ func TestExporter_wrapMetadata(t *testing.T) {
 		},
 	}
 
-	e, err := New(log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true})
+	ctx := context.Background()
+	e, err := New(ctx, log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +364,7 @@ func TestExporter_drainBacklog(t *testing.T) {
 		t.Fatalf("Creating metric client failed: %s", err)
 	}
 
-	e, err := New(log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true})
+	e, err := New(ctx, log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true})
 	if err != nil {
 		t.Fatalf("Creating Exporter failed: %s", err)
 	}

--- a/pkg/export/gcm/promtest/local_export.go
+++ b/pkg/export/gcm/promtest/local_export.go
@@ -93,7 +93,7 @@ func (l *localExportWithGCM) start(t testing.TB, _ e2e.Environment) (v1.API, map
 		t.Fatalf("create Prometheus client: %s", err)
 	}
 
-	l.e, err = export.New(log.NewJSONLogger(os.Stderr), prometheus.NewRegistry(), export.ExporterOpts{
+	l.e, err = export.New(ctx, log.NewJSONLogger(os.Stderr), prometheus.NewRegistry(), export.ExporterOpts{
 		UserAgentEnv:     "pe-github-action-test",
 		Endpoint:         "monitoring.googleapis.com:443",
 		Compression:      "none",

--- a/pkg/export/setup/setup.go
+++ b/pkg/export/setup/setup.go
@@ -16,6 +16,7 @@
 package setup
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -89,7 +90,7 @@ func Global() *export.Exporter {
 // FromFlags returns a constructor for a new exporter that is configured through flags that are
 // registered with the given application. The constructor must be called after the flags
 // have been parsed.
-func FromFlags(a *kingpin.Application, userAgentProduct string) func(log.Logger, prometheus.Registerer) (*export.Exporter, error) {
+func FromFlags(a *kingpin.Application, userAgentProduct string) func(context.Context, log.Logger, prometheus.Registerer) (*export.Exporter, error) {
 	var opts export.ExporterOpts
 	env := UAEnvUnspecified
 
@@ -183,7 +184,7 @@ func FromFlags(a *kingpin.Application, userAgentProduct string) func(log.Logger,
 	kubeName := a.Flag("export.ha.kube.name", "Name for the HA locking resource. Must be identical across replicas. May be set through the KUBE_NAME environment variable.").
 		Default("").OverrideDefaultFromEnvar("KUBE_NAME").String()
 
-	return func(logger log.Logger, metrics prometheus.Registerer) (*export.Exporter, error) {
+	return func(ctx context.Context, logger log.Logger, metrics prometheus.Registerer) (*export.Exporter, error) {
 		switch *haBackend {
 		case HABackendNone:
 		case HABackendKubernetes:
@@ -204,7 +205,7 @@ func FromFlags(a *kingpin.Application, userAgentProduct string) func(log.Logger,
 		default:
 			return nil, fmt.Errorf("unexpected HA backend %q", *haBackend)
 		}
-		return export.New(logger, metrics, opts)
+		return export.New(ctx, logger, metrics, opts)
 	}
 }
 


### PR DESCRIPTION
The way our e2e tests are written is usually we check for the GMP collector to start-up correctly.

The problem is that if we defer the metadata labeling to the configuration as opposed to flags, then the collector will never start-up correctly (and also goes against our goal which is to prevent the collector from restarting at initialization).

The simple solution here is to defer error handling until we have a configuration with scape or rule configurations.

See also: https://github.com/GoogleCloudPlatform/prometheus-engine/pull/965