### PR TITLE
chore: add image tags to manifests

### DIFF
--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -19,24 +19,23 @@ namespace:
   system: gmp-system
 images:
   alertmanager:
-    image: gke.gcr.io/prometheus-engine/alertmanager@sha256
-    tag: "4311da6164f66c4097878c023d4aa5ab908641414e087ba4d5eb29b6126158bc"
+    image: gke.gcr.io/prometheus-engine/alertmanager
+    tag: "v0.25.1-gmp.7-gke.0@sha256:4311da6164f66c4097878c023d4aa5ab908641414e087ba4d5eb29b6126158bc"
   bash:
     image: gke.gcr.io/gke-distroless/bash
     tag: "gke_distroless_20240607.00_p0"
   configReloader:
-    image: gke.gcr.io/prometheus-engine/config-reloader@sha256
-    tag: "21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e"
+    image: gke.gcr.io/prometheus-engine/config-reloader
+    tag: "v0.12.0-gke.5@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e"
   operator:
-    image: gke.gcr.io/prometheus-engine/operator@sha256
-    tag: "0894c65806a6eac0b4119ee73ec8a52f6ca119960b37aded3776f3748a75d182"
+    image: gke.gcr.io/prometheus-engine/operator
+    tag: "v0.12.0-gke.5@sha256:0894c65806a6eac0b4119ee73ec8a52f6ca119960b37aded3776f3748a75d182"
   prometheus:
-    # TODO(bwplotka): Change to "v2.45.3-gmp.7-gke.0" once tags are cloned.
-    image: gke.gcr.io/prometheus-engine/prometheus@sha256
-    tag: "8c8e35af7e2b92ac9d82ce640621c0d3aa10d7d62856681af3572d0a8fbb787b"
+    image: gke.gcr.io/prometheus-engine/prometheus
+    tag: "v2.45.3-gmp.7-gke.0@sha256:8c8e35af7e2b92ac9d82ce640621c0d3aa10d7d62856681af3572d0a8fbb787b"
   ruleEvaluator:
-    image: gke.gcr.io/prometheus-engine/rule-evaluator@sha256
-    tag: "6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0"
+    image: gke.gcr.io/prometheus-engine/rule-evaluator
+    tag: "v0.12.0-gke.5@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0"
 resources:
   alertManager:
     limits:

--- a/charts/rule-evaluator/values.yaml
+++ b/charts/rule-evaluator/values.yaml
@@ -19,11 +19,11 @@ images:
     image: gke.gcr.io/gke-distroless/bash
     tag: "gke_distroless_20240607.00_p0"
   configReloader:
-    image: gke.gcr.io/prometheus-engine/config-reloader@sha256
-    tag: "21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e"
+    image: gke.gcr.io/prometheus-engine/config-reloader
+    tag: "v0.12.0-gke.5@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e"
   ruleEvaluator:
     image: gke.gcr.io/prometheus-engine/rule-evaluator@sha256
-    tag: "6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0"
+    tag: "v0.12.0-gke.5@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0"
 resources:
   bash:
     limits:

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: datasource-syncer-init
-        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.10.0-gke.3
+        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.12.0-gke.5@sha256:f065e90e3188ee3fd858cac74a8ed326446aaed51d1f222f29ebd5f7b29d1df7
         args:
         - "--datasource-uids=$DATASOURCE_UIDS"
         - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
@@ -49,7 +49,7 @@ spec:
         spec:
           containers:
           - name: datasource-syncer
-            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.10.0-gke.3
+            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.12.0-gke.5@sha256:f065e90e3188ee3fd858cac74a8ed326446aaed51d1f222f29ebd5f7b29d1df7
             args:
             - "--datasource-uids=$DATASOURCE_UIDS"
             - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"

--- a/examples/frontend.yaml
+++ b/examples/frontend.yaml
@@ -43,7 +43,7 @@ spec:
                 - linux
       containers:
       - name: frontend
-        image: gke.gcr.io/prometheus-engine/frontend:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/frontend:v0.12.0-gke.5@sha256:bf28e9778758663230f59d69c4f37b77bd3a7a81889912dcf409ddfe104b255d
         args:
         - "--web.listen-address=:9090"
         - "--query.project-id=$PROJECT_ID"

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -347,7 +347,7 @@ spec:
           privileged: false
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.12.0-gke.5@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -382,7 +382,7 @@ spec:
             - all
           privileged: false
       - name: prometheus
-        image: gke.gcr.io/prometheus-engine/prometheus@sha256:8c8e35af7e2b92ac9d82ce640621c0d3aa10d7d62856681af3572d0a8fbb787b
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.7-gke.0@sha256:8c8e35af7e2b92ac9d82ce640621c0d3aa10d7d62856681af3572d0a8fbb787b
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage
@@ -515,7 +515,7 @@ spec:
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator@sha256:0894c65806a6eac0b4119ee73ec8a52f6ca119960b37aded3776f3748a75d182
+        image: gke.gcr.io/prometheus-engine/operator:v0.12.0-gke.5@sha256:0894c65806a6eac0b4119ee73ec8a52f6ca119960b37aded3776f3748a75d182
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"
@@ -627,7 +627,7 @@ spec:
           privileged: false
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.12.0-gke.5@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -667,7 +667,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.12.0-gke.5@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
@@ -793,7 +793,7 @@ spec:
           privileged: false
       containers:
       - name: alertmanager
-        image: gke.gcr.io/prometheus-engine/alertmanager@sha256:4311da6164f66c4097878c023d4aa5ab908641414e087ba4d5eb29b6126158bc
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.7-gke.0@sha256:4311da6164f66c4097878c023d4aa5ab908641414e087ba4d5eb29b6126158bc
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data
@@ -828,7 +828,7 @@ spec:
             - all
           privileged: false
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.12.0-gke.5@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -116,7 +116,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.12.0-gke.5@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -153,7 +153,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator@sha256:v0.12.0-gke.5@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"


### PR DESCRIPTION
Our tagging pipeline was non-functional for a period, leading us to relying on using the image shas instead of tags.

Now that the pipeline is functional again, we can provide convenient image tags for reference and installations.

Fixes #1081 