### PR TITLE
feat: workload labels

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -138,8 +138,8 @@ spec:
                       description: |-
                         Relabeling rules for metrics scraped from this endpoint. Relabeling rules that
                         override protected target labels (project_id, location, cluster, namespace, job,
-                        instance, or __address__) are not permitted. The labelmap action is not permitted
-                        in general.
+                        instance, top_level_controller, top_level_controller_type, or __address__) are
+                        not permitted. The labelmap action is not permitted in general.
                       items:
                         description: RelabelingRule defines a single Prometheus relabeling
                           rule.
@@ -606,7 +606,8 @@ spec:
                       Permitted keys are `pod`, `container`, and `node` for PodMonitoring and
                       `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring. The `container`
                       label is only populated if the scrape port is referenced by name.
-                      Defaults to [pod, container] for PodMonitoring and [namespace, pod, container]
+                      Defaults to [pod, container, top_level_controller_name, top_level_controller_type] for
+                      PodMonitoring and [namespace, pod, container, top_level_controller_name, top_level_controller_type]
                       for ClusterPodMonitoring.
                       If set to null, it will be interpreted as the empty list for PodMonitoring
                       and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility

--- a/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -128,8 +128,8 @@ spec:
                       description: |-
                         Relabeling rules for metrics scraped from this endpoint. Relabeling rules that
                         override protected target labels (project_id, location, cluster, namespace, job,
-                        instance, or __address__) are not permitted. The labelmap action is not permitted
-                        in general.
+                        instance, top_level_controller, top_level_controller_type, or __address__) are
+                        not permitted. The labelmap action is not permitted in general.
                       items:
                         description: RelabelingRule defines a single Prometheus relabeling
                           rule.
@@ -556,7 +556,8 @@ spec:
                       Permitted keys are `pod`, `container`, and `node` for PodMonitoring and
                       `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring. The `container`
                       label is only populated if the scrape port is referenced by name.
-                      Defaults to [pod, container] for PodMonitoring and [namespace, pod, container]
+                      Defaults to [pod, container, top_level_controller_name, top_level_controller_type] for
+                      PodMonitoring and [namespace, pod, container, top_level_controller_name, top_level_controller_type]
                       for ClusterPodMonitoring.
                       If set to null, it will be interpreted as the empty list for PodMonitoring
                       and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility

--- a/doc/api.md
+++ b/doc/api.md
@@ -2721,8 +2721,8 @@ Must not be larger than the scrape interval.</p>
 <td>
 <p>Relabeling rules for metrics scraped from this endpoint. Relabeling rules that
 override protected target labels (project_id, location, cluster, namespace, job,
-instance, or <strong>address</strong>) are not permitted. The labelmap action is not permitted
-in general.</p>
+instance, top_level_controller, top_level_controller_type, or <strong>address</strong>) are
+not permitted. The labelmap action is not permitted in general.</p>
 </td>
 </tr>
 <tr>
@@ -3398,7 +3398,8 @@ See MinVersion in <a href="https://pkg.go.dev/crypto/tls#Config">https://pkg.go.
 Permitted keys are <code>pod</code>, <code>container</code>, and <code>node</code> for PodMonitoring and
 <code>pod</code>, <code>container</code>, <code>node</code>, and <code>namespace</code> for ClusterPodMonitoring. The <code>container</code>
 label is only populated if the scrape port is referenced by name.
-Defaults to [pod, container] for PodMonitoring and [namespace, pod, container]
+Defaults to [pod, container, top_level_controller_name, top_level_controller_type] for
+PodMonitoring and [namespace, pod, container, top_level_controller_name, top_level_controller_type]
 for ClusterPodMonitoring.
 If set to null, it will be interpreted as the empty list for PodMonitoring
 and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -377,8 +377,8 @@ spec:
                         description: |-
                           Relabeling rules for metrics scraped from this endpoint. Relabeling rules that
                           override protected target labels (project_id, location, cluster, namespace, job,
-                          instance, or __address__) are not permitted. The labelmap action is not permitted
-                          in general.
+                          instance, top_level_controller, top_level_controller_type, or __address__) are
+                          not permitted. The labelmap action is not permitted in general.
                         items:
                           description: RelabelingRule defines a single Prometheus relabeling rule.
                           properties:
@@ -812,7 +812,8 @@ spec:
                         Permitted keys are `pod`, `container`, and `node` for PodMonitoring and
                         `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring. The `container`
                         label is only populated if the scrape port is referenced by name.
-                        Defaults to [pod, container] for PodMonitoring and [namespace, pod, container]
+                        Defaults to [pod, container, top_level_controller_name, top_level_controller_type] for
+                        PodMonitoring and [namespace, pod, container, top_level_controller_name, top_level_controller_type]
                         for ClusterPodMonitoring.
                         If set to null, it will be interpreted as the empty list for PodMonitoring
                         and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
@@ -2573,8 +2574,8 @@ spec:
                         description: |-
                           Relabeling rules for metrics scraped from this endpoint. Relabeling rules that
                           override protected target labels (project_id, location, cluster, namespace, job,
-                          instance, or __address__) are not permitted. The labelmap action is not permitted
-                          in general.
+                          instance, top_level_controller, top_level_controller_type, or __address__) are
+                          not permitted. The labelmap action is not permitted in general.
                         items:
                           description: RelabelingRule defines a single Prometheus relabeling rule.
                           properties:
@@ -2968,7 +2969,8 @@ spec:
                         Permitted keys are `pod`, `container`, and `node` for PodMonitoring and
                         `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring. The `container`
                         label is only populated if the scrape port is referenced by name.
