### PR TITLE
Do not automount initcontainer service account token

### DIFF
--- a/charts/operator/templates/alertmanager.yaml
+++ b/charts/operator/templates/alertmanager.yaml
@@ -55,6 +55,7 @@ spec:
         components.gke.io/component-name: managed_prometheus
     spec:
       priorityClassName: gmp-critical
+      automountServiceAccountToken: false
       initContainers:
       - name: config-init
         image: {{.Values.images.bash.image}}:{{.Values.images.bash.tag}}

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -821,6 +821,7 @@ spec:
         components.gke.io/component-name: managed_prometheus
     spec:
       priorityClassName: gmp-critical
+      automountServiceAccountToken: false
       initContainers:
       - name: config-init
         image: gke.gcr.io/gke-distroless/bash:gke_distroless_20240607.00_p0


### PR DESCRIPTION
Set automountServiceAccountToken: false for alertmanager StatefulSet.

The pods of this daemonset don't interact with the kubernetes API. Security best practices recommend that we either use a dedicated service account for this pod or set automountServiceAccountToken: false.
