### PR TITLE
fix(frontend): use the alternative registry for the same image

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -46,5 +46,8 @@ policies:
           - main
           - operator
           - prometheus
+          - frontend
+          - datasource-syncer
+          - config-reloader
           - rule-evaluator
-        descriptionLength: 72
+        descriptionLength: 80

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.23.1-bullseye as buildbase
 
 # Compile the UI assets.
-FROM launcher.gcr.io/google/nodejs as assets
+FROM gcr.io/google-appengine/nodejs as assets
 # To build the UI we need a recent node version and the go toolchain.
 RUN install_node v17.9.0
 COPY --from=buildbase /usr/local/go /usr/local/


### PR DESCRIPTION
Rationale: https://github.com/GoogleCloudPlatform/prometheus-engine/actions/runs/10990949209/job/30521085208?pr=1149

403 on launcher.gcr.io/google/nodejs means it's suddenly private for unknown reasons. Luckily there is an alternative registry documented on the (archived) repo https://github.com/GoogleCloudPlatform/nodejs-docker

Also added conform rules for missing components.