-                        Defaults to [pod, container] for PodMonitoring and [namespace, pod, container]
+                        Defaults to [pod, container, top_level_controller_name, top_level_controller_type] for
+                        PodMonitoring and [namespace, pod, container, top_level_controller_name, top_level_controller_type]
                         for ClusterPodMonitoring.
                         If set to null, it will be interpreted as the empty list for PodMonitoring
                         and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility

--- a/pkg/operator/apis/monitoring/v1/pod_types.go
+++ b/pkg/operator/apis/monitoring/v1/pod_types.go
@@ -108,7 +108,7 @@ func (p *PodMonitoring) Default() {
 // UpdateDefault defaults any unset fields, returning true if the object was updated.
 func (p *PodMonitoring) UpdateDefault() bool {
 	if p.Spec.TargetLabels.Metadata == nil {
-		md := []string{"pod", "container"}
+		md := []string{"pod", "container", "top_level_controller_name", "top_level_controller_type"}
 		p.Spec.TargetLabels.Metadata = &md
 		return true
 	}
@@ -188,7 +188,7 @@ func (c *ClusterPodMonitoring) Default() {
 // UpdateDefault defaults any unset fields, returning true if the object was updated.
 func (c *ClusterPodMonitoring) UpdateDefault() bool {
 	if c.Spec.TargetLabels.Metadata == nil {
-		md := []string{"namespace", "pod", "container"}
+		md := []string{"namespace", "pod", "container", "top_level_controller_name", "top_level_controller_type"}
 		c.Spec.TargetLabels.Metadata = &md
 		return true
 	}
@@ -283,8 +283,8 @@ type ScrapeEndpoint struct {
 	Timeout string `json:"timeout,omitempty"`
 	// Relabeling rules for metrics scraped from this endpoint. Relabeling rules that
 	// override protected target labels (project_id, location, cluster, namespace, job,
-	// instance, or __address__) are not permitted. The labelmap action is not permitted
-	// in general.
+	// instance, top_level_controller, top_level_controller_type, or __address__) are
+	// not permitted. The labelmap action is not permitted in general.
 	MetricRelabeling []RelabelingRule `json:"metricRelabeling,omitempty"`
 	// Prometheus HTTP client configuration.
 	HTTPClientConfig `json:",inline"`
@@ -296,7 +296,8 @@ type TargetLabels struct {
 	// Permitted keys are `pod`, `container`, and `node` for PodMonitoring and
 	// `pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring. The `container`
 	// label is only populated if the scrape port is referenced by name.
-	// Defaults to [pod, container] for PodMonitoring and [namespace, pod, container]
+	// Defaults to [pod, container, top_level_controller_name, top_level_controller_type] for
+	// PodMonitoring and [namespace, pod, container, top_level_controller_name, top_level_controller_type]
 	// for ClusterPodMonitoring.
 	// If set to null, it will be interpreted as the empty list for PodMonitoring
 	// and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility

--- a/pkg/operator/collection_test.go
+++ b/pkg/operator/collection_test.go
@@ -246,7 +246,7 @@ func TestCollectionReconcile(t *testing.T) {
 					ResourceVersion: "2",
 				}, Spec: monitoringv1.PodMonitoringSpec{
 					TargetLabels: monitoringv1.TargetLabels{
-						Metadata: &[]string{"pod", "container"},
+						Metadata: &[]string{"pod", "container", "top_level_controller_name", "top_level_controller_type"},
 					},
 					Endpoints: validScrapeEndpoints,
 				},
@@ -281,7 +281,7 @@ func TestCollectionReconcile(t *testing.T) {
 					ResourceVersion: "3",
 				}, Spec: monitoringv1.PodMonitoringSpec{
 					TargetLabels: monitoringv1.TargetLabels{
-						Metadata: &[]string{"pod", "container"},
+						Metadata: &[]string{"pod", "container", "top_level_controller_name", "top_level_controller_type"},
 					},
 					Endpoints: validScrapeEndpoints,
 				},
@@ -430,7 +430,7 @@ func TestCollectionReconcile(t *testing.T) {
 					ResourceVersion: "2",
 				}, Spec: monitoringv1.ClusterPodMonitoringSpec{
 					TargetLabels: monitoringv1.TargetLabels{
-						Metadata: &[]string{"namespace", "pod", "container"},
+						Metadata: &[]string{"namespace", "pod", "container", "top_level_controller_name", "top_level_controller_type"},
 					},
 					Endpoints: validScrapeEndpoints,
 				},
@@ -465,7 +465,7 @@ func TestCollectionReconcile(t *testing.T) {
 					ResourceVersion: "3",
 				}, Spec: monitoringv1.ClusterPodMonitoringSpec{
 					TargetLabels: monitoringv1.TargetLabels{
-						Metadata: &[]string{"namespace", "pod", "container"},
+						Metadata: &[]string{"namespace", "pod", "container", "top_level_controller_name", "top_level_controller_type"},
 					},
 					Endpoints: validScrapeEndpoints,
 				},


### PR DESCRIPTION
Reimplement #1065 with new requirements, as revised in go/gmp:expand-target-labels.