### PR TITLE
feat: add samples sent error counter

### DIFF
--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -70,7 +70,7 @@ var (
 		Name: "gcm_export_samples_sent_total",
 		Help: "Number of exported samples sent to GCM.",
 	})
-	samplesSentErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+	samplesSendErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "gcm_export_samples_send_errors_total",
 		Help: "Number of errors encountered while sending samples to GCM",
 	}, []string{"project_id"})
@@ -388,6 +388,7 @@ func New(ctx context.Context, logger log.Logger, reg prometheus.Registerer, opts
 			samplesExported,
 			samplesDropped,
 			samplesSent,
+			samplesSendErrors,
 			sendIterations,
 			shardProcess,
 			shardProcessPending,
@@ -1056,7 +1057,7 @@ func (b batch) send(
 			if err != nil {
 				//nolint:errcheck
 				level.Error(b.logger).Log("msg", "send batch", "size", len(l), "err", err)
-				samplesSentErrors.WithLabelValues(pid).Inc()
+				samplesSendErrors.WithLabelValues(pid).Inc()
 			}
 			samplesSent.Add(float64(len(l)))
 		}(pid, l)

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -70,6 +70,10 @@ var (
 		Name: "gcm_export_samples_sent_total",
 		Help: "Number of exported samples sent to GCM.",
 	})
+	samplesSentErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "gcm_export_samples_sent_errors_total",
+		Help: "Number of errors encountered while sending samples to GCM",
+	}, []string{"project_id"})
 	sendIterations = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "gcm_export_send_iterations_total",
 		Help: "Number of processing iterations of the sample export send handler.",
@@ -1052,6 +1056,7 @@ func (b batch) send(
 			if err != nil {
 				//nolint:errcheck
 				level.Error(b.logger).Log("msg", "send batch", "size", len(l), "err", err)
+				samplesSentErrors.WithLabelValues(pid).Inc()
 			}
 			samplesSent.Add(float64(len(l)))
 		}(pid, l)

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -71,7 +71,7 @@ var (
 		Help: "Number of exported samples sent to GCM.",
 	})
 	samplesSentErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "gcm_export_samples_sent_errors_total",
+		Name: "gcm_export_samples_send_errors_total",
 		Help: "Number of errors encountered while sending samples to GCM",
 	}, []string{"project_id"})
 	sendIterations = prometheus.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
We previously only logged an error when this happened, which can be hard to debug. Particularly in cases where we are writing to more than one project.

This change introduces a counter `gcm_export_samples_sent_errors_total` that is incremented every time a send call to GCM returns an error. We add the `project_id` as a label to help better inform the destination project that is experiencing the issue.

On a given collector or rule-evaluator, the cardinality of `project_id` values should be relatively small, O(100) in the more extreme cases.