### PR TITLE
fix: ensure status is added to crds

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusterrules.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterrules.yaml
@@ -124,6 +124,44 @@ spec:
             type: object
           status:
             description: Most recently observed status of the resource.
+            properties:
+              conditions:
+                description: Represents the latest available observations of a podmonitor's
+                  current state.
+                items:
+                  description: MonitoringCondition describes the condition of a PodMonitoring.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human-readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: MonitoringConditionType is the type of MonitoringCondition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the controller.
+                format: int64
+                type: integer
             type: object
         required:
         - spec

--- a/charts/operator/crds/monitoring.googleapis.com_globalrules.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_globalrules.yaml
@@ -123,6 +123,44 @@ spec:
             type: object
           status:
             description: Most recently observed status of the resource.
+            properties:
+              conditions:
+                description: Represents the latest available observations of a podmonitor's
+                  current state.
+                items:
+                  description: MonitoringCondition describes the condition of a PodMonitoring.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human-readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: MonitoringConditionType is the type of MonitoringCondition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the controller.
+                format: int64
+                type: integer
             type: object
         required:
         - spec

--- a/charts/operator/crds/monitoring.googleapis.com_rules.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_rules.yaml
@@ -124,6 +124,44 @@ spec:
             type: object
           status:
             description: Most recently observed status of the resource.
+            properties:
+              conditions:
+                description: Represents the latest available observations of a podmonitor's
+                  current state.
+                items:
+                  description: MonitoringCondition describes the condition of a PodMonitoring.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human-readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: MonitoringConditionType is the type of MonitoringCondition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the controller.
+                format: int64
+                type: integer
             type: object
         required:
         - spec

--- a/charts/operator/templates/collector.yaml
+++ b/charts/operator/templates/collector.yaml
@@ -96,6 +96,13 @@ spec:
         - --enable-feature=google-kubernetes-secret-provider
         - --storage.tsdb.path=/prometheus/data
         - --storage.tsdb.no-lockfile
+        # Special Google flag for force deleting all data on start. We use ephemeral storage in
+        # this manifest, but there are cases were container restart still reuses, potentially
+        # bad data (corrupted, with high cardinality causing OOMs or slow startups).
+        # Force deleting, so container restart is consistent with pod restart.
+        # NOTE: Data is likely already sent GCM, plus GCM export does not use that
+        # data on disk (WAL).
+        - --gmp.storage.delete-data-on-start
         # Keep 30 minutes of data. As we are backed by an emptyDir volume, this will count towards
         # the containers memory usage. We could lower it further if this becomes problematic, but
         # it the window for local data is quite convenient for debugging.

--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -16,7 +16,7 @@ commonLabels: false
 namespace:
   public: gmp-public
   system: gmp-system
-version: 0.12.0
+version: 0.13.0
 images:
   bash:
     image: gke.gcr.io/gke-distroless/bash
@@ -25,8 +25,9 @@ images:
     image: gke.gcr.io/prometheus-engine/alertmanager
     tag: v0.25.1-gmp.2-gke.0
   prometheus:
-    image: gke.gcr.io/prometheus-engine/prometheus
-    tag: v2.45.3-gmp.1-gke.0
+    # TODO(bwplotka): Change to "v2.45.3-gmp.4-gke.0" once tags are cloned.
+    image: gke.gcr.io/prometheus-engine/prometheus@sha256
+    tag: 7473d52f4a3e563e6377f8a6183091f25192b1e0705dd0933903e800bd69b7b2
   configReloader:
     image: gke.gcr.io/prometheus-engine/config-reloader
     tag: v0.9.0-gke.1

--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google-go.pkg.dev/golang:1.22.3@sha256:efc6b824652199ede8bc25e2d5a57076e0e1ffbe90735dcbda3ee956fe33b612 as buildbase
+FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010 as buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google-go.pkg.dev/golang:1.22.3@sha256:efc6b824652199ede8bc25e2d5a57076e0e1ffbe90735dcbda3ee956fe33b612 as buildbase
+FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010 as buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google-go.pkg.dev/golang:1.22.3@sha256:efc6b824652199ede8bc25e2d5a57076e0e1ffbe90735dcbda3ee956fe33b612 as buildbase
+FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010 as buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google-go.pkg.dev/golang:1.22.2@sha256:1536be4cced81bb09091bc5a0cd931d974f533549336d8e7106a9656c7f3a5ff as buildbase
+FROM google-go.pkg.dev/golang:1.22.3@sha256:efc6b824652199ede8bc25e2d5a57076e0e1ffbe90735dcbda3ee956fe33b612 as buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/doc/api.md
+++ b/doc/api.md
@@ -1385,7 +1385,7 @@ monitoring resource was created successfully.</p>
 </span>
 </h3>
 <p>
-(<em>Appears in: </em><a href="#monitoring.googleapis.com/v1.ClusterNodeMonitoring">ClusterNodeMonitoring</a>, <a href="#monitoring.googleapis.com/v1.PodMonitoringStatus">PodMonitoringStatus</a>)
+(<em>Appears in: </em><a href="#monitoring.googleapis.com/v1.ClusterNodeMonitoring">ClusterNodeMonitoring</a>, <a href="#monitoring.googleapis.com/v1.PodMonitoringStatus">PodMonitoringStatus</a>, <a href="#monitoring.googleapis.com/v1.RulesStatus">RulesStatus</a>)
 </p>
 <div>
 <p>MonitoringStatus holds status information of a monitoring resource.</p>
