### PR TITLE
fix: ensure status is added to crds

### DIFF
--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -409,8 +409,6 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := pmon.ScrapeConfigs(projectID, location, cluster, usedSecrets)
 		if err != nil {
 			msg := "generating scrape config failed for PodMonitoring endpoint"
-			//TODO: Fix ineffectual assignment. Intended behavior is unclear.
-			//nolint:ineffassign
 			cond = &monitoringv1.MonitoringCondition{
 				Type:    monitoringv1.ConfigurationCreateSuccess,
 				Status:  corev1.ConditionFalse,
@@ -418,10 +416,9 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 				Message: msg,
 			}
 			logger.Error(err, msg, "namespace", pmon.Namespace, "name", pmon.Name)
-			continue
+		} else {
+			cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
 		}
-		cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
-
 		if pmon.Status.SetMonitoringCondition(pmon.GetGeneration(), metav1.Now(), cond) {
 			r.statusUpdates = append(r.statusUpdates, &pmon)
 		}
@@ -443,8 +440,6 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := cmon.ScrapeConfigs(projectID, location, cluster, usedSecrets)
 		if err != nil {
 			msg := "generating scrape config failed for ClusterPodMonitoring endpoint"
-			//TODO: Fix ineffectual assignment. Intended behavior is unclear.
-			//nolint:ineffassign
 			cond = &monitoringv1.MonitoringCondition{
 				Type:    monitoringv1.ConfigurationCreateSuccess,
 				Status:  corev1.ConditionFalse,
@@ -452,10 +447,9 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 				Message: msg,
 			}
 			logger.Error(err, msg, "namespace", cmon.Namespace, "name", cmon.Name)
-			continue
+		} else {
+			cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
 		}
-		cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
-
 		if cmon.Status.SetMonitoringCondition(cmon.GetGeneration(), metav1.Now(), cond) {
 			r.statusUpdates = append(r.statusUpdates, &cmon)
 		}
@@ -489,8 +483,6 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		cfgs, err := cm.ScrapeConfigs(projectID, location, cluster)
 		if err != nil {
 			msg := "generating scrape config failed for ClusterNodeMonitoring endpoint"
-			//TODO: Fix ineffectual assignment. Intended behavior is unclear.
-			//nolint:ineffassign
 			cond = &monitoringv1.MonitoringCondition{
 				Type:    monitoringv1.ConfigurationCreateSuccess,
 				Status:  corev1.ConditionFalse,
@@ -498,10 +490,9 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 				Message: msg,
 			}
 			logger.Error(err, msg, "namespace", cm.Namespace, "name", cm.Name)
-			continue
+		} else {
+			cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
 		}
-		cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
-
 		if cm.Status.SetMonitoringCondition(cm.GetGeneration(), metav1.Now(), cond) {
 			r.statusUpdates = append(r.statusUpdates, &cm)
 		}

--- a/pkg/operator/collection_test.go
+++ b/pkg/operator/collection_test.go
@@ -63,122 +63,144 @@ func newFakeClientBuilder() *fake.ClientBuilder {
 		WithStatusSubresource(&monitoringv1.GlobalRules{})
 }
 
