### PR TITLE
feat: add more example self-podmonitorings

### DIFF
--- a/examples/self-pod-monitoring.yaml
+++ b/examples/self-pod-monitoring.yaml
@@ -52,3 +52,37 @@ spec:
     interval: 30s
   - port: cfg-rel-metrics
     interval: 30s
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  namespace: gmp-system
+  name: gmp-operator
+  labels:
+    app.kubernetes.io/name: gmp-operator
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gmp-operator
+  endpoints:
+  - port: metrics
+    interval: 30s
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  namespace: gmp-system
+  name: alertmanager
+  labels:
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  endpoints:
+  - port: alertmanager
+    interval: 30s
+  - port: cfg-rel-metrics
+    interval: 30s


### PR DESCRIPTION
The gmp-operator exposes Prometheus metrics that can be helpful to debug issues with managed-collection. This is also the case with the managed alertmanager.

We have examples of how to scrape metrics from other components, but not the operator or the alertmanager.

So here we provide examples to supplement the self-monitoring exporter documented in
https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/prometheus?hl=en.

Partly addresses #793.