### PR TITLE
fix: support target status for cadvisor

### DIFF
--- a/pkg/operator/endpoint_status_builder.go
+++ b/pkg/operator/endpoint_status_builder.go
@@ -163,7 +163,7 @@ func parseScrapePool(pool string) (scrapePool, error) {
 		}
 		return getClusterScopedScrapePool(pool, split), nil
 	case "ClusterNodeMonitoring":
-		if len(split) != 3 {
+		if len(split) != 3 && len(split) != 4 {
 			return scrapePool{}, fmt.Errorf("invalid ClusterNodeMonitoring scrape pool format %q", pool)
 		}
 		return getClusterScopedScrapePool(pool, split), nil

--- a/pkg/operator/target_status_test.go
+++ b/pkg/operator/target_status_test.go
@@ -1173,13 +1173,30 @@ func TestUpdateTargetStatus(t *testing.T) {
 			},
 		},
 		{
-			desc: "ClusterNodeMonitoring hardcoded scrape configs",
+			desc: "ClusterNodeMonitoring scrape configs - kubelet",
 			targets: []*prometheusv1.TargetsResult{
 				{
 					Active: []prometheusv1.ActiveTarget{{
 						Health:     "up",
 						LastError:  "",
-						ScrapePool: "ClusterNodeMonitoring/node-example-1/metrics",
+						ScrapePool: "ClusterNodeMonitoring/gmp-kubelet-metrics/metrics",
+						Labels: model.LabelSet(map[model.LabelName]model.LabelValue{
+							"instance": "a",
+							"node":     "node-1-default-pool-abcd1234",
+						}),
+						LastScrapeDuration: 1.2,
+					}},
+				},
+			},
+		},
+		{
+			desc: "ClusterNodeMonitoring scrape configs - cadvisor",
+			targets: []*prometheusv1.TargetsResult{
+				{
+					Active: []prometheusv1.ActiveTarget{{
+						Health:     "up",
+						LastError:  "",
+						ScrapePool: "ClusterNodeMonitoring/gmp-kubelet-cadvisor/metrics/cadvisor",
 						Labels: model.LabelSet(map[model.LabelName]model.LabelValue{
 							"instance": "a",
 							"node":     "node-1-default-pool-abcd1234",


### PR DESCRIPTION
Cherry pick of ccab5b3e7dad9a61ce159e438dba214f1b094234 onto the 0.13 release branch, so we can release a patch fix `v0.13.1` candidate.

We had not tested ClusterNodeMonitoring-generated cadvisor scrape targets, which have an additional path suffix in the scrape pool. We consider that here when building the endpoint status and add a unit test.

This fixes #1097.