### PR TITLE
fix(e2e): reduce e2e flakiness when a deployment pod restarts

### DIFF
--- a/e2e/deploy/operator.go
+++ b/e2e/deploy/operator.go
@@ -44,6 +44,7 @@ func operatorPod(ctx context.Context, kubeClient client.Client, operatorNamespac
 	if err != nil {
 		return nil, err
 	}
+	podList = kube.PodsReady(podList)
 	if len(podList) != 1 {
 		return nil, fmt.Errorf("expected 1 pod, found %d", len(podList))
 	}

--- a/e2e/kube/debug.go
+++ b/e2e/kube/debug.go
@@ -23,7 +23,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
@@ -138,18 +137,4 @@ func workloadPods(ctx context.Context, kubeClient client.Client, o client.Object
 	default:
 		return nil, errors.New("invalid object type")
 	}
-}
-
-func podsFromSelector(ctx context.Context, kubeClient client.Client, ps *metav1.LabelSelector) ([]corev1.Pod, error) {
-	selector, err := metav1.LabelSelectorAsSelector(ps)
-	if err != nil {
-		return nil, err
-	}
-	podList := &corev1.PodList{}
-	if err := kubeClient.List(ctx, podList, &client.ListOptions{
-		LabelSelector: selector,
-	}); err != nil {
-		return nil, err
-	}
-	return podList.Items, nil
 }

--- a/e2e/kube/pod.go
+++ b/e2e/kube/pod.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -46,6 +47,29 @@ func PodLogs(ctx context.Context, restConfig *rest.Config, namespace, name, cont
 		return "", err
 	}
 	return builder.String(), nil
+}
+
+// PodsReady filters the given pod list, returning only ready pods.
+func PodsReady(pods []corev1.Pod) []corev1.Pod {
+	var podsFiltered []corev1.Pod
+	for _, pod := range pods {
+		if isPodReady(&pod) {
+			podsFiltered = append(podsFiltered, pod)
+		}
+	}
+	return podsFiltered
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	if len(pod.Spec.Containers) != len(pod.Status.ContainerStatuses) {
+		return false
+	}
+	for _, container := range pod.Status.ContainerStatuses {
+		if !container.Ready {
+			return false
+		}
+	}
+	return true
 }
 
 func waitForPodContainerReady(ctx context.Context, kubeClient client.Client, pod *corev1.Pod, container string) error {
@@ -105,4 +129,18 @@ func podByAddr(ctx context.Context, kubeClient client.Client, addr *net.TCPAddr)
 	}
 	key := client.ObjectKeyFromObject(pod)
 	return nil, "", fmt.Errorf("unable to find port %d in pod %s", addr.Port, key)
+}
+
+func podsFromSelector(ctx context.Context, kubeClient client.Client, ps *metav1.LabelSelector) ([]corev1.Pod, error) {
+	selector, err := metav1.LabelSelectorAsSelector(ps)
+	if err != nil {
+		return nil, err
+	}
+	podList := &corev1.PodList{}
+	if err := kubeClient.List(ctx, podList, &client.ListOptions{
+		LabelSelector: selector,
+	}); err != nil {
+		return nil, err
+	}
+	return podList.Items, nil
 }

--- a/e2e/ruler_test.go
+++ b/e2e/ruler_test.go
@@ -719,6 +719,7 @@ func ruleEvaluatorPod(ctx context.Context, kubeClient client.Client, namespace s
 	if err != nil {
 		return nil, err
 	}
+	podList = kube.PodsReady(podList)
 	if len(podList) != 1 {
 		return nil, fmt.Errorf("expected 1 pod, found %d", len(podList))
 	}


### PR DESCRIPTION
Sometimes e2e tests fail if a deployment pod fails to startup, and restarts, or the GMP operator causes the pod to restart and we query the pod too quick.

The quick and easy fix is to only filter active pods.