### PR TITLE
feat: add rules-evaluator proxy calls to frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@
 !e2e
 !third_party
 !vendor
+!internal
 pkg/ui/build
 pkg/ui/assets_vfsdata.go
 **/Dockerfile

--- a/charts/operator/templates/rule-evaluator.yaml
+++ b/charts/operator/templates/rule-evaluator.yaml
@@ -175,3 +175,20 @@ spec:
         runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rule-evaluator
+  namespace: {{.Values.namespace.system}}
+  {{- if .Values.commonLabels }}
+  labels:
+    {{- include "prometheus-engine.rule-evaluator.labels" . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+      {{- include "prometheus-engine.rule-evaluator.selectorLabels" . | nindent 6 }}
+  ports:
+    - name: rule-evaluator
+      port: 19092
+      targetPort: 19092

--- a/charts/rule-evaluator/templates/service.yaml
+++ b/charts/rule-evaluator/templates/service.yaml
@@ -1,0 +1,28 @@
+{{- /*
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: rule-evaluator
+  labels:
+    {{- include "rule-evaluator.labels" . | nindent 4 }}
+spec:
+  selector:
+      {{- include "rule-evaluator.selectorLabels" . | nindent 6 }}
+  ports:
+    - name: rule-evaluator
+      port: 9092
+      targetPort: 9092

--- a/cmd/frontend/README.md
+++ b/cmd/frontend/README.md
@@ -12,6 +12,8 @@ Currently, the following API endpoints are supported:
 * `api/v1/query`
 * `api/v1/query_range`
 * `api/v1/label/__name__/values`
+* `api/v1/rules`
+* `api/v1/alerts`
 
 ## Spinup
 
@@ -49,6 +51,8 @@ Usage of frontend:
     	Project ID of the Google Cloud Monitoring workspace project to query.
   -query.target-url string
     	The URL to forward authenticated requests to. (PROJECT_ID is replaced with the --query.project-id flag.) (default "https://monitoring.googleapis.com/v1/projects/PROJECT_ID/location/global/prometheus")
+  -rules.target-urls string
+    	Comma separated lists of URLs that support HTTP Prometheus Alert and Rules APIs (/api/v1/alerts, /api/v1/rules), e.g. GMP rule-evaluator. NOTE: Results are merged as-is, no sorting and deduplication is done. (default "http://rule-evaluator.gmp-system.svc.cluster.local:19092")
   -web.external-url string
     	The URL under which the frontend is externally reachable (for example, if it is served via a reverse proxy). Used for generating relative and absolute links back to the frontend itself. If the URL has a path portion, it will be used to prefix served HTTP endpoints. If omitted, relevant URL components will be derived automatically.
   -web.listen-address string

--- a/cmd/frontend/internal/rule/client.go
+++ b/cmd/frontend/internal/rule/client.go
@@ -1,0 +1,116 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/GoogleCloudPlatform/prometheus-engine/internal/promapi"
+	promapiv1 "github.com/prometheus/prometheus/web/api/v1"
+)
+
+const (
+	rulesPath  = "/api/v1/rules"
+	alertsPath = "/api/v1/alerts"
+)
+
+var errRequestFailed = errors.New("request to endpoint failed")
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// client is a client for fetching rules and alerts from a Prometheus-compatible endpoint.
+type client struct {
+	client httpClient
+}
+
+// newClient creates a new client.
+func newClient(c httpClient) *client {
+	return &client{client: c}
+}
+
+// RuleGroups fetches rule-groups from a single endpoint.
+func (r *client) RuleGroups(ctx context.Context, baseURL url.URL, queryString string) ([]*promapiv1.RuleGroup, error) {
+	resp, err := r.call(ctx, baseURL, rulesPath, queryString)
+	if err != nil {
+		return nil, fmt.Errorf("calling endpoint failed with error: %w", err)
+	}
+
+	var parsedResp promapi.Response[promapi.RulesResponseData]
+	if err := json.Unmarshal(resp, &parsedResp); err != nil {
+		return nil, fmt.Errorf("unmarshalling response from endpoint failed with error: %w", err)
+	}
+
+	return parsedResp.Data.Groups, nil
+}
+
+// Alerts fetches alerts from the endpoint.
+func (r *client) Alerts(ctx context.Context, baseURL url.URL, queryString string) ([]*promapiv1.Alert, error) {
+	resp, err := r.call(ctx, baseURL, alertsPath, queryString)
+	if err != nil {
+		return nil, fmt.Errorf("calling endpoint failed with error: %w", err)
+	}
+
+	var parsedResp promapi.Response[promapi.AlertsResponseData]
+	if err := json.Unmarshal(resp, &parsedResp); err != nil {
+		return nil, fmt.Errorf("unmarshalling response from endpoint failed with error: %w", err)
+	}
+
+	return parsedResp.Data.Alerts, nil
+}
+
+// call calls the server with the given query string and returns the response.
+func (r *client) call(ctx context.Context, baseURL url.URL, endpoint, queryString string) ([]byte, error) {
+	fullURL := url.URL{
+		Scheme:   baseURL.Scheme,
+		Host:     baseURL.Host,
+		Path:     path.Join(baseURL.Path, endpoint),
+		RawQuery: queryString,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("constructing request to endpoint %s failed with error: %w", baseURL.Path, err)
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, fmt.Errorf("request to endpoint %s was canceled: %w", baseURL.Path, err)
+		}
+
+		return nil, fmt.Errorf("request to endpoint %s failed with error: %w", baseURL.Path, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request to endpoint %s failed with status code: %d. error: %w", baseURL.Path, resp.StatusCode, errRequestFailed)
+	}
+
+	defer resp.Body.Close()
+	rawResponse, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body from endpoint %s failed with error: %w", baseURL.Path, err)
+	}
+
+	return rawResponse, nil
+}

--- a/cmd/frontend/internal/rule/client_test.go
+++ b/cmd/frontend/internal/rule/client_test.go
@@ -1,0 +1,223 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	promapiv1 "github.com/prometheus/prometheus/web/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+type mockClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockClient) Do(req *http.Request) (*http.Response, error) {
+	return m.DoFunc(req)
+}
+
+func TestClient_call(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		baseURL     url.URL
+		endpoint    string
+		queryString string
+	}
+
+	for _, tt := range []struct {
+		name    string
+		client  httpClient
+		args    args
+		want    string
+		wantErr error
+	}{
+		{
+			name: "happy path",
+			client: &mockClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					require.Equal(t, "GET", req.Method)
+					require.Equal(t, "http://example.edu/api/v1/test?queryParam=foo", req.URL.String())
+					return &http.Response{
+						Body:       io.NopCloser(strings.NewReader(`{"key": "value"}`)),
+						StatusCode: http.StatusOK,
+					}, nil
+				},
+			},
+			args: args{
+				baseURL:     url.URL{Scheme: "http", Host: "example.edu", Path: "/api/v1/"},
+				endpoint:    "test",
+				queryString: "queryParam=foo",
+			},
+			want:    `{"key": "value"}`,
+			wantErr: nil,
+		},
+		{
+			name: "error on non-2xx status code",
+			client: &mockClient{
+				DoFunc: func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Body:       io.NopCloser(nil),
+						StatusCode: http.StatusTeapot,
+					}, nil
+				},
+			},
+			wantErr: errRequestFailed,
+		},
+		{
+			name: "error on client-response error",
+			client: &mockClient{
+				DoFunc: func(_ *http.Request) (*http.Response, error) {
+					return nil, context.Canceled
+				},
+			},
+			wantErr: context.Canceled,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newClient(tt.client)
+			got, err := r.call(context.Background(), tt.args.baseURL, tt.args.endpoint, tt.args.queryString)
+
+			require.ErrorIs(t, err, tt.wantErr)
+			require.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestClient_Alerts(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		client      httpClient
+		baseURL     url.URL
+		queryString string
+		want        []*promapiv1.Alert
+		wantErr     bool
+	}{
+		{
+			name: "happy path",
+			client: &mockClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					require.Equal(t, "GET", req.Method)
+					require.Equal(t, "http://example.edu/path-prefix/api/v1/alerts?queryParam=foo", req.URL.String())
+					return &http.Response{
+						Body:       io.NopCloser(strings.NewReader(`{"status": "success", "data": {"alerts": [{"state": "firing"}]}}`)),
+						StatusCode: http.StatusOK,
+					}, nil
+				},
+			},
+			baseURL:     url.URL{Scheme: "http", Host: "example.edu", Path: "/path-prefix"},
+			queryString: "queryParam=foo",
+			want:        []*promapiv1.Alert{{State: "firing"}},
+		},
+		{
+			name: "json-unmarshal error results in error",
+			client: &mockClient{
+				DoFunc: func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Body:       io.NopCloser(strings.NewReader(`not-json`)),
+						StatusCode: http.StatusOK,
+					}, nil
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "client-response error results in error",
+			client: &mockClient{
+				DoFunc: func(_ *http.Request) (*http.Response, error) {
+					return nil, context.Canceled
+				},
+			},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newClient(tt.client)
+			got, err := r.Alerts(context.Background(), tt.baseURL, tt.queryString)
+
+			require.Equal(t, tt.wantErr, err != nil)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClient_Rules(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		client      httpClient
+		baseURL     url.URL
+		queryString string
+		want        []*promapiv1.RuleGroup
+		wantErr     bool
+	}{
+		{
+			name: "happy path",
+			client: &mockClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					require.Equal(t, "GET", req.Method)
+					require.Equal(t, "http://example.edu/path-prefix/api/v1/rules?queryParam=bar", req.URL.String())
+					return &http.Response{
+						Body:       io.NopCloser(strings.NewReader(`{"status": "success", "data": {"groups": [{"name": "test"}]}}`)),
+						StatusCode: http.StatusOK,
+					}, nil
+				},
+			},
+			baseURL:     url.URL{Scheme: "http", Host: "example.edu", Path: "/path-prefix"},
+			queryString: "queryParam=bar",
+			want:        []*promapiv1.RuleGroup{{Name: "test"}},
+		},
+		{
+			name: "json-unmarshal error results in error",
+			client: &mockClient{
+				DoFunc: func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Body:       io.NopCloser(strings.NewReader(`not-json`)),
+						StatusCode: http.StatusOK,
+					}, nil
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "client-response error results in error",
+			client: &mockClient{
+				DoFunc: func(_ *http.Request) (*http.Response, error) {
+					return nil, context.Canceled
+				},
+			},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newClient(tt.client)
+			got, err := r.RuleGroups(context.Background(), tt.baseURL, tt.queryString)
+
+			require.Equal(t, tt.wantErr, err != nil)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/frontend/internal/rule/proxy.go
+++ b/cmd/frontend/internal/rule/proxy.go
@@ -1,0 +1,160 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/prometheus-engine/internal/promapi"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	promapiv1 "github.com/prometheus/prometheus/web/api/v1"
+)
+
+var errAllEndpointsFailed = errors.New("all endpoint failed")
+
+// Retriever is an interface for fetching rules and alerts.
+type retriever interface {
+	RuleGroups(ctx context.Context, baseURL url.URL, queryString string) ([]*promapiv1.RuleGroup, error)
+	Alerts(ctx context.Context, baseURL url.URL, queryString string) ([]*promapiv1.Alert, error)
+}
+
+// Proxy fan-outs requests to multiple endpoints serving rules and alerts.
+// Results are un-sorted and concatenated as-is. In case of errors from any endpoint,
+// warning log and partial results are returned.
+type Proxy struct {
+	logger    log.Logger
+	endpoints []url.URL
+	client    retriever
+}
+
+// NewProxy creates a new proxy.
+func NewProxy(logger log.Logger, c httpClient, ruleEndpoints []url.URL) *Proxy {
+	return &Proxy{
+		logger:    logger,
+		endpoints: ruleEndpoints,
+		client:    newClient(c),
+	}
+}
+
+func (p *Proxy) RuleGroups(w http.ResponseWriter, req *http.Request) {
+	rules, err := fanoutForward[*promapiv1.RuleGroup](req.Context(), p.logger, p.endpoints, req.URL.RawQuery, p.client.RuleGroups)
+	if err != nil {
+		p.handleError(w, req, err)
+		return
+	}
+
+	promapi.WriteSuccessResponse(p.logger, w, http.StatusOK, req.URL.Path, promapi.RulesResponseData{Groups: rules})
+}
+
+func (p *Proxy) Alerts(w http.ResponseWriter, req *http.Request) {
+	alerts, err := fanoutForward[*promapiv1.Alert](req.Context(), p.logger, p.endpoints, req.URL.RawQuery, p.client.Alerts)
+	if err != nil {
+		p.handleError(w, req, err)
+		return
+	}
+
+	promapi.WriteSuccessResponse(p.logger, w, http.StatusOK, req.URL.Path, promapi.AlertsResponseData{Alerts: alerts})
+}
+
+// fanoutForward calls the endpoints in parallel and returns the combined results.
+func fanoutForward[T *promapiv1.Alert | *promapiv1.RuleGroup](
+	ctx context.Context,
+	logger log.Logger,
+	ruleEndpoints []url.URL,
+	rawQuery string,
+	retrieveFn func(context.Context, url.URL, string) ([]T, error),
+) ([]T, error) {
+	if len(ruleEndpoints) == 0 {
+		_ = level.Warn(logger).Log("msg", "tried to fetch rules/alerts, no endpoints (--rules.target-urls) configured")
+		return []T{}, nil
+	}
+
+	var (
+		wg                  = sync.WaitGroup{}
+		resultChan, errChan = make(chan []T), make(chan error)
+		results             []T
+		errs                []error
+	)
+
+	// Parallel call to all endpoints.
+	for _, baseURL := range ruleEndpoints {
+		wg.Add(1)
+		go func(baseURL url.URL) {
+			defer wg.Done()
+
+			result, err := retrieveFn(ctx, baseURL, rawQuery)
+			if err != nil {
+				errChan <- fmt.Errorf("retrieving alerts from %s failed: %w", baseURL.String(), err)
+				return
+			}
+
+			resultChan <- result
+		}(baseURL)
+	}
+
+	go func() {
+		// Wait for all rule evaluators to finish and close the channels.
+		wg.Wait()
+		close(resultChan)
+		close(errChan)
+	}()
+
+	// Collect results and errors from the channels.
+	for resultChan != nil || errChan != nil {
+		select {
+		case result, ok := <-resultChan:
+			if !ok {
+				resultChan = nil
+				continue
+			}
+			results = append(results, result...)
+		case err, ok := <-errChan:
+			if !ok {
+				errChan = nil
+				continue
+			}
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) != 0 {
+		if len(errs) == len(ruleEndpoints) {
+			_ = level.Error(logger).Log("msg", "all endpoints failed", "errors", errs)
+			return nil, errAllEndpointsFailed
+		}
+		_ = level.Warn(logger).Log("msg", "some endpoints failed; potentially partial result", "errors", errs)
+	}
+	// TODO(bwplotka): Sort?
+	return results, nil
+}
+
+// handleError writes an error response to the client based on the error.
+func (p *Proxy) handleError(w http.ResponseWriter, req *http.Request, err error) {
+	if errors.Is(err, context.Canceled) {
+		promapi.WriteError(p.logger, w, promapi.ErrorCanceled, err.Error(), http.StatusGatewayTimeout, req.URL.Path)
+		return
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		promapi.WriteError(p.logger, w, promapi.ErrorTimeout, err.Error(), http.StatusGatewayTimeout, req.URL.Path)
+		return
+	}
+	promapi.WriteError(p.logger, w, promapi.ErrorInternal, err.Error(), http.StatusInternalServerError, req.URL.Path)
+}

--- a/cmd/frontend/internal/rule/proxy_test.go
+++ b/cmd/frontend/internal/rule/proxy_test.go
@@ -1,0 +1,379 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/prometheus-engine/internal/promapi"
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
+	promapiv1 "github.com/prometheus/prometheus/web/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRetriever struct {
+	AlertsFunc     func(context.Context, url.URL, string) ([]*promapiv1.Alert, error)
+	RuleGroupsFunc func(context.Context, url.URL, string) ([]*promapiv1.RuleGroup, error)
+}
+
+func (m *mockRetriever) Alerts(ctx context.Context, baseURL url.URL, queryString string) ([]*promapiv1.Alert, error) {
+	return m.AlertsFunc(ctx, baseURL, queryString)
+}
+
+func (m *mockRetriever) RuleGroups(ctx context.Context, baseURL url.URL, queryString string) ([]*promapiv1.RuleGroup, error) {
+	return m.RuleGroupsFunc(ctx, baseURL, queryString)
+}
+
+func TestProxy_handleError(t *testing.T) {
+	t.Parallel()
+
+	dummyRequest, _ := http.NewRequest(http.MethodGet, "http://localhost/path", nil)
+
+	for _, tt := range []struct {
+		name          string
+		err           error
+		wantStatus    int
+		wantErrorType string
+	}{
+		{
+			name:          "context canceled returns canceled error-type and 504",
+			err:           context.Canceled,
+			wantStatus:    http.StatusGatewayTimeout,
+			wantErrorType: string(promapi.ErrorCanceled),
+		},
+		{
+			name:          "context deadline exceeded returns timeout error-type and 504",
+			err:           context.DeadlineExceeded,
+			wantStatus:    http.StatusGatewayTimeout,
+			wantErrorType: string(promapi.ErrorTimeout),
+		},
+		{
+			name:          "generic error returns internal error-type and 500",
+			err:           errors.New("some error"),
+			wantStatus:    http.StatusInternalServerError,
+			wantErrorType: string(promapi.ErrorInternal),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+			p := NewProxy(log.NewNopLogger(), nil, nil)
+			p.handleError(recorder, dummyRequest, tt.err)
+
+			require.Equal(t, tt.wantStatus, recorder.Code)
+
+			response := promapi.Response[promapi.GenericResponseData]{}
+			err := json.Unmarshal(recorder.Body.Bytes(), &response)
+			require.NoError(t, err)
+			require.Equal(t, promapi.ErrorType(tt.wantErrorType), response.ErrorType)
+		})
+	}
+}
+
+func TestFanoutForward_AlertsReturnSuccess(t *testing.T) {
+	t.Parallel()
+
+	mockCli := &mockClient{
+		DoFunc: func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body:       io.NopCloser(strings.NewReader(`{"status":"success","data":{"alerts":[{"labels":{"labelKey1":"labelVal1"},"annotations":{"annoKey1":"AnnoVal1"},"state":"firing","activeAt":"2011-11-11T11:11:11.111122223Z","value":"1e+00"},{"labels":{"labelKey2":"labelVal2"},"annotations":{"annoKey2":"AnnoVal2"},"state":"firing","activeAt":"2022-02-22T22:22:22.999977773Z","value":"2e+00"}]}}`)),
+				StatusCode: http.StatusOK,
+			}, nil
+		},
+	}
+	retriever := newClient(mockCli)
+
+	activeAt1, _ := time.Parse(time.RFC3339Nano, "2011-11-11T11:11:11.111122223Z")
+	activeAt2, _ := time.Parse(time.RFC3339Nano, "2022-02-22T22:22:22.999977773Z")
+	expected := []*promapiv1.Alert{ // 2 times called a client which each returned 2 alerts ==> 4 alerts
+		{
+			Labels:          []labels.Label{{Name: "labelKey1", Value: "labelVal1"}},
+			Annotations:     []labels.Label{{Name: "annoKey1", Value: "AnnoVal1"}},
+			State:           "firing",
+			ActiveAt:        &activeAt1,
+			Value:           "1e+00",
+			KeepFiringSince: nil,
+		},
+		{
+			Labels:          []labels.Label{{Name: "labelKey2", Value: "labelVal2"}},
+			Annotations:     []labels.Label{{Name: "annoKey2", Value: "AnnoVal2"}},
+			State:           "firing",
+			ActiveAt:        &activeAt2,
+			Value:           "2e+00",
+			KeepFiringSince: nil,
+		},
+		{
+			Labels:          []labels.Label{{Name: "labelKey1", Value: "labelVal1"}},
+			Annotations:     []labels.Label{{Name: "annoKey1", Value: "AnnoVal1"}},
+			State:           "firing",
+			ActiveAt:        &activeAt1,
+			Value:           "1e+00",
+			KeepFiringSince: nil,
+		},
+		{
+			Labels:          []labels.Label{{Name: "labelKey2", Value: "labelVal2"}},
+			Annotations:     []labels.Label{{Name: "annoKey2", Value: "AnnoVal2"}},
+			State:           "firing",
+			ActiveAt:        &activeAt2,
+			Value:           "2e+00",
+			KeepFiringSince: nil,
+		},
+	}
+
+	retrieverUrls := []url.URL{
+		{Scheme: "http", Host: "localhost:8080", Path: "with-prefix"},
+		{Scheme: "https", Host: "localhost:8081", Path: ""},
+	}
+
+	alerts, err := fanoutForward(context.Background(), log.NewNopLogger(), retrieverUrls, "?qkey=qval", func(ctx context.Context, u url.URL, s string) ([]*promapiv1.Alert, error) {
+		return retriever.Alerts(ctx, u, s)
+	})
+
+	require.NoError(t, err)
+	require.Len(t, alerts, 4)
+	require.Equal(t, expected, alerts)
+}
+
+func TestFanoutForward_AlertsTwoReturnSuccessWithOneOfTwoBrokenClients(t *testing.T) {
+	t.Parallel()
+
+	retrieverUrls := []url.URL{
+		{Scheme: "http", Host: "localhost:8080", Path: "with-prefix"},
+		{Scheme: "https", Host: "localhost:8081", Path: ""},
+	}
+
+	mockCli := &mockClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host == "localhost:8080" {
+				return nil, errors.New("some error")
+			}
+			return &http.Response{
+				Body:       io.NopCloser(strings.NewReader(`{"status":"success","data":{"alerts":[{"labels":{"labelKey1":"labelVal1"},"annotations":{"annoKey1":"AnnoVal1"},"state":"firing","activeAt":"2011-11-11T11:11:11.111122223Z","value":"1e+00"},{"labels":{"labelKey2":"labelVal2"},"annotations":{"annoKey2":"AnnoVal2"},"state":"firing","activeAt":"2022-02-22T22:22:22.999977773Z","value":"2e+00"}]}}`)),
+				StatusCode: http.StatusOK,
+			}, nil
+		},
+	}
+	retriever := newClient(mockCli)
+
+	activeAt1, _ := time.Parse(time.RFC3339Nano, "2011-11-11T11:11:11.111122223Z")
+	activeAt2, _ := time.Parse(time.RFC3339Nano, "2022-02-22T22:22:22.999977773Z")
+	expected := []*promapiv1.Alert{ // 2 times called a client which each returned 2 alerts ==> 4 alerts
+		{
+			Labels:          []labels.Label{{Name: "labelKey1", Value: "labelVal1"}},
+			Annotations:     []labels.Label{{Name: "annoKey1", Value: "AnnoVal1"}},
+			State:           "firing",
+			ActiveAt:        &activeAt1,
+			Value:           "1e+00",
+			KeepFiringSince: nil,
+		},
+		{
+			Labels:          []labels.Label{{Name: "labelKey2", Value: "labelVal2"}},
+			Annotations:     []labels.Label{{Name: "annoKey2", Value: "AnnoVal2"}},
+			State:           "firing",
+			ActiveAt:        &activeAt2,
+			Value:           "2e+00",
+			KeepFiringSince: nil,
+		},
+	}
+	alerts, err := fanoutForward(context.Background(), log.NewNopLogger(), retrieverUrls, "?qkey=qval", func(ctx context.Context, u url.URL, s string) ([]*promapiv1.Alert, error) {
+		return retriever.Alerts(ctx, u, s)
+	})
+
+	require.NoError(t, err)
+	require.Len(t, alerts, 2)
+	require.Equal(t, expected, alerts)
+}
+
+func TestFanoutForward_AlertsTwoReturnErrorIfAllClientsFail(t *testing.T) {
+	t.Parallel()
+
+	retrieverUrls := []url.URL{
+		{Scheme: "http", Host: "localhost:8080", Path: "with-prefix"},
+		{Scheme: "https", Host: "localhost:8081", Path: ""},
+	}
+
+	mockCli := &mockClient{
+		DoFunc: func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("some error")
+		},
+	}
+	retriever := newClient(mockCli)
+	alerts, err := fanoutForward(context.Background(), log.NewNopLogger(), retrieverUrls, "?qkey=qval", func(ctx context.Context, u url.URL, s string) ([]*promapiv1.Alert, error) {
+		return retriever.Alerts(ctx, u, s)
+	})
+
+	require.Nil(t, alerts)
+	require.ErrorIs(t, err, errAllEndpointsFailed)
+}
+
+func TestProxy_Alerts(t *testing.T) {
+	t.Parallel()
+
+	activeAt1, _ := time.Parse(time.RFC3339Nano, "2011-11-11T11:11:11.111122223Z")
+	activeAt2, _ := time.Parse(time.RFC3339Nano, "2022-02-22T22:22:22.999977773Z")
+	for _, tt := range []struct {
+		name                  string
+		ruleEvaluatorBaseURLs []url.URL
+		ruleRetriever         retriever
+		wantStatus            int
+		wantBody              string
+	}{
+		{
+			name:                  "no rule evaluators returns success with empty alerts",
+			ruleEvaluatorBaseURLs: []url.URL{},
+			ruleRetriever: &mockRetriever{
+				AlertsFunc: func(context.Context, url.URL, string) ([]*promapiv1.Alert, error) {
+					t.Fatal("Should not call the rule retriever if there are no rule evaluators' URLs")
+					return nil, nil
+				},
+				RuleGroupsFunc: func(context.Context, url.URL, string) ([]*promapiv1.RuleGroup, error) {
+					t.Fatal("Should not call the rule retriever if there are no rule evaluators' URLs")
+					return nil, nil
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   `{"status":"success","data":{"alerts":[]}}`,
+		},
+		{
+			name: "func calls correct client method",
+			ruleEvaluatorBaseURLs: []url.URL{
+				{Scheme: "http", Host: "localhost:8080", Path: "with-prefix"},
+			},
+			ruleRetriever: &mockRetriever{
+				RuleGroupsFunc: func(context.Context, url.URL, string) ([]*promapiv1.RuleGroup, error) {
+					t.Fatal("Should not call the RULES endpoint when fetching alerts")
+					return nil, nil
+				},
+				AlertsFunc: func(_ context.Context, baseURL url.URL, _ string) ([]*promapiv1.Alert, error) {
+					require.Equal(t, "http://localhost:8080/with-prefix", baseURL.String())
+					return []*promapiv1.Alert{
+						{
+							Labels:      []labels.Label{{Name: "labelKey1", Value: "labelVal1"}},
+							Annotations: []labels.Label{{Name: "annoKey1", Value: "AnnoVal1"}},
+							State:       "firing",
+							ActiveAt:    &activeAt1,
+							Value:       "1e+00",
+						},
+						{
+							Labels:      []labels.Label{{Name: "labelKey2", Value: "labelVal2"}},
+							Annotations: []labels.Label{{Name: "annoKey2", Value: "AnnoVal2"}},
+							State:       "firing",
+							ActiveAt:    &activeAt2,
+							Value:       "2e+00",
+						},
+					}, nil
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   `{"status":"success","data":{"alerts":[{"labels":{"labelKey1":"labelVal1"},"annotations":{"annoKey1":"AnnoVal1"},"state":"firing","activeAt":"2011-11-11T11:11:11.111122223Z","value":"1e+00"},{"labels":{"labelKey2":"labelVal2"},"annotations":{"annoKey2":"AnnoVal2"},"state":"firing","activeAt":"2022-02-22T22:22:22.999977773Z","value":"2e+00"}]}}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Proxy{
+				logger:    log.NewNopLogger(),
+				endpoints: tt.ruleEvaluatorBaseURLs,
+				client:    tt.ruleRetriever,
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+			w := httptest.NewRecorder()
+			r.Alerts(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Code)
+			require.JSONEq(t, tt.wantBody, w.Body.String(), fmt.Sprintf("expected: %s, got: %s", tt.wantBody, w.Body.String()))
+		})
+	}
+}
+
+func TestProxy_RuleGroups(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		ruleEvaluatorBaseURLs []url.URL
+		ruleRetriever         retriever
+		wantStatus            int
+		wantBody              string
+	}{
+		{
+			name:                  "no rule evaluators returns success with empty groups",
+			ruleEvaluatorBaseURLs: []url.URL{},
+			ruleRetriever: &mockRetriever{
+				AlertsFunc: func(context.Context, url.URL, string) ([]*promapiv1.Alert, error) {
+					t.Fatal("Should not call the rule retriever if there are no rule evaluators' URLs")
+					return nil, nil
+				},
+				RuleGroupsFunc: func(context.Context, url.URL, string) ([]*promapiv1.RuleGroup, error) {
+					t.Fatal("Should not call the rule retriever if there are no rule evaluators' URLs")
+					return nil, nil
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   `{"status":"success","data":{"groups":[]}}`,
+		},
+		{
+			name: "func calls correct client method",
+			ruleEvaluatorBaseURLs: []url.URL{
+				{Scheme: "http", Host: "localhost:8080", Path: "with-prefix"},
+			},
+			ruleRetriever: &mockRetriever{
+				AlertsFunc: func(context.Context, url.URL, string) ([]*promapiv1.Alert, error) {
+					t.Fatal("Should not call the ALERTS endpoint when fetching rules")
+					return nil, nil
+				},
+				RuleGroupsFunc: func(_ context.Context, baseURL url.URL, _ string) ([]*promapiv1.RuleGroup, error) {
+					require.Equal(t, "http://localhost:8080/with-prefix", baseURL.String())
+					return []*promapiv1.RuleGroup{
+						{
+							Name:  "group1",
+							File:  "file1",
+							Rules: []promapiv1.Rule{},
+						},
+					}, nil
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   `{"status":"success","data":{"groups":[{"name":"group1","file":"file1","rules":[],"interval":0,"limit":0,"evaluationTime":0,"lastEvaluation":"0001-01-01T00:00:00Z"}]}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Proxy{
+				logger:    log.NewNopLogger(),
+				endpoints: tt.ruleEvaluatorBaseURLs,
+				client:    tt.ruleRetriever,
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+			w := httptest.NewRecorder()
+			r.RuleGroups(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Code)
+			require.JSONEq(t, tt.wantBody, w.Body.String(), fmt.Sprintf("expected: %s, got: %s", tt.wantBody, w.Body.String()))
+		})
+	}
+}

--- a/cmd/rule-evaluator/internal/api.go
+++ b/cmd/rule-evaluator/internal/api.go
@@ -82,6 +82,7 @@ func NewAPI(logger log.Logger, rulesManager RuleRetriever) *API {
 
 func (api *API) writeResponse(w http.ResponseWriter, httpResponseCode int, endpointURI string, resp response) {
 	logger := log.With(api.logger, "endpointURI", endpointURI, "intendedStatusCode", httpResponseCode)
+	w.Header().Set("Content-Type", "application/json")
 
 	jsonResponse, err := json.Marshal(resp)
 	if err != nil {

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -52,6 +52,7 @@ COPY charts charts
 COPY doc doc
 COPY pkg pkg
 COPY e2e e2e
+COPY internal internal
 
 # Init a dummy git repo so we can check if generated code changes via
 # git diff.

--- a/internal/promapi/promapi.go
+++ b/internal/promapi/promapi.go
@@ -1,0 +1,110 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	promapiv1 "github.com/prometheus/prometheus/web/api/v1"
+)
+
+// Redundant code for API compliance below can be DRY'ed up if/when this issue is addressed:
+// https://github.com/prometheus/prometheus/issues/14962
+
+// https://prometheus.io/docs/prometheus/latest/querying/api/#format-overview
+// Response is the prometheus-compatible Response format.
+type Response[T RulesResponseData | AlertsResponseData | GenericResponseData] struct {
+	Status    status    `json:"status"`
+	Data      T         `json:"data,omitempty"`
+	ErrorType ErrorType `json:"errorType,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	Warnings  []string  `json:"warnings,omitempty"`
+	Infos     []string  `json:"infos,omitempty"`
+}
+
+type RulesResponseData struct {
+	Groups []*promapiv1.RuleGroup `json:"groups"`
+}
+
+type AlertsResponseData struct {
+	Alerts []*promapiv1.Alert `json:"alerts"`
+}
+
+type GenericResponseData interface{}
+
+type ErrorType string
+
+const (
+	ErrorNone        ErrorType = ""
+	ErrorTimeout     ErrorType = "timeout"
+	ErrorCanceled    ErrorType = "canceled"
+	ErrorExec        ErrorType = "execution"
+	ErrorBadData     ErrorType = "bad_data"
+	ErrorInternal    ErrorType = "internal"
+	ErrorUnavailable ErrorType = "unavailable"
+	ErrorNotFound    ErrorType = "not_found"
+)
+
+// https://prometheus.io/docs/prometheus/latest/querying/api/#format-overview
+// status is the prometheus-compatible status type.
+type status string
+
+const (
+	statusSuccess status = "success"
+	statusError   status = "error"
+)
+
+// writeResponse writes a Response to given responseWriter w if it can, otherwise it logs the error and writes a generic error.
+func writeResponse[T RulesResponseData | AlertsResponseData | GenericResponseData](logger log.Logger, w http.ResponseWriter, httpResponseCode int, endpointURI string, resp Response[T]) {
+	logger = log.With(logger, "endpointURI", endpointURI, "intendedStatusCode", httpResponseCode)
+	w.Header().Set("Content-Type", "application/json")
+
+	jsonResponse, err := json.Marshal(resp)
+	if err != nil {
+		_ = level.Error(logger).Log("msg", "failed to marshal Response", "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+
+		if _, err = w.Write([]byte(`{"status":"error","ErrorType":"internal","error":"failed to marshal Response"}`)); err != nil {
+			_ = level.Error(logger).Log("msg", "failed to write error Response to responseWriter", "err", err)
+		}
+		return
+	}
+
+	w.WriteHeader(httpResponseCode)
+	if _, err = w.Write(jsonResponse); err != nil {
+		_ = level.Error(logger).Log("msg", "failed to write Response to responseWriter", "err", err)
+	}
+}
+
+// WriteSuccessResponse writes a successful Response to the given responseWriter w.
+func WriteSuccessResponse[T RulesResponseData | AlertsResponseData](logger log.Logger, w http.ResponseWriter, httpResponseCode int, endpointURI string, responseData T) {
+	writeResponse(logger, w, httpResponseCode, endpointURI, Response[T]{
+		Status: statusSuccess,
+		Data:   responseData,
+	})
+}
+
+// WriteError writes an error Response to the given responseWriter w.
+func WriteError(logger log.Logger, w http.ResponseWriter, errType ErrorType, errMsg string, httpResponseCode int, endpointURI string) {
+	writeResponse(logger, w, httpResponseCode, endpointURI, Response[GenericResponseData]{
+		Status:    statusError,
+		ErrorType: errType,
+		Error:     errMsg,
+		Data:      nil,
+	})
+}

--- a/internal/promapi/promapi_test.go
+++ b/internal/promapi/promapi_test.go
@@ -1,0 +1,186 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-kit/log"
+	promapiv1 "github.com/prometheus/prometheus/web/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+type recursiveStruct struct {
+	Recursive *recursiveStruct `json:"recursive"`
+}
+
+func Test_writeResponse(t *testing.T) {
+	t.Parallel()
+
+	recursor := &recursiveStruct{}
+	recursor.Recursive = recursor
+
+	type testCase struct {
+		name             string
+		httpResponseCode int
+		resp             Response[GenericResponseData]
+		wantBody         string
+		wantStatus       int
+	}
+	tests := []testCase{
+		{
+			name:             "happy path rulesResponseData",
+			httpResponseCode: http.StatusOK,
+			resp: Response[GenericResponseData]{
+				Data: RulesResponseData{Groups: []*promapiv1.RuleGroup{}},
+			},
+			wantBody:   `{"status":"","data":{"groups":[]}}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:             "happy path alertsResponseData",
+			httpResponseCode: http.StatusOK,
+			resp: Response[GenericResponseData]{
+				Data: AlertsResponseData{Alerts: []*promapiv1.Alert{}},
+			},
+			wantBody:   `{"status":"","data":{"alerts":[]}}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:             "happy path string response data",
+			httpResponseCode: http.StatusOK,
+			resp: Response[GenericResponseData]{
+				Data: "foo bar baz qux",
+			},
+			wantBody:   `{"status":"","data":"foo bar baz qux"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:             "json marshalling error returns prom-api compatible error",
+			httpResponseCode: http.StatusOK,
+			resp: Response[GenericResponseData]{
+				Data: recursor, // recursive struct will cause json marshalling error
+			},
+			wantBody:   `{"status":"error","ErrorType":"internal","error":"failed to marshal Response"}`,
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recorder := httptest.NewRecorder()
+			writeResponse[GenericResponseData](log.NewNopLogger(), recorder, tt.httpResponseCode, "", tt.resp)
+			require.JSONEq(t, tt.wantBody, recorder.Body.String())
+			require.Equal(t, tt.wantStatus, recorder.Code)
+		})
+	}
+}
+
+func TestWriteSuccessResponse(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name             string
+		httpResponseCode int
+		responseData     RulesResponseData
+		wantBody         string
+		wantStatus       int
+	}
+	tests := []testCase{
+		{
+			name:             "happy path",
+			httpResponseCode: http.StatusOK,
+			responseData:     RulesResponseData{Groups: []*promapiv1.RuleGroup{}},
+			wantBody:         `{"status":"success","data":{"groups":[]}}`,
+			wantStatus:       http.StatusOK,
+		},
+		{
+			name:             "empty responseData",
+			httpResponseCode: http.StatusOK,
+			responseData:     RulesResponseData{},
+			wantBody:         `{"status":"success","data":{"groups":null}}`,
+			wantStatus:       http.StatusOK,
+		},
+		{
+			name:             "adheres to status code",
+			httpResponseCode: http.StatusTeapot,
+			responseData:     RulesResponseData{},
+			wantBody:         `{"status":"success","data":{"groups":null}}`,
+			wantStatus:       http.StatusTeapot,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recorder := httptest.NewRecorder()
+			WriteSuccessResponse(log.NewNopLogger(), recorder, tt.httpResponseCode, "", tt.responseData)
+
+			require.JSONEq(t, tt.wantBody, recorder.Body.String())
+			require.Equal(t, tt.wantStatus, recorder.Code)
+		})
+	}
+}
+
+func TestWriteErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name             string
+		httpResponseCode int
+		errType          ErrorType
+		errMsg           string
+		wantBody         string
+		wantStatus       int
+	}
+	tests := []testCase{
+		{
+			name:             "happy path",
+			httpResponseCode: http.StatusInternalServerError,
+			errType:          ErrorInternal,
+			errMsg:           "foo error message",
+			wantBody:         `{"status":"error","errorType":"internal","error":"foo error message"}`,
+			wantStatus:       http.StatusInternalServerError,
+		},
+		{
+			name:             "empty responseData",
+			httpResponseCode: http.StatusOK,
+			errType:          ErrorNone,
+			errMsg:           "bar error message",
+			wantBody:         `{"status":"error","error":"bar error message"}`,
+			wantStatus:       http.StatusOK,
+		},
+		{
+			name:             "adheres to status code",
+			httpResponseCode: http.StatusTeapot,
+			errType:          ErrorTimeout,
+			errMsg:           "baz error message",
+			wantBody:         `{"status":"error","errorType":"timeout","error":"baz error message"}`,
+			wantStatus:       http.StatusTeapot,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recorder := httptest.NewRecorder()
+			WriteError(log.NewNopLogger(), recorder, tt.errType, tt.errMsg, tt.httpResponseCode, "")
+
+			//require.JSONEq(t, tt.wantBody, recorder.Body.String())
+			require.Equal(t, tt.wantBody, recorder.Body.String())
+			require.Equal(t, tt.wantStatus, recorder.Code)
+		})
+	}
+}

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -292,6 +292,20 @@ spec:
     targetPort: 9093
   clusterIP: None
 ---
+# Source: operator/templates/rule-evaluator.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: rule-evaluator
+  namespace: gmp-system
+spec:
+  selector:
+      app.kubernetes.io/name: rule-evaluator
+  ports:
+    - name: rule-evaluator
+      port: 19092
+      targetPort: 19092
+---
 # Source: operator/templates/service.yaml
 apiVersion: v1
 kind: Service

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -88,6 +88,21 @@ subjects:
   namespace: default
   kind: ServiceAccount
 ---
+# Source: rule-evaluator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: rule-evaluator
+  labels:
+    app.kubernetes.io/name: rule-evaluator
+spec:
+  selector:
+      app.kubernetes.io/name: rule-evaluator
+  ports:
+    - name: rule-evaluator
+      port: 9092
+      targetPort: 9092
+---
 # Source: rule-evaluator/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Enabling to query `/api/v1/rules` and `/api/v1/alerts` from the `frontend` by proxying these calls to the `rule-evaluator` pod.

This PR also creates a k8s service manifest for the `rule-evaluator` in order to be able to reach it from `frontend`

Note:
~~There was no proper way to test the k8s manifests in an actual cluster. If there is a way to test this setup properly before merging, that would probably be advisable.~~
Update: Added e2e tests