### PR TITLE
feat: allow loading rule-evaluator query options from config

### DIFF
--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -364,6 +364,7 @@ type update struct {
 
 type GoogleCloudConfig struct {
 	Export *GoogleCloudExportConfig `yaml:"export,omitempty"`
+	Query  *GoogleCloudQueryConfig  `yaml:"query,omitempty"`
 }
 
 type GoogleCloudExportConfig struct {

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -312,6 +312,12 @@ func (config *RuleEvaluatorConfig) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+type GoogleCloudQueryConfig struct {
+	ProjectID       string `yaml:"project_id,omitempty"`
+	GeneratorURL    string `yaml:"generator_url,omitempty"`
+	CredentialsFile string `yaml:"credentials,omitempty"`
+}
+
 // makeRuleEvaluatorConfig creates the config for rule-evaluator.
 // This is stored as a Secret rather than a ConfigMap as it could contain
 // sensitive configuration information.

--- a/pkg/operator/operator_config_test.go
+++ b/pkg/operator/operator_config_test.go
@@ -38,7 +38,11 @@ rule_files:
 google_cloud:
     export:
         compression: gzip
-        credentials: credentials.json
+        credentials: credentials1.json
+    query:
+        project_id: abc123
+        generator_url: http://example.com/
+        credentials: credentials2.json
 `
 	out := RuleEvaluatorConfig{}
 	if err := yaml.Unmarshal([]byte(code), &out); err != nil {
@@ -48,9 +52,14 @@ google_cloud:
 	expected := RuleEvaluatorConfig{
 		Config: config.DefaultConfig,
 		GoogleCloud: GoogleCloudConfig{
+			Query: &GoogleCloudQueryConfig{
+				ProjectID:       "abc123",
+				GeneratorURL:    "http://example.com/",
+				CredentialsFile: "credentials2.json",
+			},
 			Export: &GoogleCloudExportConfig{
 				Compression:     ptr.To(string(monitoringv1.CompressionGzip)),
-				CredentialsFile: ptr.To("credentials.json"),
+				CredentialsFile: ptr.To("credentials1.json"),
 			},
 		},
 	}


### PR DESCRIPTION
~~Pre-req: https://github.com/GoogleCloudPlatform/prometheus-engine/pull/1104~~

The following are now settable in the rule-evaluator Prometheus config:

```yaml
google_cloud:
  query:
    project_id: []string
    generator_url: string
    credentials: string
```

When both CLI arguments and configurations are present, the CLI arguments will be the default and the set configurations will override the CLI arguments.

For now, this is only settable at startup time. https://github.com/GoogleCloudPlatform/prometheus-engine/pull/1129 allows setting on runtime.