### PR TITLE
test: support kind tests with images without tags

### DIFF
--- a/hack/kind-test.sh
+++ b/hack/kind-test.sh
@@ -101,9 +101,9 @@ docker_tag_push() {
 # Ultimately this should be replaced with go templating.
 update_manifests() {
   for bin in "$@"; do
-    find manifests -type f -name "*.yaml" -exec sed -i "s#image: .*/${bin}:.*#image: localhost:${REGISTRY_PORT}/${bin}:${TAG_NAME}#g" {} \;
+    find manifests -type f -name "*.yaml" -exec sed -i -E "s#image: .*/${bin}(@.*)?:.*#image: localhost:${REGISTRY_PORT}/${bin}:${TAG_NAME}#g" {} \;
     if [ "$bin" = "go-synthetic" ]; then
-      find examples/instrumentation -type f -name "*.yaml" -exec sed -i "s#image: .*/example-app:.*#image: localhost:${REGISTRY_PORT}/${bin}:${TAG_NAME}#g" {} \;
+      find examples/instrumentation -type f -name "*.yaml" -exec sed -i -E "s#image: .*/example-app(@.*)?:.*#image: localhost:${REGISTRY_PORT}/${bin}:${TAG_NAME}#g" {} \;
     fi
   done
 }


### PR DESCRIPTION
Current sed regex breaks if there's no tag. We're moving to tag-less images, so this fixes that problem.