### PR TITLE
chore: switch dev images to AR instead of GCR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ KIND_PARALLEL?=5
 DOCKER_HOST?=unix:///var/run/docker.sock
 DOCKER_VOLUME:=$(DOCKER_HOST:unix://%=%)
 
-IMAGE_REGISTRY?=gcr.io/$(PROJECT_ID)/prometheus-engine
+IMAGE_REGISTRY?=us-east4-docker.pkg.dev/$(PROJECT_ID)/prometheus-engine
 TAG_NAME?=$(shell date "+gmp-%Y%d%m_%H%M")
 
 # If an individual test is not specified, run them all.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"strconv"
 
 	"github.com/go-logr/logr"


### PR DESCRIPTION
[GCR is being phased out](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr). This change allows us to push dev images, like those created with `DOCKER_PUSH=1 make operator`, to Artifact Repository instead of Container Registry.