### PR TITLE
fix: change data source syncer period to 10 minutes

### DIFF
--- a/charts/datasource-syncer/templates/cronjob.yaml
+++ b/charts/datasource-syncer/templates/cronjob.yaml
@@ -18,7 +18,7 @@ kind: CronJob
 metadata:
   name: datasource-syncer
 spec:
-  schedule: "*/30 * * * *" # Run once every 30 minutes, must run at least once an hour.
+  schedule: "*/10 * * * *" # Run once every 10 minutes, must run at least once an hour.
   jobTemplate:
     spec:
       template:

--- a/cmd/datasource-syncer/README.md
+++ b/cmd/datasource-syncer/README.md
@@ -9,7 +9,7 @@ This CLI tool acts as a cron job which remotely syncs data to a given Grafana Pr
 
 By regularly refreshing the oAuth2 access token, you can configure Grafana to directly query Google Cloud Monitoring (Managed Service for Prometheus).
 
-[Google access tokens have a lifetime of 1 hour.](https://cloud.google.com/docs/authentication/token-types#at-lifetime) This script runs every 20 minutes to ensure you have an uninterrupted connection between Grafana and Google Cloud Monitoring.
+[Google access tokens have a lifetime of 1 hour.](https://cloud.google.com/docs/authentication/token-types#at-lifetime) This script runs every 10 minutes to ensure you have an uninterrupted connection between Grafana and Google Cloud Monitoring.
 
 For instructions, see the [Google Cloud documentation for configuring Grafana to use Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus/query).
 

--- a/cmd/datasource-syncer/README.md
+++ b/cmd/datasource-syncer/README.md
@@ -9,7 +9,7 @@ This CLI tool acts as a cron job which remotely syncs data to a given Grafana Pr
 
 By regularly refreshing the oAuth2 access token, you can configure Grafana to directly query Google Cloud Monitoring (Managed Service for Prometheus).
 
-[Google access tokens have a lifetime of 1 hour.](https://cloud.google.com/docs/authentication/token-types#at-lifetime) This script runs every 30 minutes to ensure you have an uninterrupted connection between Grafana and Google Cloud Monitoring.
+[Google access tokens have a lifetime of 1 hour.](https://cloud.google.com/docs/authentication/token-types#at-lifetime) This script runs every 20 minutes to ensure you have an uninterrupted connection between Grafana and Google Cloud Monitoring.
 
 For instructions, see the [Google Cloud documentation for configuring Grafana to use Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus/query).
 

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -55,7 +55,7 @@ kind: CronJob
 metadata:
   name: datasource-syncer
 spec:
-  schedule: "*/30 * * * *" # Run once every 30 minutes, must run at least once an hour.
+  schedule: "*/20 * * * *" # Run once every 20 minutes, must run at least once an hour.
   jobTemplate:
     spec:
       template:

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -55,7 +55,7 @@ kind: CronJob
 metadata:
   name: datasource-syncer
 spec:
-  schedule: "*/20 * * * *" # Run once every 20 minutes, must run at least once an hour.
+  schedule: "*/10 * * * *" # Run once every 10 minutes, must run at least once an hour.
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
fix: change data source syncer period to 10 minutes

Every 30 minutes meant that there could be at most 1 network timeout before losing connection. Running every 10 minutes instead makes it much less likely that a networking hiccup will cause Grafana to fail.