### PR TITLE
Use protobuf encoding for core K8s APIs in Prometheus Engine

### DIFF
--- a/e2e/kube/pod.go
+++ b/e2e/kube/pod.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,8 @@ import (
 
 // PodLogs returns the logs of the pod with the given name.
 func PodLogs(ctx context.Context, restConfig *rest.Config, namespace, name, container string) (string, error) {
+	coreConfig := rest.CopyConfig(restConfig)
+	coreConfig.ContentType = runtime.ContentTypeProtobuf
 	clientSet, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return "", err

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	coordinationv1client "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -102,6 +103,7 @@ func NewKubernetes(
 
 	// Construct clients for leader election
 	config = rest.CopyConfig(config)
+	config.ContentType = runtime.ContentTypeProtobuf
 	rest.AddUserAgent(config, "leader-election")
 
 	corev1Client, err := corev1client.NewForConfig(config)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -262,7 +262,9 @@ func New(logger logr.Logger, clientConfig *rest.Config, opts Options) (*Operator
 
 	// Determine whether VPA is installed in the cluster. If so, set up the scaling controller.
 	var vpaAvailable bool
-	clientset, err := apiextensions.NewForConfig(clientConfig)
+	coreClientConfig := rest.CopyConfig(clientConfig)
+	coreClientConfig.ContentType = runtime.ContentTypeProtobuf
+	clientset, err := apiextensions.NewForConfig(coreClientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("create clientset: %w", err)
 	}


### PR DESCRIPTION
For core K8s API objects like Pods, Nodes, etc., we can use protobuf encoding which, compared to the default JSON encoding, reduces CPU consumption related to (de)serialization, reduces overall latency of the API calls, reduces memory footprint and the work performed by the GC and results in quicker propagation of objects to event handlers of shared informers.

Core system components of K8s default their serialization method to protobuf for 8 years already: https://github.com/kubernetes/kubernetes/pull/25738.

Some benchmarks comparing JSON vs. protobuf showcasing how the latter data format (de)serializes faster and uses less memory:

- https://medium.com/@akresling/go-benchmark-json-v-protobuf-4ec3c62ec8d4
- https://www.codingexplorations.com/blog/performance-comparison-protobuf-marshaling-vs-json-marshaling-in-go
- https://medium.com/@david_turner/protocol-buffers-just-how-fast-are-they-9ec19ea580db