### PR TITLE
docs: update dcgm daemonset sample yaml

### DIFF
--- a/examples/nvidia-dcgm/exporter.yaml
+++ b/examples/nvidia-dcgm/exporter.yaml
@@ -44,6 +44,7 @@ spec:
       - name: nvidia-install-dir-host
         hostPath:
           path: /home/kubernetes/bin/nvidia
+          type: Directory
       containers:
       - image: "nvcr.io/nvidia/cloud-native/dcgm:3.3.0-1-ubuntu22.04"
         command: ["nv-hostengine", "-n", "-b", "ALL"]


### PR DESCRIPTION
Same as #1009 but for the DCGM daemonset -- missed that there were two identical definitions (one for DCGM, one for DCGM exporter).