### PR TITLE
Update DCGM sample YAML so that /home/kubernetes/bin/nvidia is not created if it does not exist

### DIFF
--- a/examples/nvidia-dcgm/exporter.yaml
+++ b/examples/nvidia-dcgm/exporter.yaml
@@ -91,6 +91,7 @@ spec:
       - name: nvidia-install-dir-host
         hostPath:
           path: /home/kubernetes/bin/nvidia
+          type: Directory
       - name: pod-resources
         hostPath:
           path: /var/lib/kubelet/pod-resources


### PR DESCRIPTION
Context: b/345755257

Verified via https://kubernetes.io/docs/concepts/storage/volumes/?spm=a2c63.p38356.0.0.28874dcbfWkCRx#hostpath-volume-types this is a well-defined option.