### PR TITLE
feat: set rule-evaluator options using config

### DIFF
--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -614,12 +614,3 @@ func isPodMonitoringScrapeEndpointSuccess(status *monitoringv1.ScrapeEndpointSta
 	}
 	return nil
 }
-
-func getEnvVar(evs []corev1.EnvVar, key string) string {
-	for _, ev := range evs {
-		if ev.Name == key {
-			return ev.Value
-		}
-	}
-	return ""
-}


### PR DESCRIPTION
Pre-req: https://github.com/GoogleCloudPlatform/prometheus-engine/pull/1129

Uses the new config settings instead of CLI flags for rule-evaluator, and makes Deployment UPDATE permissions optional.