### PR TITLE
chore: prepare v0.13.1 release candidate

### DIFF
--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -16,31 +16,29 @@ commonLabels: false
 namespace:
   public: gmp-public
   system: gmp-system
-version: 0.13.0
+version: 0.13.1
 images:
   bash:
     image: gke.gcr.io/gke-distroless/bash
     tag: "20220419" # NOTE: Has to be quoted otherwise it will be treated as a number.
   alertmanager:
     image: gke.gcr.io/prometheus-engine/alertmanager
-    tag: v0.25.1-gmp.2-gke.0
+    tag: "v0.25.1-gmp.8-gke.0@sha256:3854f01750baf1102adffb7d928522a0bd3f0f29d22c5fd659d63e0ee93bcab8"
   prometheus:
-    # TODO(bwplotka): Change to "v2.45.3-gmp.4-gke.0" once tags are cloned.
-    image: gke.gcr.io/prometheus-engine/prometheus@sha256
-    tag: 7473d52f4a3e563e6377f8a6183091f25192b1e0705dd0933903e800bd69b7b2
+    image: gke.gcr.io/prometheus-engine/prometheus
+    tag: "v2.45.3-gmp.9-gke.0@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
   configReloader:
     image: gke.gcr.io/prometheus-engine/config-reloader
-    tag: v0.9.0-gke.1
+    tag: v0.13.1-gke.0
   operator:
     image: gke.gcr.io/prometheus-engine/operator
-    tag: v0.9.0-gke.1
+    tag: v0.13.1-gke.0
   ruleEvaluator:
     image: gke.gcr.io/prometheus-engine/rule-evaluator
-    tag: v0.9.0-gke.1
+    tag: v0.13.1-gke.0
   datasourceSyncer:
     image: gcr.io/gke-release/prometheus-engine/datasource-syncer
-    #TODO(macxamin) Sync CURRENT_DATASOURCE_SYNCER_TAG with CURRENT_TAG
-    tag: v0.10.0-gke.3
+    tag: v0.13.1-gke.0
 resources:
   alertManager:
     limits:

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -41,7 +41,7 @@ spec:
                 - linux
       containers:
       - name: datasource-syncer-init
-        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.10.0-gke.3
+        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.13.1-gke.0
         args:
         - "--datasource-uids=$DATASOURCE_UIDS"
         - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
@@ -79,7 +79,7 @@ spec:
                     - linux
           containers:
           - name: datasource-syncer
-            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.10.0-gke.3
+            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.13.1-gke.0
             args:
             - "--datasource-uids=$DATASOURCE_UIDS"
             - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"

--- a/examples/frontend.yaml
+++ b/examples/frontend.yaml
@@ -43,7 +43,7 @@ spec:
                 - linux
       containers:
       - name: frontend
-        image: gke.gcr.io/prometheus-engine/frontend:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/frontend:v0.13.1-gke.0
         args:
         - "--web.listen-address=:9090"
         - "--query.project-id=$PROJECT_ID"

--- a/examples/instrumentation/go-synthetic/go-synthetic-basic-auth.yaml
+++ b/examples/instrumentation/go-synthetic/go-synthetic-basic-auth.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: go-synthetic
         # TODO(bwplotka): Rename image to go-synthetic (example-app is misleading, we actually use go-synthetic).
-        image: gke.gcr.io/prometheus-engine/example-app@sha256:40658e4aff1f5c696f08037f1cb3f3b947096e378f4cbe89fe4187de72cd9358
+        image: gke.gcr.io/prometheus-engine/example-app:v0.13.1-gke.0
         args:
         - "--listen-address=:8080"
         - "--cpu-burn-ops=75"

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -331,7 +331,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.13.0
+        app.kubernetes.io/version: 0.13.1
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -357,7 +357,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -393,7 +393,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: prometheus
-        image: gke.gcr.io/prometheus-engine/prometheus@sha256:7473d52f4a3e563e6377f8a6183091f25192b1e0705dd0933903e800bd69b7b2
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.9-gke.0@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage
@@ -527,14 +527,14 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.13.0
+        app.kubernetes.io/version: 0.13.1
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.9.0-gke.1
+        image: gke.gcr.io/prometheus-engine/operator:v0.13.1-gke.0
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"
@@ -628,7 +628,7 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
         app: managed-prometheus-rule-evaluator
-        app.kubernetes.io/version: 0.13.0
+        app.kubernetes.io/version: 0.13.1
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -654,7 +654,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -695,7 +695,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.9.0-gke.1
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.13.1-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
@@ -801,7 +801,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.13.0
+        app.kubernetes.io/version: 0.13.1
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
@@ -824,7 +824,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: alertmanager
-        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.2-gke.0
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.8-gke.0@sha256:3854f01750baf1102adffb7d928522a0bd3f0f29d22c5fd659d63e0ee93bcab8
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data
@@ -860,7 +860,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -103,7 +103,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.13.0
+        app.kubernetes.io/version: 0.13.1
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
@@ -116,7 +116,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.9.0-gke.1
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -154,7 +154,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.9.0-gke.1
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.13.1-gke.0
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"


### PR DESCRIPTION
First, we preemptively tag the binaries in this repo with their anticipated Docker image tags from the build pipeline.

Secondly, we bump the tags of prometheus and alertmanager to match what we expect will be deployed in the final manifest.