### PR TITLE
chore: update manifests to 0.13.1

### DIFF
--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -18,27 +18,28 @@ namespace:
   system: gmp-system
 version: 0.13.1
 images:
+  # NOTE: All tags have to be quoted otherwise they might be treated as a number.
   bash:
     image: gke.gcr.io/gke-distroless/bash
-    tag: "gke_distroless_20240607.00_p0" # NOTE: Has to be quoted otherwise it will be treated as a number.
+    tag: "gke_distroless_20240907.00_p0"
   alertmanager:
     image: gke.gcr.io/prometheus-engine/alertmanager
-    tag: "v0.25.1-gmp.8-gke.0@sha256:3854f01750baf1102adffb7d928522a0bd3f0f29d22c5fd659d63e0ee93bcab8"
+    tag: "v0.25.1-gmp.8-gke.0"
   prometheus:
     image: gke.gcr.io/prometheus-engine/prometheus
-    tag: "v2.45.3-gmp.9-gke.0@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+    tag: "v2.45.3-gmp.9-gke.0"
   configReloader:
     image: gke.gcr.io/prometheus-engine/config-reloader
-    tag: v0.13.1-gke.0
+    tag: "v0.13.1-gke.0"
   operator:
     image: gke.gcr.io/prometheus-engine/operator
-    tag: v0.13.1-gke.0
+    tag: "v0.13.1-gke.0"
   ruleEvaluator:
     image: gke.gcr.io/prometheus-engine/rule-evaluator
-    tag: v0.13.1-gke.0
+    tag: "v0.13.1-gke.0"
   datasourceSyncer:
     image: gcr.io/gke-release/prometheus-engine/datasource-syncer
-    tag: v0.13.1-gke.0
+    tag: "v0.13.1-gke.0"
 resources:
   alertManager:
     limits:

--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -16,29 +16,29 @@ commonLabels: false
 namespace:
   public: gmp-public
   system: gmp-system
-version: 0.13.0
+version: 0.13.1
 images:
   bash:
     image: gke.gcr.io/gke-distroless/bash
     tag: "gke_distroless_20240607.00_p0" # NOTE: Has to be quoted otherwise it will be treated as a number.
   alertmanager:
     image: gke.gcr.io/prometheus-engine/alertmanager
-    tag: "v0.25.1-gmp.8-gke.0"
+    tag: "v0.25.1-gmp.8-gke.0@sha256:3854f01750baf1102adffb7d928522a0bd3f0f29d22c5fd659d63e0ee93bcab8"
   prometheus:
     image: gke.gcr.io/prometheus-engine/prometheus
-    tag: v2.45.3-gmp.9-gke.0
+    tag: "v2.45.3-gmp.9-gke.0@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
   configReloader:
-    image: gke.gcr.io/prometheus-engine/config-reloader@sha256
-    tag: "21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e"
+    image: gke.gcr.io/prometheus-engine/config-reloader
+    tag: v0.13.1-gke.0
   operator:
-    image: gke.gcr.io/prometheus-engine/operator@sha256
-    tag: "0894c65806a6eac0b4119ee73ec8a52f6ca119960b37aded3776f3748a75d182"
+    image: gke.gcr.io/prometheus-engine/operator
+    tag: v0.13.1-gke.0
   ruleEvaluator:
-    image: gke.gcr.io/prometheus-engine/rule-evaluator@sha256
-    tag: "6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0"
+    image: gke.gcr.io/prometheus-engine/rule-evaluator
+    tag: v0.13.1-gke.0
   datasourceSyncer:
-    image: gcr.io/gke-release/prometheus-engine/datasource-syncer@sha256
-    tag: "f065e90e3188ee3fd858cac74a8ed326446aaed51d1f222f29ebd5f7b29d1df7"
+    image: gcr.io/gke-release/prometheus-engine/datasource-syncer
+    tag: v0.13.1-gke.0
 resources:
   alertManager:
     limits:

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -41,7 +41,7 @@ spec:
                 - linux
       containers:
       - name: datasource-syncer-init
-        image: gcr.io/gke-release/prometheus-engine/datasource-syncer@sha256:f065e90e3188ee3fd858cac74a8ed326446aaed51d1f222f29ebd5f7b29d1df7
+        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.13.1-gke.0
         args:
         - "--datasource-uids=$DATASOURCE_UIDS"
         - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
@@ -79,7 +79,7 @@ spec:
                     - linux
           containers:
           - name: datasource-syncer
