### PR TITLE
fix: use clusterpodmonitoring for nvidia-dcgm

### DIFF
--- a/examples/nvidia-dcgm/pod-monitoring.yaml
+++ b/examples/nvidia-dcgm/pod-monitoring.yaml
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 apiVersion: monitoring.googleapis.com/v1
-kind: PodMonitoring
+kind: ClusterPodMonitoring
 metadata:
   name: nvidia-dcgm-exporter
-  namespace: gmp-public
   labels:
     app.kubernetes.io/name: nvidia-dcgm-exporter
     app.kubernetes.io/part-of: google-cloud-managed-prometheus
@@ -27,3 +26,5 @@ spec:
   endpoints:
   - port: metrics
     interval: 30s
+  targetLabels:
+    metadata: []


### PR DESCRIPTION
NVIDIA dcgm-exporter captures and records the "pod", "namespace", and "container" labels. We should honor those in our relabeling.

Hence, we use a ClusterPodMonitoring with an empty .targetLabels.metadata (akin to what we do for KSM) to preserve them.