-// Tests that the collection does not overwrite the non-managed status fields.
 func TestCollectionStatus(t *testing.T) {
-	statusIn := monitoringv1.PodMonitoringStatus{
-		EndpointStatuses: []monitoringv1.ScrapeEndpointStatus{
-			{
-				Name:             "PodMonitoring/gmp-test/prom-example-1/metrics",
-				ActiveTargets:    1,
-				UnhealthyTargets: 0,
-				LastUpdateTime:   metav1.Date(2022, time.November, 1, 0, 0, 0, 0, time.UTC),
-				SampleGroups: []monitoringv1.SampleGroup{
+	cases := []struct {
+		doc         string
+		wantStatus  corev1.ConditionStatus
+		wantReason  string
+		wantMessage string
+		endpoint    monitoringv1.ScrapeEndpoint
+	}{
+		{
+			doc:        "collection does not overwrite the non-managed status fields",
+			wantStatus: corev1.ConditionTrue,
+			endpoint: monitoringv1.ScrapeEndpoint{
+				Port:     intstr.FromString("metrics"),
+				Interval: "10s",
+			},
+		},
+		{
+			doc:         "status is false because endpoint is empty",
+			wantStatus:  corev1.ConditionFalse,
+			wantReason:  "ScrapeConfigError",
+			wantMessage: "generating scrape config failed for PodMonitoring endpoint",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.doc, func(t *testing.T) {
+			statusIn := monitoringv1.PodMonitoringStatus{
+				EndpointStatuses: []monitoringv1.ScrapeEndpointStatus{
 					{
-						SampleTargets: []monitoringv1.SampleTarget{
+						Name:             "PodMonitoring/gmp-test/prom-example-1/metrics",
+						ActiveTargets:    1,
+						UnhealthyTargets: 0,
+						LastUpdateTime:   metav1.Date(2022, time.November, 1, 0, 0, 0, 0, time.UTC),
+						SampleGroups: []monitoringv1.SampleGroup{
 							{
-								Health: "up",
-								Labels: map[model.LabelName]model.LabelValue{
-									"instance": "a",
+								SampleTargets: []monitoringv1.SampleTarget{
+									{
+										Health: "up",
+										Labels: map[model.LabelName]model.LabelValue{
+											"instance": "a",
+										},
+										LastScrapeDurationSeconds: "1.2",
+									},
 								},
-								LastScrapeDurationSeconds: "1.2",
+								Count: ptr.To(int32(1)),
 							},
 						},
-						Count: ptr.To(int32(1)),
+						CollectorsFraction: "1",
 					},
 				},
-				CollectorsFraction: "1",
-			},
-		},
-	}
+			}
 
-	statusOut := *statusIn.DeepCopy()
-	statusOut.Conditions = append(statusOut.Conditions, monitoringv1.MonitoringCondition{
-		Type:               monitoringv1.ConfigurationCreateSuccess,
-		Status:             corev1.ConditionTrue,
-		LastUpdateTime:     metav1.Time{},
-		LastTransitionTime: metav1.Time{},
-		Reason:             "",
-		Message:            "",
-	})
+			statusOut := *statusIn.DeepCopy()
+			statusOut.Conditions = append(statusOut.Conditions, monitoringv1.MonitoringCondition{
+				Type:               monitoringv1.ConfigurationCreateSuccess,
+				Status:             c.wantStatus,
+				LastUpdateTime:     metav1.Time{},
+				LastTransitionTime: metav1.Time{},
+				Reason:             c.wantReason,
+				Message:            c.wantMessage,
+			})
 
-	logger := testr.New(t)
-	ctx := logr.NewContext(context.Background(), logger)
-	opts := Options{
-		ProjectID: "test-proj",
-		Location:  "test-loc",
-		Cluster:   "test-cluster",
-	}
-	if err := opts.defaultAndValidate(logger); err != nil {
-		t.Fatal("Invalid options:", err)
-	}
+			logger := testr.New(t)
+			ctx := logr.NewContext(context.Background(), logger)
+			opts := Options{
+				ProjectID: "test-proj",
+				Location:  "test-loc",
+				Cluster:   "test-cluster",
+			}
+			if err := opts.defaultAndValidate(logger); err != nil {
+				t.Fatal("Invalid options:", err)
+			}
 
-	kubeClient := newFakeClientBuilder().
-		WithObjects(&monitoringv1.PodMonitoring{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "prom-example",
-				Namespace: "gmp-test",
-			},
-			Spec: monitoringv1.PodMonitoringSpec{
-				Endpoints: []monitoringv1.ScrapeEndpoint{{
-					Port:     intstr.FromString("metrics"),
-					Interval: "10s",
-				}},
-			},
-			Status: statusIn,
-		}).
-		WithObjects(&monitoringv1.OperatorConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      NameOperatorConfig,
-				Namespace: opts.PublicNamespace,
-			},
-		}).
-		WithObjects(&appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      NameCollector,
-				Namespace: opts.OperatorNamespace,
-			},
-			Spec: appsv1.DaemonSetSpec{
-				Selector: &metav1.LabelSelector{},
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Name: "prometheus",
-						}},
+			kubeClient := newFakeClientBuilder().
+				WithObjects(&monitoringv1.PodMonitoring{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prom-example",
+						Namespace: "gmp-test",
 					},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Endpoints: []monitoringv1.ScrapeEndpoint{c.endpoint},
+					},
+					Status: statusIn,
+				}).
+				WithObjects(&monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      NameOperatorConfig,
+						Namespace: opts.PublicNamespace,
+					},
+				}).
+				WithObjects(&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      NameCollector,
+						Namespace: opts.OperatorNamespace,
+					},
+					Spec: appsv1.DaemonSetSpec{
+						Selector: &metav1.LabelSelector{},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: "prometheus",
+								}},
+							},
+						},
+					},
+				}).
+				Build()
+
+			collectionReconciler := newCollectionReconciler(kubeClient, opts)
+			if _, err := collectionReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: opts.PublicNamespace,
+					Name:      NameOperatorConfig,
 				},
-			},
-		}).
-		Build()
+			}); err != nil {
+				t.Fatal(err)
+			}
 
-	collectionReconciler := newCollectionReconciler(kubeClient, opts)
-	if _, err := collectionReconciler.Reconcile(ctx, reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: opts.PublicNamespace,
-			Name:      NameOperatorConfig,
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	var podMonitorings monitoringv1.PodMonitoringList
-	if err := kubeClient.List(ctx, &podMonitorings); err != nil {
-		t.Fatal(err)
-	}
-	switch amount := len(podMonitorings.Items); amount {
-	case 1:
-		status := podMonitorings.Items[0].Status
-		for i := range status.Conditions {
-			// Normalize times because we cannot predict this.
-			condition := &status.Conditions[i]
-			condition.LastUpdateTime = metav1.Time{}
-			condition.LastTransitionTime = metav1.Time{}
-		}
-		if diff := cmp.Diff(status, statusOut); diff != "" {
-			t.Fatalf("invalid PodMonitoringStatus: %s", diff)
-		}
-	default:
-		t.Fatalf("invalid PodMonitorings found: %d", amount)
+			var podMonitorings monitoringv1.PodMonitoringList
+			if err := kubeClient.List(ctx, &podMonitorings); err != nil {
+				t.Fatal(err)
+			}
+			switch amount := len(podMonitorings.Items); amount {
+			case 1:
+				status := podMonitorings.Items[0].Status
+				for i := range status.Conditions {
+					// Normalize times because we cannot predict this.
+					condition := &status.Conditions[i]
+					condition.LastUpdateTime = metav1.Time{}
+					condition.LastTransitionTime = metav1.Time{}
+				}
+				if diff := cmp.Diff(status, statusOut); diff != "" {
+					t.Fatalf("invalid PodMonitoringStatus: %s", diff)
+				}
+			default:
+				t.Fatalf("invalid PodMonitorings found: %d", amount)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Made sure monitoring statuses are propagated when there is a failure.

Added a test case for it. Test logic wasn't modified. Only added variables to be able to change the podmonitoring and error messages.