### PR TITLE
fix: use correct rule-evalutor image in manifest

### DIFF
--- a/charts/rule-evaluator/values.yaml
+++ b/charts/rule-evaluator/values.yaml
@@ -22,7 +22,7 @@ images:
     image: gke.gcr.io/prometheus-engine/config-reloader
     tag: "v0.12.0-gke.5@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e"
   ruleEvaluator:
-    image: gke.gcr.io/prometheus-engine/rule-evaluator@sha256
+    image: gke.gcr.io/prometheus-engine/rule-evaluator
     tag: "v0.12.0-gke.5@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0"
 resources:
   bash:

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -153,7 +153,7 @@ spec:
             - all
           privileged: false
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator@sha256:v0.12.0-gke.5@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.12.0-gke.5@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"


### PR DESCRIPTION
The standalone rule-evaluator image was incorrectly tagged in 353231bf3e90965e72c2ce77ab0f3367892ab2ac.