### PR TITLE
fix: Use upstream go image for build

### DIFF
--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google-go.pkg.dev/golang:1.22.3@sha256:efc6b824652199ede8bc25e2d5a57076e0e1ffbe90735dcbda3ee956fe33b612 as buildbase
+FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010 as buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google-go.pkg.dev/golang:1.22.3@sha256:efc6b824652199ede8bc25e2d5a57076e0e1ffbe90735dcbda3ee956fe33b612 as buildbase
+FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010 as buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google-go.pkg.dev/golang:1.22.3@sha256:efc6b824652199ede8bc25e2d5a57076e0e1ffbe90735dcbda3ee956fe33b612 as buildbase
+FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010 as buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum


### PR DESCRIPTION
This fixes an issue with images on ARM64.
Tested and verified fix on ARM64 and AMD64 machines.

Testing steps:
```
# Build images
docker buildx build --builder mybuilder -t gcr.io/$PROJECT_ID/prometheus-engine/operator:arm-test1 cmd/operator/Dockerfile --platform linux/arm64,linux/amd64 --build-arg QEMU_VERSION=latest --push

docker buildx build --builder mybuilder -t gcr.io/$PROJECT_ID/prometheus-engine/config-reloader:arm-test1 cmd/operator/Dockerfile --platform linux/arm64,linux/amd64 --build-arg QEMU_VERSION=latest --push

docker buildx build --builder mybuilder -t gcr.io/$PROJECT_ID/prometheus-engine/rule-evaluator:arm-test1 cmd/operator/Dockerfile --platform linux/arm64,linux/amd64 --build-arg QEMU_VERSION=latest --push
# Add built images to manifests/operator.yaml
kubectl apply -f manifests/operator.yaml
```