### PR TITLE
fix(operator): support secrets outside default ns for scrape auth

### DIFF
--- a/e2e/authorization_test.go
+++ b/e2e/authorization_test.go
@@ -66,7 +66,7 @@ func TestTLS(t *testing.T) {
 	)
 }
 
-func TestBasicAuthPassword(t *testing.T) {
+func TestBasicAuthNoPassword(t *testing.T) {
 	ctx := contextWithDeadline(t)
 	kubeClient, restConfig, err := setupCluster(ctx, t)
 	if err != nil {

--- a/pkg/operator/apis/monitoring/v1/http_types.go
+++ b/pkg/operator/apis/monitoring/v1/http_types.go
@@ -101,11 +101,8 @@ func (s *SecretKeySelector) toPrometheusSecretRef(m PodMonitoringCRD, pool Prome
 	}
 	if m.IsNamespaceScoped() {
 		monitoringNamespace := m.GetNamespace()
-		if monitoringNamespace == "" {
-			monitoringNamespace = metav1.NamespaceDefault
-		}
-		if ns != monitoringNamespace {
-			return "", fmt.Errorf("must use namespace %q, got: %q", m.GetNamespace(), ns)
+		if monitoringNamespace != "" {
+			ns = monitoringNamespace
 		}
 	}
 

--- a/pkg/operator/apis/monitoring/v1/http_types.go
+++ b/pkg/operator/apis/monitoring/v1/http_types.go
@@ -97,13 +97,13 @@ func (s *SecretKeySelector) toPrometheusSecretRef(m PodMonitoringCRD, pool Prome
 
 	ns := s.Namespace
 	if ns == "" {
-		ns = metav1.NamespaceDefault
-	}
-	if m.IsNamespaceScoped() {
-		monitoringNamespace := m.GetNamespace()
-		if monitoringNamespace != "" {
-			ns = monitoringNamespace
+		if m.IsNamespaceScoped() {
+			ns = m.GetNamespace()
+		} else {
+			ns = metav1.NamespaceDefault
 		}
+	} else if m.IsNamespaceScoped() && ns != m.GetNamespace() {
+		return "", fmt.Errorf("must use namespace %q, got: %q", m.GetNamespace(), ns)
 	}
 
 	ref := fmt.Sprintf("%s/%s/%s", ns, s.Name, s.Key)


### PR DESCRIPTION
Fixes the issue shared through https://github.com/GoogleCloudPlatform/prometheus-engine/pull/776#issuecomment-2087606662.

The current implementation only supports a PodMonitoring selecting a Secret from the `default` namespace.

The existing E2E test cases were using a Secret deployed inside the `default` namespace therefore not covering this "edge" case:

https://github.com/GoogleCloudPlatform/prometheus-engine/blob/f21c2ba4c0a9c3108209c1e59ec75d52e388235e/e2e/authorization_test.go#L96-L177