### PR TITLE
refactor: cleanup export flags

### DIFF
--- a/cmd/rule-evaluator/README.md
+++ b/cmd/rule-evaluator/README.md
@@ -60,7 +60,7 @@ Flags:
       --export.credentials-file=""  
                                  Credentials file for authentication with the
                                  GCM API.
-      --export.label.project-id=EXPORT.LABEL.PROJECT-ID  
+      --export.label.project-id=""  
                                  Default project ID set for all exported data.
                                  Prefer setting the external label "project_id"
                                  in the Prometheus configuration if not using
@@ -69,13 +69,12 @@ Flags:
                                  Mode for user agent used for requests against
                                  the GCM API. Valid values are "gke", "kubectl",
                                  "on-prem", "baremetal" or "unspecified".
-      --export.label.location=EXPORT.LABEL.LOCATION  
+      --export.label.location=""  
                                  The default location set for all exported data.
                                  Prefer setting the external label "location" in
                                  the Prometheus configuration if not using the
                                  auto-discovered default.
-      --export.label.cluster=EXPORT.LABEL.CLUSTER  
-                                 The default cluster set for all scraped
+      --export.label.cluster=""  The default cluster set for all scraped
                                  targets. Prefer setting the external label
                                  "cluster" in the Prometheus configuration if
                                  not using the auto-discovered default.
@@ -101,6 +100,12 @@ Flags:
                                  The buffer size for each individual shard.
                                  Each element in buffer (queue) consists of
                                  sample and hash.
+      --export.token-url=""      The request URL to generate token that's needed
+                                 to ingest metrics to the project
+      --export.token-body=""     The request Body to generate token that's
+                                 needed to ingest metrics to the project.
+      --export.quota-project=""  The projectID of an alternative project for
+                                 quota attribution.
       --export.debug.fetch-metadata-timeout=10s  
                                  The total timeout for the initial gathering
                                  of the best-effort GCP data from the metadata
@@ -110,15 +115,6 @@ Flags:
                                  information for the user agent. This is done on
                                  startup, so make sure this work to be faster
                                  than your readiness and liveliness probes.
-      --export.token-url=EXPORT.TOKEN-URL  
-                                 The request URL to generate token that's needed
-                                 to ingest metrics to the project
-      --export.token-body=EXPORT.TOKEN-BODY  
-                                 The request Body to generate token that's
-                                 needed to ingest metrics to the project.
-      --export.quota-project=EXPORT.QUOTA-PROJECT  
-                                 The projectID of an alternative project for
-                                 quota attribution.
       --export.ha.backend=none   Which backend to use to coordinate HA pairs
                                  that both send metric data to the GCM API.
                                  Valid values are "none" or "kube"

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -309,7 +309,7 @@ func TestExporter_wrapMetadata(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	e, err := New(ctx, log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true})
+	e, err := New(ctx, log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true}, NopLease())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -364,7 +364,7 @@ func TestExporter_drainBacklog(t *testing.T) {
 		t.Fatalf("Creating metric client failed: %s", err)
 	}
 
-	e, err := New(ctx, log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true})
+	e, err := New(ctx, log.NewJSONLogger(log.NewSyncWriter(os.Stderr)), nil, ExporterOpts{DisableAuth: true}, NopLease())
 	if err != nil {
 		t.Fatalf("Creating Exporter failed: %s", err)
 	}

--- a/pkg/export/gcm/promtest/local_export.go
+++ b/pkg/export/gcm/promtest/local_export.go
@@ -93,18 +93,14 @@ func (l *localExportWithGCM) start(t testing.TB, _ e2e.Environment) (v1.API, map
 		t.Fatalf("create Prometheus client: %s", err)
 	}
 
-	l.e, err = export.New(ctx, log.NewJSONLogger(os.Stderr), prometheus.NewRegistry(), export.ExporterOpts{
-		UserAgentEnv:     "pe-github-action-test",
-		Endpoint:         "monitoring.googleapis.com:443",
-		Compression:      "none",
-		MetricTypePrefix: export.MetricTypePrefix,
-
-		Cluster:   cluster,
-		Location:  location,
-		ProjectID: creds.ProjectID,
-
+	exporterOpts := export.ExporterOpts{
+		UserAgentEnv:        "pe-github-action-test",
+		Cluster:             cluster,
+		Location:            location,
+		ProjectID:           creds.ProjectID,
 		CredentialsFromJSON: l.gcmSA,
-	})
+	}
+	l.e, err = export.New(ctx, log.NewJSONLogger(os.Stderr), prometheus.NewRegistry(), exporterOpts, export.NopLease())
 	if err != nil {
 		t.Fatalf("create exporter: %v", err)
 	}


### PR DESCRIPTION
This PR cleans up all export flags so that:
- The code is more readable as it's more broken up by function.
- We could move these options to YAML one day and update them at runtime instead of at startup.

Changes:
- Ensures all flag values have their own struct.
- Move flag validation and defaulting to their own methods.
- Ensure all flag structs have only serializable values (e.g. `ExporterOpts.Lease` was moved out).
- Use URLs with `kingpin` (flag library) to avoid needing to parse strings manually.

I also broke up the monstrosity that was the `setup` package exporter constructor which returned a function that would create an exporter. The reason this was done was because first we setup flags and then returned a method that would create the exporter once the flags were parsed. Now you can just call `SetupFlags` and then call `exporter.New`.

Tested a Prometheus version built with these changes with `e2e` tests, and they pass.