### PR TITLE
fix: cadvisor/kubelet example regex

### DIFF
--- a/examples/cadvisor-metrics.yaml
+++ b/examples/cadvisor-metrics.yaml
@@ -24,8 +24,5 @@ spec:
     metricRelabeling:
     # Ensure any changes made to the metrics are also reflected in https://cloud.google.com/kubernetes-engine/docs/how-to/cadvisor-kubelet-metrics#cadvisor-metrics
     - sourceLabels: [__name__]
-      regex: >
-        container_(cpu_cfs_periods_total|cpu_cfs_throttled_periods_total|cpu_usage_seconds_total|memory_rss|memory_working_set_bytes)|
-        container_fs_(limit_bytes|read_seconds_total|reads_bytes_total|reads_total|usage_bytes|write_seconds_total|writes_bytes_total|writes_total)|
-        container_network_(receive_bytes|receive_packets_dropped|receive_packets|transmit_bytes|transmit_packets_dropped|transmit_packets)_total
+      regex: container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_limit_bytes|container_fs_read_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_usage_bytes|container_fs_write_seconds_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_rss|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total
       action: keep

--- a/examples/kubelet-metrics.yaml
+++ b/examples/kubelet-metrics.yaml
@@ -24,7 +24,5 @@ spec:
     metricRelabeling:
     # Ensure any changes made to the metrics are also reflected in https://cloud.google.com/kubernetes-engine/docs/how-to/cadvisor-kubelet-metrics#kubelet-pod-metrics
     - sourceLabels: [__name__]
-      regex: > 
-            kubelet_(node_name|certificate_manager_server_ttl_seconds|pleg_relist_duration_seconds|pod_worker_duration_seconds|running_containers|running_pods|runtime_operations_total)|
-            kubelet_volume_(stats_available_bytes|stats_capacity_bytes|stats_inodes_free|stats_inodes_used|stats_inodes|stats_used_bytes)
+      regex: kubelet_certificate_manager_server_ttl_seconds|kubelet_node_name|kubelet_pleg_relist_duration_seconds.*|kubelet_pod_worker_duration_seconds.*|kubelet_running_containers|kubelet_running_pods|kubelet_runtime_operations_total|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes
       action: keep


### PR DESCRIPTION
Cherry-pick f30fa3ab7956eafd8f7c5f248baf381030e5fdab from `main` onto the `release/0.13 branch`, as this is what we're deploying in the 0.13 release candidates.