### PR TITLE
test: add defaulting edge case for secret key selector

### DIFF
--- a/pkg/operator/apis/monitoring/v1/http_types_test.go
+++ b/pkg/operator/apis/monitoring/v1/http_types_test.go
@@ -70,6 +70,15 @@ func TestClusterSecretKeySelector_toPrometheusSecretRef_PodMonitoring(t *testing
 		},
 		{
 			monitoringNamespace: "foo",
+			secretNamespace:     metav1.NamespaceDefault,
+		},
+		{
+			monitoringNamespace: "foo",
+			secretNamespace:     "",
+			expectedNamespace:   "foo",
+		},
+		{
+			monitoringNamespace: "foo",
 			secretNamespace:     "foo",
 			expectedNamespace:   "foo",
 		},


### PR DESCRIPTION
Adds test case for scenario fixed by https://github.com/GoogleCloudPlatform/prometheus-engine/pull/995

This test fails in the 0.13 release branch but passes on main now that the above PR has been merged.