### PR TITLE
chore: update setup-go action

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '~1.22'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:


### PR DESCRIPTION
[setup-go@v5](https://github.com/actions/setup-go?tab=readme-ov-file#v5) updates to Node 20 from Node 16, which is [deprecated as of September 11, 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol).