### PR TITLE
refactor: use scale subresource to update replica counts

### DIFF
--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -89,12 +89,22 @@ rules:
   resourceNames: ["rule-evaluator"]
   verbs: ["get", "patch", "update"]
 - resources:
+  - deployments/scale
+  apiGroups: ["apps"]
+  resourceNames: ["rule-evaluator"]
+  verbs: ["get", "patch", "update"]
+- resources:
   - services
   apiGroups: [""]
   resourceNames: ["alertmanager"]
   verbs: ["get", "list", "watch"]
 - resources:
   - statefulsets
+  apiGroups: ["apps"]
+  resourceNames: ["alertmanager"]
+  verbs: ["get", "patch", "update"]
+- resources:
+  - statefulsets/scale
   apiGroups: ["apps"]
   resourceNames: ["alertmanager"]
   verbs: ["get", "patch", "update"]

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -215,12 +215,22 @@ rules:
   resourceNames: ["rule-evaluator"]
   verbs: ["get", "patch", "update"]
 - resources:
+  - deployments/scale
+  apiGroups: ["apps"]
+  resourceNames: ["rule-evaluator"]
+  verbs: ["get", "patch", "update"]
+- resources:
   - services
   apiGroups: [""]
   resourceNames: ["alertmanager"]
   verbs: ["get", "list", "watch"]
 - resources:
   - statefulsets
+  apiGroups: ["apps"]
+  resourceNames: ["alertmanager"]
+  verbs: ["get", "patch", "update"]
+- resources:
+  - statefulsets/scale
   apiGroups: ["apps"]
   resourceNames: ["alertmanager"]
   verbs: ["get", "patch", "update"]


### PR DESCRIPTION
This PR helps us get rid of our Deployment and StatefulSet RBAC policies one day (in favor of only allowing the scale sub-resource).