### PR TITLE
feat: add insecure-skip-verify field to ClusterNodeMonitoring scrape endpoint

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusternodemonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusternodemonitorings.yaml
@@ -131,6 +131,14 @@ spec:
                         Timeout for metrics scrapes. Must be a valid Prometheus duration.
                         Must not be larger then the scrape interval.
                       type: string
+                    tls:
+                      description: TLS configures the scrape request's TLS settings.
+                      properties:
+                        insecureSkipVerify:
+                          description: InsecureSkipVerify disables target certificate
+                            validation.
+                          type: boolean
+                      type: object
                   type: object
                 type: array
               limits:

--- a/doc/api.md
+++ b/doc/api.md
@@ -24,6 +24,8 @@ Resource Types:
 </li><li>
 <a href="#monitoring.googleapis.com/v1.ClusterNodeMonitoringSpec">ClusterNodeMonitoringSpec</a>
 </li><li>
+<a href="#monitoring.googleapis.com/v1.ClusterNodeTLS">ClusterNodeTLS</a>
+</li><li>
 <a href="#monitoring.googleapis.com/v1.ClusterPodMonitoring">ClusterPodMonitoring</a>
 </li><li>
 <a href="#monitoring.googleapis.com/v1.ClusterPodMonitoringSpec">ClusterPodMonitoringSpec</a>
@@ -535,6 +537,37 @@ ScrapeLimits
 </td>
 <td>
 <p>Limits to apply at scrape time.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="monitoring.googleapis.com/v1.ClusterNodeTLS">
+<span id="ClusterNodeTLS">ClusterNodeTLS
+</span>
+</h3>
+<p>
+(<em>Appears in: </em><a href="#monitoring.googleapis.com/v1.ScrapeNodeEndpoint">ScrapeNodeEndpoint</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>insecureSkipVerify</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InsecureSkipVerify disables target certificate validation.</p>
 </td>
 </tr>
 </tbody>
@@ -2958,6 +2991,20 @@ Must not be larger then the scrape interval.</p>
 override protected target labels (project_id, location, cluster, namespace, job,
 instance, or <strong>address</strong>) are not permitted. The labelmap action is not permitted
 in general.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tls</code><br/>
+<em>
+<a href="#monitoring.googleapis.com/v1.ClusterNodeTLS">
+ClusterNodeTLS
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TLS configures the scrape request&rsquo;s TLS settings.</p>
 </td>
 </tr>
 </tbody>

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -127,6 +127,13 @@ spec:
                           Timeout for metrics scrapes. Must be a valid Prometheus duration.
                           Must not be larger then the scrape interval.
                         type: string
+                      tls:
+                        description: TLS configures the scrape request's TLS settings.
+                        properties:
+                          insecureSkipVerify:
+                            description: InsecureSkipVerify disables target certificate validation.
+                            type: boolean
+                        type: object
                     type: object
                   type: array
                 limits:

--- a/pkg/operator/apis/monitoring/v1/node_types.go
+++ b/pkg/operator/apis/monitoring/v1/node_types.go
@@ -51,6 +51,15 @@ type ScrapeNodeEndpoint struct {
 	// instance, or __address__) are not permitted. The labelmap action is not permitted
 	// in general.
 	MetricRelabeling []RelabelingRule `json:"metricRelabeling,omitempty"`
+	// TLS configures the scrape request's TLS settings.
+	// +optional
+	TLS *ClusterNodeTLS `json:"tls,omitempty"`
+}
+
+type ClusterNodeTLS struct {
+	// InsecureSkipVerify disables target certificate validation.
+	// +optional
+	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 }
 
 // ClusterNodeMonitoringSpec contains specification parameters for ClusterNodeMonitoring.
@@ -204,6 +213,9 @@ func (c *ClusterNodeMonitoring) endpointScrapeConfig(ep *ScrapeNodeEndpoint, pro
 		TLSConfig: config.TLSConfig{
 			CAFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 		},
+	}
+	if tls := ep.TLS; tls != nil {
+		httpCfg.TLSConfig.InsecureSkipVerify = tls.InsecureSkipVerify
 	}
 
 	return buildPrometheusScrapeConfig(fmt.Sprintf("%s%s", c.GetKey(), metricsPath), discoveryCfgs, httpCfg, relabelCfgs, c.Spec.Limits,


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/prometheus-engine/issues/807

And ensures we have full feature parity with the original Kubelet scraping options.