@@ -2425,6 +2425,31 @@ RulesStatus
 <div>
 <p>RulesStatus contains status information for a Rules resource.</p>
 </div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>MonitoringStatus</code><br/>
+<em>
+<a href="#monitoring.googleapis.com/v1.MonitoringStatus">
+MonitoringStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>MonitoringStatus</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="monitoring.googleapis.com/v1.SampleGroup">
 <span id="SampleGroup">SampleGroup
 </span>

--- a/e2e/alertmanager_test.go
+++ b/e2e/alertmanager_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestAlertmanager(t *testing.T) {
-	ctx := context.Background()
+	ctx := contextWithDeadline(t)
 	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {
 		t.Fatalf("error instantiating clients. err: %s", err)

--- a/e2e/authorization_test.go
+++ b/e2e/authorization_test.go
@@ -29,6 +29,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,8 +38,8 @@ const errUnauthorized = "server returned HTTP status 401 Unauthorized"
 const errInvalidClientCredentials = "oauth2: \"invalid_client\" \"incorrect client credentials\""
 
 func TestTLS(t *testing.T) {
-	ctx := context.Background()
-	kubeClient, _, err := setupCluster(ctx, t)
+	ctx := contextWithDeadline(t)
+	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {
 		t.Fatalf("error instantiating clients. err: %s", err)
 	}
@@ -46,7 +47,7 @@ func TestTLS(t *testing.T) {
 	t.Run("patch-example-app-args", testPatchExampleAppArgs(ctx, kubeClient, []string{
 		"--tls-create-self-signed=true",
 	}))
-	authorizationTest(ctx, t, kubeClient, "tls",
+	authorizationTest(ctx, t, restConfig, kubeClient, "tls",
 		&monitoringv1.ScrapeEndpoint{
 			Scheme:   "https",
 			Port:     intstr.FromString("web"),
@@ -66,8 +67,8 @@ func TestTLS(t *testing.T) {
 }
 
 func TestBasicAuthPassword(t *testing.T) {
-	ctx := context.Background()
-	kubeClient, _, err := setupCluster(ctx, t)
+	ctx := contextWithDeadline(t)
+	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {
 		t.Fatalf("error instantiating clients. err: %s", err)
 	}
@@ -75,7 +76,7 @@ func TestBasicAuthPassword(t *testing.T) {
 	t.Run("patch-example-app-args", testPatchExampleAppArgs(ctx, kubeClient, []string{
 		"--basic-auth-username=user",
 	}))
-	authorizationTest(ctx, t, kubeClient, "basic-auth-no-password",
+	authorizationTest(ctx, t, restConfig, kubeClient, "basic-auth-no-password",
 		&monitoringv1.ScrapeEndpoint{
 			Port:     intstr.FromString("web"),
 			Interval: "5s",
@@ -93,8 +94,8 @@ func TestBasicAuthPassword(t *testing.T) {
 }
 
 func TestBasicAuthNoUsername(t *testing.T) {
-	ctx := context.Background()
-	kubeClient, _, err := setupCluster(ctx, t)
+	ctx := contextWithDeadline(t)
+	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {
 		t.Fatalf("error instantiating clients. err: %s", err)
 	}
@@ -108,7 +109,7 @@ func TestBasicAuthNoUsername(t *testing.T) {
 	t.Run("patch-example-app-args", testPatchExampleAppArgs(ctx, kubeClient, []string{
 		"--basic-auth-password=pass",
 	}))
-	authorizationTest(ctx, t, kubeClient, "basic-auth-no-username",
+	authorizationTest(ctx, t, restConfig, kubeClient, "basic-auth-no-username",
 		&monitoringv1.ScrapeEndpoint{
 			Port:     intstr.FromString("web"),
 			Interval: "5s",
@@ -131,8 +132,8 @@ func TestBasicAuthNoUsername(t *testing.T) {
 }
 
 func TestBasicAuth(t *testing.T) {
-	ctx := context.Background()
-	kubeClient, _, err := setupCluster(ctx, t)
+	ctx := contextWithDeadline(t)
+	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {
 		t.Fatalf("error instantiating clients. err: %s", err)
 	}
@@ -147,7 +148,7 @@ func TestBasicAuth(t *testing.T) {
 		"--basic-auth-username=user",
 		"--basic-auth-password=pass",
 	}))
-	authorizationTest(ctx, t, kubeClient, "basic-auth",
+	authorizationTest(ctx, t, restConfig, kubeClient, "basic-auth",
 		&monitoringv1.ScrapeEndpoint{
 			Port:     intstr.FromString("web"),
 			Interval: "5s",
@@ -176,8 +177,8 @@ func TestBasicAuth(t *testing.T) {
 }
 
 func TestAuthNoCredentials(t *testing.T) {
-	ctx := context.Background()
-	kubeClient, _, err := setupCluster(ctx, t)
+	ctx := contextWithDeadline(t)
+	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {
 		t.Fatalf("error instantiating clients. err: %s", err)
 	}
@@ -185,7 +186,7 @@ func TestAuthNoCredentials(t *testing.T) {
 	t.Run("patch-example-app-args", testPatchExampleAppArgs(ctx, kubeClient, []string{
 		"--auth-scheme=Bearer",
 	}))
-	authorizationTest(ctx, t, kubeClient, "auth",
+	authorizationTest(ctx, t, restConfig, kubeClient, "auth",
 		&monitoringv1.ScrapeEndpoint{
 			Port:     intstr.FromString("web"),
 			Interval: "5s",
@@ -203,8 +204,8 @@ func TestAuthNoCredentials(t *testing.T) {
 }
 
 func TestAuth(t *testing.T) {
-	ctx := context.Background()
-	kubeClient, _, err := setupCluster(ctx, t)
+	ctx := contextWithDeadline(t)
+	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {
 		t.Fatalf("error instantiating clients. err: %s", err)
 	}
@@ -219,7 +220,7 @@ func TestAuth(t *testing.T) {
 		"--auth-scheme=Bearer",
 		"--auth-parameters=pass",
 	}))
-	authorizationTest(ctx, t, kubeClient, "auth",
+	authorizationTest(ctx, t, restConfig, kubeClient, "auth",
 		&monitoringv1.ScrapeEndpoint{
 			Port:     intstr.FromString("web"),
 			Interval: "5s",
@@ -245,8 +246,8 @@ func TestAuth(t *testing.T) {
 }
 
 func TestOAuth2NoSecret(t *testing.T) {
-	ctx := context.Background()
-	kubeClient, _, err := setupCluster(ctx, t)
+	ctx := contextWithDeadline(t)
+	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {
 		t.Fatalf("error instantiating clients. err: %s", err)
 	}
@@ -261,7 +262,7 @@ func TestOAuth2NoSecret(t *testing.T) {
 		fmt.Sprintf("--oauth2-scopes=%s", clientScope),
 		fmt.Sprintf("--oauth2-access-token=%s", accessToken),
 	}))
-	authorizationTest(ctx, t, kubeClient, "oauth2-no-client-secret",
+	authorizationTest(ctx, t, restConfig, kubeClient, "oauth2-no-client-secret",
 		&monitoringv1.ScrapeEndpoint{
 			Port:     intstr.FromString("web"),
 			Interval: "5s",
@@ -281,8 +282,8 @@ func TestOAuth2NoSecret(t *testing.T) {
 }
 
 func TestOAuth2(t *testing.T) {
-	ctx := context.Background()
-	kubeClient, _, err := setupCluster(ctx, t)
+	ctx := contextWithDeadline(t)
+	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {
 		t.Fatalf("error instantiating clients. err: %s", err)
 	}
@@ -305,7 +306,7 @@ func TestOAuth2(t *testing.T) {
 		fmt.Sprintf("--oauth2-scopes=%s", clientScope),
 		fmt.Sprintf("--oauth2-access-token=%s", accessToken),
 	}))
-	authorizationTest(ctx, t, kubeClient, "oauth2",
+	authorizationTest(ctx, t, restConfig, kubeClient, "oauth2",
 		&monitoringv1.ScrapeEndpoint{
 			Port:     intstr.FromString("web"),
 			Interval: "5s",
@@ -337,17 +338,17 @@ func TestOAuth2(t *testing.T) {
 	)
 }
 
-func authorizationTest(ctx context.Context, t *testing.T, kubeClient client.Client, name string, successConfig, failureConfig *monitoringv1.ScrapeEndpoint, errMsg string) {
+func authorizationTest(ctx context.Context, t *testing.T, restConfig *rest.Config, kubeClient client.Client, name string, successConfig, failureConfig *monitoringv1.ScrapeEndpoint, errMsg string) {
 	t.Run("podmonitoring", func(t *testing.T) {
-		authorizationPodMonitoringTest(ctx, t, kubeClient, name, successConfig, failureConfig, errMsg)
+		authorizationPodMonitoringTest(ctx, t, restConfig, kubeClient, name, successConfig, failureConfig, errMsg)
 	})
 	t.Run("clustermonitoring", func(t *testing.T) {
-		authorizationClusterPodMonitoringTest(ctx, t, kubeClient, name, successConfig, failureConfig, errMsg)
+		authorizationClusterPodMonitoringTest(ctx, t, restConfig, kubeClient, name, successConfig, failureConfig, errMsg)
 	})
 }
 
-func authorizationPodMonitoringTest(ctx context.Context, t *testing.T, kubeClient client.Client, name string, successConfig, failureConfig *monitoringv1.ScrapeEndpoint, errMsg string) {
-	t.Run("collector-deployed", testCollectorDeployed(ctx, kubeClient))
+func authorizationPodMonitoringTest(ctx context.Context, t *testing.T, restConfig *rest.Config, kubeClient client.Client, name string, successConfig, failureConfig *monitoringv1.ScrapeEndpoint, errMsg string) {
+	t.Run("collector-deployed", testCollectorDeployed(ctx, restConfig, kubeClient))
 	t.Run("enable-target-status", testEnableTargetStatus(ctx, kubeClient))
 
 	pm := &monitoringv1.PodMonitoring{
@@ -387,8 +388,8 @@ func authorizationPodMonitoringTest(ctx context.Context, t *testing.T, kubeClien
 	t.Run(fmt.Sprintf("%s-podmon-failure", name), testEnsurePodMonitoringFailure(ctx, kubeClient, pmFail, errMsg))
 }
 
-func authorizationClusterPodMonitoringTest(ctx context.Context, t *testing.T, kubeClient client.Client, name string, successConfig, failureConfig *monitoringv1.ScrapeEndpoint, errMsg string) {
-	t.Run("collector-deployed", testCollectorDeployed(ctx, kubeClient))
+func authorizationClusterPodMonitoringTest(ctx context.Context, t *testing.T, restConfig *rest.Config, kubeClient client.Client, name string, successConfig, failureConfig *monitoringv1.ScrapeEndpoint, errMsg string) {
+	t.Run("collector-deployed", testCollectorDeployed(ctx, restConfig, kubeClient))
 	t.Run("enable-target-status", testEnableTargetStatus(ctx, kubeClient))
 
 	cpm := &monitoringv1.ClusterPodMonitoring{

--- a/e2e/deploy/operator.go
+++ b/e2e/deploy/operator.go
@@ -44,6 +44,7 @@ func operatorPod(ctx context.Context, kubeClient client.Client, operatorNamespac
 	if err != nil {
 		return nil, err
 	}
+	podList = kube.PodsReady(podList)
 	if len(podList) != 1 {
 		return nil, fmt.Errorf("expected 1 pod, found %d", len(podList))
 	}

--- a/e2e/deploy/operator.go
+++ b/e2e/deploy/operator.go
@@ -44,7 +44,6 @@ func operatorPod(ctx context.Context, kubeClient client.Client, operatorNamespac
 	if err != nil {
 		return nil, err
 	}
-	podList = kube.PodsReady(podList)
 	if len(podList) != 1 {
 		return nil, fmt.Errorf("expected 1 pod, found %d", len(podList))
 	}

--- a/e2e/kube/daemonset.go
+++ b/e2e/kube/daemonset.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DaemonSetPods returns the pods used for the given DaemonSet.
+func DaemonSetPods(ctx context.Context, kubeClient client.Client, namespace, name string) ([]corev1.Pod, error) {
+	daemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(daemonSet), daemonSet); err != nil {
+		return nil, err
+	}
+
+	return podsFromSelector(ctx, kubeClient, daemonSet.Spec.Selector)
+}

--- a/e2e/kube/debug.go
+++ b/e2e/kube/debug.go
@@ -23,7 +23,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
@@ -138,18 +137,4 @@ func workloadPods(ctx context.Context, kubeClient client.Client, o client.Object
 	default:
 		return nil, errors.New("invalid object type")
 	}
-}
-
-func podsFromSelector(ctx context.Context, kubeClient client.Client, ps *metav1.LabelSelector) ([]corev1.Pod, error) {
-	selector, err := metav1.LabelSelectorAsSelector(ps)
-	if err != nil {
-		return nil, err
-	}
-	podList := &corev1.PodList{}
-	if err := kubeClient.List(ctx, podList, &client.ListOptions{
-		LabelSelector: selector,
-	}); err != nil {
-		return nil, err
-	}
-	return podList.Items, nil
 }

--- a/e2e/kube/debug.go
+++ b/e2e/kube/debug.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
@@ -137,4 +138,18 @@ func workloadPods(ctx context.Context, kubeClient client.Client, o client.Object
 	default:
 		return nil, errors.New("invalid object type")
 	}
+}
+
+func podsFromSelector(ctx context.Context, kubeClient client.Client, ps *metav1.LabelSelector) ([]corev1.Pod, error) {
+	selector, err := metav1.LabelSelectorAsSelector(ps)
+	if err != nil {
+		return nil, err
+	}
+	podList := &corev1.PodList{}
+	if err := kubeClient.List(ctx, podList, &client.ListOptions{
+		LabelSelector: selector,
+	}); err != nil {
+		return nil, err
+	}
+	return podList.Items, nil
 }

--- a/e2e/kube/deployment.go
+++ b/e2e/kube/deployment.go
@@ -72,15 +72,5 @@ func DeploymentPods(ctx context.Context, kubeClient client.Client, namespace, na
 		return nil, err
 	}
 
-	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
-	if err != nil {
-		return nil, err
-	}
-	podList := &corev1.PodList{}
-	if err := kubeClient.List(ctx, podList, &client.ListOptions{
-		LabelSelector: selector,
-	}); err != nil {
-		return nil, err
-	}
-	return podList.Items, nil
+	return podsFromSelector(ctx, kubeClient, deployment.Spec.Selector)
 }

--- a/e2e/kube/pod.go
+++ b/e2e/kube/pod.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -46,6 +47,29 @@ func PodLogs(ctx context.Context, restConfig *rest.Config, namespace, name, cont
 		return "", err
 	}
 	return builder.String(), nil
+}
+
+// PodsReady filters the given pod list, returning only ready pods.
+func PodsReady(pods []corev1.Pod) []corev1.Pod {
+	var podsFiltered []corev1.Pod
+	for _, pod := range pods {
+		if isPodReady(&pod) {
+			podsFiltered = append(podsFiltered, pod)
+		}
+	}
+	return podsFiltered
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	if len(pod.Spec.Containers) != len(pod.Status.ContainerStatuses) {
+		return false
+	}
+	for _, container := range pod.Status.ContainerStatuses {
+		if !container.Ready {
+			return false
+		}
+	}
+	return true
 }
 
 func waitForPodContainerReady(ctx context.Context, kubeClient client.Client, pod *corev1.Pod, container string) error {
@@ -105,4 +129,18 @@ func podByAddr(ctx context.Context, kubeClient client.Client, addr *net.TCPAddr)
 	}
 	key := client.ObjectKeyFromObject(pod)
 	return nil, "", fmt.Errorf("unable to find port %d in pod %s", addr.Port, key)
+}
+
+func podsFromSelector(ctx context.Context, kubeClient client.Client, ps *metav1.LabelSelector) ([]corev1.Pod, error) {
+	selector, err := metav1.LabelSelectorAsSelector(ps)
+	if err != nil {
+		return nil, err
+	}
+	podList := &corev1.PodList{}
+	if err := kubeClient.List(ctx, podList, &client.ListOptions{
+		LabelSelector: selector,
+	}); err != nil {
+		return nil, err
+	}
+	return podList.Items, nil
 }

--- a/e2e/kube/pod.go
+++ b/e2e/kube/pod.go
@@ -48,29 +48,6 @@ func PodLogs(ctx context.Context, restConfig *rest.Config, namespace, name, cont
 	return builder.String(), nil
 }
 
-// PodsReady filters the given pod list, returning only ready pods.
-func PodsReady(pods []corev1.Pod) []corev1.Pod {
-	var podsFiltered []corev1.Pod
-	for _, pod := range pods {
-		if isPodReady(&pod) {
-			podsFiltered = append(podsFiltered, pod)
-		}
-	}
-	return podsFiltered
-}
-
-func isPodReady(pod *corev1.Pod) bool {
-	if len(pod.Spec.Containers) != len(pod.Status.ContainerStatuses) {
-		return false
-	}
-	for _, container := range pod.Status.ContainerStatuses {
-		if !container.Ready {
-			return false
-		}
-	}
-	return true
-}
-
 func waitForPodContainerReady(ctx context.Context, kubeClient client.Client, pod *corev1.Pod, container string) error {
 	return waitForResourceReady(ctx, kubeClient, pod, func(pod *corev1.Pod) error {
 		return isPodContainerReady(pod, container)
@@ -128,18 +105,4 @@ func podByAddr(ctx context.Context, kubeClient client.Client, addr *net.TCPAddr)
 	}
 	key := client.ObjectKeyFromObject(pod)
 	return nil, "", fmt.Errorf("unable to find port %d in pod %s", addr.Port, key)
-}
-
-func podsFromSelector(ctx context.Context, kubeClient client.Client, ps *metav1.LabelSelector) ([]corev1.Pod, error) {
-	selector, err := metav1.LabelSelectorAsSelector(ps)
-	if err != nil {
-		return nil, err
-	}
-	podList := &corev1.PodList{}
-	if err := kubeClient.List(ctx, podList, &client.ListOptions{
-		LabelSelector: selector,
-	}); err != nil {
-		return nil, err
-	}
-	return podList.Items, nil
 }

--- a/e2e/ruler_test.go
+++ b/e2e/ruler_test.go
@@ -559,7 +559,7 @@ func testCreateRules(
 		if err := kube.WaitForDeploymentReady(ctx, kubeClient, systemNamespace, operator.NameRuleEvaluator); err != nil {
 			t.Errorf("rule-evaluator is not ready: %s", err)
 			out := strings.Builder{}
-			if err := kube.Debug(ctx, restConfig, kubeClient, &appsv1.Deployment{
+			if err := kube.Debug(context.Background(), restConfig, kubeClient, &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: systemNamespace,
 					Name:      operator.NameRuleEvaluator,

--- a/e2e/ruler_test.go
+++ b/e2e/ruler_test.go
@@ -719,6 +719,7 @@ func ruleEvaluatorPod(ctx context.Context, kubeClient client.Client, namespace s
 	if err != nil {
 		return nil, err
 	}
+	podList = kube.PodsReady(podList)
 	if len(podList) != 1 {
 		return nil, fmt.Errorf("expected 1 pod, found %d", len(podList))
 	}

--- a/e2e/ruler_test.go
+++ b/e2e/ruler_test.go
@@ -719,7 +719,6 @@ func ruleEvaluatorPod(ctx context.Context, kubeClient client.Client, namespace s
 	if err != nil {
 		return nil, err
 	}
-	podList = kube.PodsReady(podList)
 	if len(podList) != 1 {
 		return nil, fmt.Errorf("expected 1 pod, found %d", len(podList))
 	}

--- a/e2e/webhook_test.go
+++ b/e2e/webhook_test.go
@@ -31,7 +31,7 @@ import (
 
 // TestWebhooksNoRBAC validates that the operator works without any webhook RBAC policies.
 func TestWebhooksNoRBAC(t *testing.T) {
-	ctx := context.Background()
+	ctx := contextWithDeadline(t)
 	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {
 		t.Fatalf("error instantiating clients. err: %s", err)

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -331,7 +331,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.12.0
+        app.kubernetes.io/version: 0.13.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -393,7 +393,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: prometheus
-        image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.1-gke.0
+        image: gke.gcr.io/prometheus-engine/prometheus@sha256:7473d52f4a3e563e6377f8a6183091f25192b1e0705dd0933903e800bd69b7b2
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage
@@ -401,6 +401,13 @@ spec:
         - --enable-feature=google-kubernetes-secret-provider
         - --storage.tsdb.path=/prometheus/data
         - --storage.tsdb.no-lockfile
+        # Special Google flag for force deleting all data on start. We use ephemeral storage in
+        # this manifest, but there are cases were container restart still reuses, potentially
+        # bad data (corrupted, with high cardinality causing OOMs or slow startups).
+        # Force deleting, so container restart is consistent with pod restart.
+        # NOTE: Data is likely already sent GCM, plus GCM export does not use that
+        # data on disk (WAL).
+        - --gmp.storage.delete-data-on-start
         # Keep 30 minutes of data. As we are backed by an emptyDir volume, this will count towards
         # the containers memory usage. We could lower it further if this becomes problematic, but
         # it the window for local data is quite convenient for debugging.
@@ -520,7 +527,7 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.12.0
+        app.kubernetes.io/version: 0.13.0
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
@@ -621,7 +628,7 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
         app: managed-prometheus-rule-evaluator
-        app.kubernetes.io/version: 0.12.0
+        app.kubernetes.io/version: 0.13.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -794,7 +801,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.12.0
+        app.kubernetes.io/version: 0.13.0
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -103,7 +103,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.12.0
+        app.kubernetes.io/version: 0.13.0
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -1298,6 +1298,41 @@ spec:
               type: object
             status:
               description: Most recently observed status of the resource.
+              properties:
+                conditions:
+                  description: Represents the latest available observations of a podmonitor's current state.
+                  items:
+                    description: MonitoringCondition describes the condition of a PodMonitoring.
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: The last time this condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human-readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: MonitoringConditionType is the type of MonitoringCondition.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: The generation observed by the controller.
+                  format: int64
+                  type: integer
               type: object
           required:
             - spec
@@ -1520,6 +1555,41 @@ spec:
               type: object
             status:
               description: Most recently observed status of the resource.
+              properties:
+                conditions:
+                  description: Represents the latest available observations of a podmonitor's current state.
+                  items:
+                    description: MonitoringCondition describes the condition of a PodMonitoring.
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: The last time this condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human-readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: MonitoringConditionType is the type of MonitoringCondition.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: The generation observed by the controller.
+                  format: int64
+                  type: integer
               type: object
           required:
             - spec
@@ -3378,6 +3448,41 @@ spec:
               type: object
             status:
               description: Most recently observed status of the resource.
+              properties:
+                conditions:
+                  description: Represents the latest available observations of a podmonitor's current state.
+                  items:
+                    description: MonitoringCondition describes the condition of a PodMonitoring.
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: The last time this condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human-readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: MonitoringConditionType is the type of MonitoringCondition.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: The generation observed by the controller.
+                  format: int64
+                  type: integer
               type: object
           required:
             - spec

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -539,7 +539,7 @@ const (
 	ClientName = "prometheus-engine-export"
 	// mainModuleVersion is the version of the main module. Align with git tag.
 	// TODO(TheSpiritXIII): Remove with https://github.com/golang/go/issues/50603
-	mainModuleVersion = "v0.12.0-rc.0" // x-release-please-version
+	mainModuleVersion = "v0.13.0-rc.0" // x-release-please-version
 	// mainModuleName is the name of the main module. Align with go.mod.
 	mainModuleName = "github.com/GoogleCloudPlatform/prometheus-engine"
 )

--- a/pkg/export/setup/setup.go
+++ b/pkg/export/setup/setup.go
@@ -160,7 +160,7 @@ func FromFlags(a *kingpin.Application, userAgentProduct string) func(context.Con
 		Default(strconv.Itoa(export.BatchSizeMax)).UintVar(&opts.Efficiency.BatchSize)
 
 	a.Flag("export.debug.shard-count", "Number of shards that track series to send.").
-		Default(strconv.Itoa(export.BatchSizeMax)).UintVar(&opts.Efficiency.ShardCount)
+		Default(strconv.Itoa(export.DefaultShardCount)).UintVar(&opts.Efficiency.ShardCount)
 
 	a.Flag("export.debug.shard-buffer-size", "The buffer size for each individual shard. Each element in buffer (queue) consists of sample and hash.").
 		Default(strconv.Itoa(export.DefaultShardBufferSize)).UintVar(&opts.Efficiency.ShardBufferSize)

--- a/pkg/operator/apis/monitoring/v1/pod_types.go
+++ b/pkg/operator/apis/monitoring/v1/pod_types.go
@@ -26,10 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-var (
-	errInvalidCond = fmt.Errorf("condition needs both 'Type' and 'Status' fields set")
-)
-
 // PodMonitoringCRD represents a Kubernetes CRD that monitors Pod endpoints.
 type PodMonitoringCRD interface {
 	MonitoringCRD

--- a/pkg/operator/apis/monitoring/v1/pod_types_test.go
+++ b/pkg/operator/apis/monitoring/v1/pod_types_test.go
@@ -190,10 +190,7 @@ func TestSetMonitoringCondition(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.doc, func(t *testing.T) {
 			got := c.curr
-			change, err := got.SetMonitoringCondition(c.generation, c.now, c.cond)
-			if err != nil {
-				t.Fatalf("set podmonitoring condition: %s", err)
-			}
+			change := got.SetMonitoringCondition(c.generation, c.now, c.cond)
 
 			// Get resolved podmonitorings.
 			if change != c.change {

--- a/pkg/operator/apis/monitoring/v1/rules_types.go
+++ b/pkg/operator/apis/monitoring/v1/rules_types.go
@@ -55,6 +55,10 @@ func (*Rules) ValidateDelete() (admission.Warnings, error) {
 	return nil, nil
 }
 
+func (r *Rules) GetMonitoringStatus() *MonitoringStatus {
+	return &r.Status.MonitoringStatus
+}
+
 // RulesList is a list of Rules.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type RulesList struct {
@@ -100,6 +104,10 @@ func (*ClusterRules) ValidateDelete() (admission.Warnings, error) {
 	return nil, nil
 }
 
+func (r *ClusterRules) GetMonitoringStatus() *MonitoringStatus {
+	return &r.Status.MonitoringStatus
+}
+
 // ClusterRulesList is a list of ClusterRules.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type ClusterRulesList struct {
@@ -142,6 +150,10 @@ func (r *GlobalRules) ValidateUpdate(runtime.Object) (admission.Warnings, error)
 func (*GlobalRules) ValidateDelete() (admission.Warnings, error) {
 	// Deletions are always valid.
 	return nil, nil
+}
+
+func (r *GlobalRules) GetMonitoringStatus() *MonitoringStatus {
+	return &r.Status.MonitoringStatus
 }
 
 // GlobalRulesList is a list of GlobalRules.
@@ -192,5 +204,5 @@ type Rule struct {
 
 // RulesStatus contains status information for a Rules resource.
 type RulesStatus struct {
-	// TODO: add status information.
+	MonitoringStatus `json:",inline"`
 }

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -409,8 +409,6 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := pmon.ScrapeConfigs(projectID, location, cluster, usedSecrets)
 		if err != nil {
 			msg := "generating scrape config failed for PodMonitoring endpoint"
-			//TODO: Fix ineffectual assignment. Intended behavior is unclear.
-			//nolint:ineffassign
 			cond = &monitoringv1.MonitoringCondition{
 				Type:    monitoringv1.ConfigurationCreateSuccess,
 				Status:  corev1.ConditionFalse,
@@ -418,10 +416,9 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 				Message: msg,
 			}
 			logger.Error(err, msg, "namespace", pmon.Namespace, "name", pmon.Name)
-			continue
+		} else {
+			cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
 		}
-		cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
-
 		if pmon.Status.SetMonitoringCondition(pmon.GetGeneration(), metav1.Now(), cond) {
 			r.statusUpdates = append(r.statusUpdates, &pmon)
 		}
@@ -443,8 +440,6 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := cmon.ScrapeConfigs(projectID, location, cluster, usedSecrets)
 		if err != nil {
 			msg := "generating scrape config failed for ClusterPodMonitoring endpoint"
-			//TODO: Fix ineffectual assignment. Intended behavior is unclear.
-			//nolint:ineffassign
 			cond = &monitoringv1.MonitoringCondition{
 				Type:    monitoringv1.ConfigurationCreateSuccess,
 				Status:  corev1.ConditionFalse,
@@ -452,10 +447,9 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 				Message: msg,
 			}
 			logger.Error(err, msg, "namespace", cmon.Namespace, "name", cmon.Name)
-			continue
+		} else {
+			cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
 		}
-		cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
-
 		if cmon.Status.SetMonitoringCondition(cmon.GetGeneration(), metav1.Now(), cond) {
 			r.statusUpdates = append(r.statusUpdates, &cmon)
 		}
@@ -489,8 +483,6 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := cm.ScrapeConfigs(projectID, location, cluster)
 		if err != nil {
 			msg := "generating scrape config failed for ClusterNodeMonitoring endpoint"
-			//TODO: Fix ineffectual assignment. Intended behavior is unclear.
-			//nolint:ineffassign
 			cond = &monitoringv1.MonitoringCondition{
 				Type:    monitoringv1.ConfigurationCreateSuccess,
 				Status:  corev1.ConditionFalse,
@@ -498,10 +490,9 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 				Message: msg,
 			}
 			logger.Error(err, msg, "namespace", cm.Namespace, "name", cm.Name)
-			continue
+		} else {
+			cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
 		}
-		cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
-
 		if cm.Status.SetMonitoringCondition(cm.GetGeneration(), metav1.Now(), cond) {
 			r.statusUpdates = append(r.statusUpdates, &cm)
 		}

--- a/pkg/operator/collection_test.go
+++ b/pkg/operator/collection_test.go
@@ -56,7 +56,11 @@ func newFakeClientBuilder() *fake.ClientBuilder {
 	return fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithStatusSubresource(&monitoringv1.PodMonitoring{}).
-		WithStatusSubresource(&monitoringv1.ClusterPodMonitoring{})
+		WithStatusSubresource(&monitoringv1.ClusterPodMonitoring{}).
+		WithStatusSubresource(&monitoringv1.ClusterNodeMonitoring{}).
+		WithStatusSubresource(&monitoringv1.Rules{}).
+		WithStatusSubresource(&monitoringv1.ClusterRules{}).
+		WithStatusSubresource(&monitoringv1.GlobalRules{})
 }
 
 // Tests that the collection does not overwrite the non-managed status fields.

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -202,6 +203,7 @@ func hasGlobalRules(ctx context.Context, c client.Client) (bool, error) {
 	return len(rules.Items) > 0, nil
 }
 
+// ensureRuleConfigs updates the Prometheus Rules ConfigMap.
 func (r *rulesReconciler) ensureRuleConfigs(ctx context.Context, projectID, location, cluster string, compression monitoringv1.CompressionType) error {
 	logger, _ := logr.FromContext(ctx)
 
@@ -234,15 +236,37 @@ func (r *rulesReconciler) ensureRuleConfigs(ctx context.Context, projectID, loca
 	if err := r.client.List(ctx, &rulesList); err != nil {
 		return fmt.Errorf("list rules: %w", err)
 	}
-	for _, rs := range rulesList.Items {
+
+	now := metav1.Now()
+	conditionSuccess := &monitoringv1.MonitoringCondition{
+		Type:   monitoringv1.ConfigurationCreateSuccess,
+		Status: corev1.ConditionTrue,
+	}
+	var statusUpdates []monitoringv1.MonitoringCRD
+
+	for i := range rulesList.Items {
+		rs := &rulesList.Items[i]
 		result, err := rs.RuleGroupsConfig(projectID, location, cluster)
 		if err != nil {
-			// TODO(freinartz): update resource condition.
-			logger.Error(err, "converting rules failed", "rules_namespace", rs.Namespace, "rules_name", rs.Name)
+			msg := "generating rule config failed"
+			if rs.Status.SetMonitoringCondition(rs.GetGeneration(), now, &monitoringv1.MonitoringCondition{
+				Type:    monitoringv1.ConfigurationCreateSuccess,
+				Status:  corev1.ConditionFalse,
+				Message: msg,
+				Reason:  err.Error(),
+			}) {
+				statusUpdates = append(statusUpdates, rs)
+			}
+			logger.Error(err, "convert rules", "err", err, "namespace", rs.Namespace, "name", rs.Name)
+			continue
 		}
 		filename := fmt.Sprintf("rules__%s__%s.yaml", rs.Namespace, rs.Name)
 		if err := setConfigMapData(cm, compression, filename, result); err != nil {
 			return err
+		}
+
+		if rs.Status.SetMonitoringCondition(rs.GetGeneration(), now, conditionSuccess) {
+			statusUpdates = append(statusUpdates, rs)
 		}
 	}
 
@@ -250,15 +274,29 @@ func (r *rulesReconciler) ensureRuleConfigs(ctx context.Context, projectID, loca
 	if err := r.client.List(ctx, &clusterRulesList); err != nil {
 		return fmt.Errorf("list cluster rules: %w", err)
 	}
-	for _, rs := range clusterRulesList.Items {
+	for i := range clusterRulesList.Items {
+		rs := &clusterRulesList.Items[i]
 		result, err := rs.RuleGroupsConfig(projectID, location, cluster)
 		if err != nil {
-			// TODO(freinartz): update resource condition.
-			logger.Error(err, "converting rules failed", "clusterrules_name", rs.Name)
+			msg := "generating rule config failed"
+			if rs.Status.SetMonitoringCondition(rs.Generation, now, &monitoringv1.MonitoringCondition{
+				Type:    monitoringv1.ConfigurationCreateSuccess,
+				Status:  corev1.ConditionFalse,
+				Message: msg,
+				Reason:  err.Error(),
+			}) {
+				statusUpdates = append(statusUpdates, rs)
+			}
+			logger.Error(err, "convert rules", "err", err, "namespace", rs.Namespace, "name", rs.Name)
+			continue
 		}
 		filename := fmt.Sprintf("clusterrules__%s.yaml", rs.Name)
 		if err := setConfigMapData(cm, compression, filename, result); err != nil {
 			return err
+		}
+
+		if rs.Status.SetMonitoringCondition(rs.GetGeneration(), now, conditionSuccess) {
+			statusUpdates = append(statusUpdates, rs)
 		}
 	}
 
@@ -266,15 +304,29 @@ func (r *rulesReconciler) ensureRuleConfigs(ctx context.Context, projectID, loca
 	if err := r.client.List(ctx, &globalRulesList); err != nil {
 		return fmt.Errorf("list global rules: %w", err)
 	}
-	for _, rs := range globalRulesList.Items {
+	for i := range globalRulesList.Items {
+		rs := &globalRulesList.Items[i]
 		result, err := rs.RuleGroupsConfig()
 		if err != nil {
-			// TODO(freinartz): update resource condition.
-			logger.Error(err, "converting rules failed", "globalrules_name", rs.Name)
+			msg := "generating rule config failed"
+			if rs.Status.SetMonitoringCondition(rs.Generation, now, &monitoringv1.MonitoringCondition{
+				Type:    monitoringv1.ConfigurationCreateSuccess,
+				Status:  corev1.ConditionFalse,
+				Message: msg,
+				Reason:  err.Error(),
+			}) {
+				statusUpdates = append(statusUpdates, rs)
+			}
+			logger.Error(err, "convert rules", "err", err, "namespace", rs.Namespace, "name", rs.Name)
+			continue
 		}
 		filename := fmt.Sprintf("globalrules__%s.yaml", rs.Name)
 		if err := setConfigMapData(cm, compression, filename, result); err != nil {
 			return err
+		}
+
+		if rs.Status.SetMonitoringCondition(rs.GetGeneration(), now, conditionSuccess) {
+			statusUpdates = append(statusUpdates, rs)
 		}
 	}
 
@@ -286,5 +338,13 @@ func (r *rulesReconciler) ensureRuleConfigs(ctx context.Context, projectID, loca
 	} else if err != nil {
 		return fmt.Errorf("update generated rules: %w", err)
 	}
-	return nil
+
+	var errs []error
+	for _, obj := range statusUpdates {
+		if err := patchMonitoringStatus(ctx, r.client, obj, obj.GetMonitoringStatus()); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
Made sure monitoring statuses are propagated when there is a failure.

Added a test case for it. Test logic wasn't modified. Only added variables to be able to change the podmonitoring and error messages.