### PR TITLE
chore: update to Go 1.22.4 for non-critical cmds

### DIFF
--- a/cmd/datasource-syncer/Dockerfile
+++ b/cmd/datasource-syncer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.3-bullseye AS buildbase
+FROM golang:1.22.4-bullseye as buildbase
 WORKDIR /app
 COPY . ./
 

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-FROM golang:1.22.4-bullseye AS buildbase
+FROM golang:1.22.4-bullseye as buildbase
 
 # Compile the UI assets.
 FROM launcher.gcr.io/google/nodejs as assets

--- a/examples/instrumentation/go-synthetic/Dockerfile
+++ b/examples/instrumentation/go-synthetic/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.3-bullseye AS buildbase
+FROM golang:1.22.4-bullseye as buildbase
 WORKDIR /app
 COPY . ./
 


### PR DESCRIPTION
Matches what we have in the release/0.12 branch. However, the release/0.12 branch forgot to update go-synthetic.