-            image: gcr.io/gke-release/prometheus-engine/datasource-syncer@sha256:f065e90e3188ee3fd858cac74a8ed326446aaed51d1f222f29ebd5f7b29d1df7
+            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.13.1-gke.0
             args:
             - "--datasource-uids=$DATASOURCE_UIDS"
             - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"

--- a/examples/frontend.yaml
+++ b/examples/frontend.yaml
@@ -43,7 +43,7 @@ spec:
                 - linux
       containers:
       - name: frontend
-        image: gke.gcr.io/prometheus-engine/frontend:v0.8.0-gke.4
+        image: gke.gcr.io/prometheus-engine/frontend:v0.13.1-gke.0
         args:
         - "--web.listen-address=:9090"
         - "--query.project-id=$PROJECT_ID"

--- a/examples/instrumentation/go-synthetic/go-synthetic-basic-auth.yaml
+++ b/examples/instrumentation/go-synthetic/go-synthetic-basic-auth.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: go-synthetic
         # TODO(bwplotka): Rename image to go-synthetic (example-app is misleading, we actually use go-synthetic).
-        image: gke.gcr.io/prometheus-engine/example-app@sha256:40658e4aff1f5c696f08037f1cb3f3b947096e378f4cbe89fe4187de72cd9358
+        image: gke.gcr.io/prometheus-engine/example-app:v0.13.1-gke.0
         args:
         - "--listen-address=:8080"
         - "--cpu-burn-ops=75"

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -345,7 +345,7 @@ spec:
       priorityClassName: gmp-critical
       initContainers:
       - name: config-init
-        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20240607.00_p0
+        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20240907.00_p0
         command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
         volumeMounts:
         - name: config-out
@@ -395,7 +395,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: prometheus
-        image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.9-gke.0@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.9-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage
@@ -642,7 +642,7 @@ spec:
       priorityClassName: gmp-critical
       initContainers:
       - name: config-init
-        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20240607.00_p0
+        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20240907.00_p0
         command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
         volumeMounts:
         - name: config-out
@@ -812,7 +812,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
       - name: config-init
-        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20240607.00_p0
+        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20240907.00_p0
         command: ['/bin/bash', '-c', 'touch /alertmanager/config_out/config.yaml && echo -e "receivers:\n  - name: noop\nroute:\n  receiver: noop" > alertmanager/config_out/config.yaml']
         volumeMounts:
         - name: alertmanager-config
@@ -826,7 +826,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: alertmanager
-        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.8-gke.0@sha256:3854f01750baf1102adffb7d928522a0bd3f0f29d22c5fd659d63e0ee93bcab8
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.8-gke.0
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -333,7 +333,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.13.0
+        app.kubernetes.io/version: 0.13.1
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -359,7 +359,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -395,7 +395,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: prometheus
-        image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.9-gke.0
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.45.3-gmp.9-gke.0@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage
@@ -529,14 +529,14 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.13.0
+        app.kubernetes.io/version: 0.13.1
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator@sha256:0894c65806a6eac0b4119ee73ec8a52f6ca119960b37aded3776f3748a75d182
+        image: gke.gcr.io/prometheus-engine/operator:v0.13.1-gke.0
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"
@@ -630,7 +630,7 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
         app: managed-prometheus-rule-evaluator
-        app.kubernetes.io/version: 0.13.0
+        app.kubernetes.io/version: 0.13.1
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -656,7 +656,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -697,7 +697,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.13.1-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
@@ -803,7 +803,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.13.0
+        app.kubernetes.io/version: 0.13.1
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
@@ -826,7 +826,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: alertmanager
-        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.8-gke.0
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.8-gke.0@sha256:3854f01750baf1102adffb7d928522a0bd3f0f29d22c5fd659d63e0ee93bcab8
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data
@@ -862,7 +862,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -103,7 +103,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.13.0
+        app.kubernetes.io/version: 0.13.1
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
@@ -116,7 +116,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader@sha256:21055a361185da47fbd2c21389fb5cd00b54bfed5c784e0dc258b5b416beaf7e
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -154,7 +154,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator@sha256:6ae997a8ed636da06b7a9dc7fc950b98ce91c38c135aad2dcc95d6d3dd841ee0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.13.1-gke.0
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -109,7 +109,7 @@ spec:
       automountServiceAccountToken: true
       initContainers:
       - name: config-init
-        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20240607.00_p0
+        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20240907.00_p0
         command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
         volumeMounts:
         - name: config-out


### PR DESCRIPTION
Cherry pick of https://github.com/GoogleCloudPlatform/prometheus-engine/pull/1117/files#diff-812b265e1da8d8a3c64370d7d4b87bd6d109bda0d44b066ee86b8329d4004f43 and distroless bump.
