### PR TITLE
feat: allow environment variable for GMP Grafana datasource-syncer

### DIFF
--- a/cmd/datasource-syncer/main.go
+++ b/cmd/datasource-syncer/main.go
@@ -70,9 +70,14 @@ func main() {
 	}
 
 	if *grafanaAPIToken == "" {
-		//nolint:errcheck
-		level.Error(logger).Log("msg", "--grafana-api-token must be set")
-		os.Exit(1)
+		envToken := os.Getenv("GRAFANA_SERVICE_ACCOUNT_TOKEN")
+		if envToken != "" {
+			grafanaAPIToken = &envToken
+		} else {
+			//nolint:errcheck
+			level.Error(logger).Log("msg", "--grafana-api-token or the environment variable GRAFANA_SERVICE_ACCOUNT_TOKEN must be set")
+			os.Exit(1)
+		}
 	}
 	if *grafanaEndpoint == "" {
 		//nolint:errcheck

--- a/cmd/datasource-syncer/main.go
+++ b/cmd/datasource-syncer/main.go
@@ -71,13 +71,12 @@ func main() {
 
 	if *grafanaAPIToken == "" {
 		envToken := os.Getenv("GRAFANA_SERVICE_ACCOUNT_TOKEN")
-		if envToken != "" {
-			grafanaAPIToken = &envToken
-		} else {
+		if envToken == "" {
 			//nolint:errcheck
 			level.Error(logger).Log("msg", "--grafana-api-token or the environment variable GRAFANA_SERVICE_ACCOUNT_TOKEN must be set")
 			os.Exit(1)
 		}
+		grafanaAPIToken = &envToken
 	}
 	if *grafanaEndpoint == "" {
 		//nolint:errcheck


### PR DESCRIPTION
It's requested by a customer who wants to pass the Grafana API token as an environment variable when deploy the datasource-syncer on Cloud Run.

The environment variable could have the API token as plain text or get the value from the GCP's Secret Manager service.