### PR TITLE
fix(deps): bump golang to 1.22-bullseye

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ export CURRENT_CONFIG_RELOADER_TAG = v0.9.0-gke.1
 #TODO(macxamin) Sync CURRENT_DATASOURCE_SYNCER_TAG with CURRENT_TAG
 export CURRENT_DATASOURCE_SYNCER_TAG = v0.10.0-gke.3
 export CURRENT_BASH_TAG = 20220419
-export LABEL_API_VERSION = 0.11.0
+export LABEL_API_VERSION = 0.11.2
 updateversions: ## Modify all manifests, so it contains the expected versions.
                 ##
                 ## TODO(bwplotka): CI does not check updateversions--add that there.

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -17,4 +17,4 @@ name: prometheus-engine
 description: Google Managed Service for Prometheus (GMP) Operator
 type: application
 version: 0.1.0
-appVersion: 0.11.0
+appVersion: 0.11.2

--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-bullseye AS buildbase
+FROM golang:1.22-bullseye@sha256:067c5c7fe6d79f900c5ebe8351166356d6e3bbfcc6f807030e89b9a929252273 AS buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/cmd/datasource-syncer/Dockerfile
+++ b/cmd/datasource-syncer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-bullseye AS buildbase
+FROM golang:1.22-bullseye@sha256:067c5c7fe6d79f900c5ebe8351166356d6e3bbfcc6f807030e89b9a929252273 AS buildbase
 WORKDIR /app
 COPY . ./
 

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM golang:1.22-bullseye AS buildbase
+FROM golang:1.22-bullseye@sha256:067c5c7fe6d79f900c5ebe8351166356d6e3bbfcc6f807030e89b9a929252273 AS buildbase
 
 # Compile the UI assets.
 FROM launcher.gcr.io/google/nodejs as assets

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22-bullseye AS buildbase
+FROM golang:1.22-bullseye@sha256:067c5c7fe6d79f900c5ebe8351166356d6e3bbfcc6f807030e89b9a929252273 AS buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/examples/instrumentation/go-synthetic/Dockerfile
+++ b/examples/instrumentation/go-synthetic/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20-bullseye AS buildbase
+FROM golang:1.22-bullseye@sha256:067c5c7fe6d79f900c5ebe8351166356d6e3bbfcc6f807030e89b9a929252273 AS buildbase
 WORKDIR /app
 COPY . ./
 

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -14,7 +14,7 @@
 
 # deps builds binaries in an isolated environment to avoid
 # funkiness in the hermetic build.
-FROM golang:1.22-bullseye as deps
+FROM golang:1.22-bullseye@sha256:067c5c7fe6d79f900c5ebe8351166356d6e3bbfcc6f807030e89b9a929252273 AS deps
 WORKDIR /workspace
 # Have to clone and install this as the go.mod uses replace directives.
 # RUN git clone --depth 1 --branch v0.53.1 https://github.com/prometheus-operator/prometheus-operator  \

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -322,7 +322,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.11.0
+        app.kubernetes.io/version: 0.11.2
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -506,7 +506,7 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.11.0
+        app.kubernetes.io/version: 0.11.2
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
@@ -586,7 +586,7 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
         app: managed-prometheus-rule-evaluator
-        app.kubernetes.io/version: 0.11.0
+        app.kubernetes.io/version: 0.11.2
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -751,7 +751,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.11.0
+        app.kubernetes.io/version: 0.11.2
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -530,7 +530,7 @@ const (
 	ClientName = "prometheus-engine-export"
 	// mainModuleVersion is the version of the main module. Align with git tag.
 	// TODO(TheSpiritXIII): Remove with https://github.com/golang/go/issues/50603
-	mainModuleVersion = "v0.11.1-rc.1" // x-release-please-version
+	mainModuleVersion = "v0.11.2-rc.0" // x-release-please-version
 	// mainModuleName is the name of the main module. Align with go.mod.
 	mainModuleName = "github.com/GoogleCloudPlatform/prometheus-engine"
 )


### PR DESCRIPTION
* This specifically fixes CVE-2024-24790 in the config-reloader and frontend containers.
* We also update all Dockerfiles to use 1.22-bullseye.
* We ensure we specify the image sha for precesion and repeatability.
* We prepare the manifests to tag v0.11.2.