### PR TITLE
feat: add /api/v1/status/buildinfo endpoint for Grafana compatibility

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -35,6 +35,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/prometheus-engine/cmd/frontend/internal/rule"
+	"github.com/GoogleCloudPlatform/prometheus-engine/internal/promapi"
+	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/export"
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/ui"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -112,6 +114,12 @@ func main() {
 		ruleEndpointURLs = append(ruleEndpointURLs, *ruleEndpointURL)
 	}
 
+	version, err := export.Version()
+	if err != nil {
+		_ = level.Error(logger).Log("msg", "Unable to fetch module version", "err", err)
+		os.Exit(1)
+	}
+
 	var g run.Group
 	{
 		term := make(chan os.Signal, 1)
@@ -154,8 +162,11 @@ func main() {
 		)
 
 		server := &http.Server{Addr: *listenAddress}
+		buildInfoHandler := http.HandlerFunc(promapi.BuildinfoHandlerFunc(log.With(logger, "component", "buildinfo-handler"), "frontend", version))
+		http.Handle("/api/v1/status/buildinfo", buildInfoHandler)
 		http.Handle("/metrics", promhttp.HandlerFor(metrics, promhttp.HandlerOpts{Registry: metrics}))
 		http.Handle("/api/v1/rules", http.HandlerFunc(ruleProxy.RuleGroups))
+		http.Handle("/api/v1/rules/", http.NotFoundHandler())
 		http.Handle("/api/v1/alerts", http.HandlerFunc(ruleProxy.Alerts))
 		http.Handle("/api/", authenticate(forward(logger, targetURL, transport)))
 

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -18,6 +18,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 COPY cmd cmd
 COPY pkg pkg
+COPY internal internal
 COPY vendor vendor
 
 FROM buildbase as appbase

--- a/internal/promapi/buildinfo.go
+++ b/internal/promapi/buildinfo.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promapi
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	promapiv1 "github.com/prometheus/prometheus/web/api/v1"
+)
+
+const (
+	timestampFormat = "20060102-15:04:05"
+	buildinfoPath   = "/api/v1/status/buildinfo"
+	exposedVersion  = "2.55.0" // We support APIs similar to the last pre 3.0 Prometheus version.
+)
+
+// BuildinfoHandlerFunc simulates the /api/v1/status/buildinfo prometheus endpoint.
+// It is used by Grafana to determine the Prometheus flavor, e.g. to check whether the ruler-api is enabled.
+// binary: e.g. "frontend" or "rule-evaluator".
+func BuildinfoHandlerFunc(logger log.Logger, binaryName, binaryVersion string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		// TODO(yama6a): Populate buildinfo at build time, analogous to: https://github.com/prometheus/common/blob/v0.60.0/version/info.go
+		response := promapiv1.PrometheusVersion{
+			Version:   exposedVersion,
+			Revision:  fmt.Sprintf("gmp/%s-%s", binaryName, binaryVersion),
+			Branch:    "HEAD",
+			BuildUser: "gmp@localhost",
+			BuildDate: getBinaryCreatedTimestamp(logger),
+			GoVersion: runtime.Version(),
+		}
+		WriteSuccessResponse(logger, w, http.StatusOK, buildinfoPath, response)
+	}
+}
+
+func getBinaryCreatedTimestamp(logger log.Logger) string {
+	fileInfo, err := os.Stat(os.Args[0])
+	if err != nil {
+		_ = level.Error(logger).Log("msg", "Failed to get binary creation timestamp, usinng now()", "err", err)
+		return time.Now().Format(timestampFormat)
+	}
+
+	return fileInfo.ModTime().Format(timestampFormat)
+}

--- a/internal/promapi/buildinfo_test.go
+++ b/internal/promapi/buildinfo_test.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-kit/log"
+	promapiv1 "github.com/prometheus/prometheus/web/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildinfoHandlerFunc(t *testing.T) {
+	t.Parallel()
+
+	handleFunc := BuildinfoHandlerFunc(log.NewNopLogger(), "frontend", "v1.2.3")
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status/buildinfo", nil)
+
+	handleFunc(recorder, req)
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	// unmarshal into promapiv1.PrometheusVersion object
+	resp := Response[promapiv1.PrometheusVersion]{}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+	defer recorder.Result().Body.Close()
+
+	require.Equal(t, exposedVersion, resp.Data.Version)
+	require.Equal(t, "gmp/frontend-v1.2.3", resp.Data.Revision)
+}

--- a/internal/promapi/promapi.go
+++ b/internal/promapi/promapi.go
@@ -92,7 +92,7 @@ func writeResponse[T RulesResponseData | AlertsResponseData | GenericResponseDat
 }
 
 // WriteSuccessResponse writes a successful Response to the given responseWriter w.
-func WriteSuccessResponse[T RulesResponseData | AlertsResponseData](logger log.Logger, w http.ResponseWriter, httpResponseCode int, endpointURI string, responseData T) {
+func WriteSuccessResponse[T RulesResponseData | AlertsResponseData | promapiv1.PrometheusVersion](logger log.Logger, w http.ResponseWriter, httpResponseCode int, endpointURI string, responseData T) {
 	writeResponse(logger, w, httpResponseCode, endpointURI, Response[T]{
 		Status: statusSuccess,
 		Data:   responseData,


### PR DESCRIPTION
## Purpose 

This PR will make the GMP frontend compatible with Grafana for alerting and recording rules. It will also enable the rule-evaluator to be used as a datasource, albeit only for alerting and recording rules. 

Currently, Grafana won't attempt to import any rules without the `/api/v1/status/buildinfo` endpoint available. This PR adds it.

Adding the rule-evaluator as a Prometheus Datasource works as well with this feature. It produces an error when adding the datasource, due to it not implementing the `/api/v1/query` endpoint and its siblings. It does however succeed in importing the rules into Grafana. The GMP frontend will work without said error message.

## Details

The `/api/v1/status/buildinfo` endpoint is used by Grafana in order to determine the "flavor" of a Prometheus Datasource (Mimir / Cortex / Vanilla Prometheus).

Under certain circumstances, Grafana also probes the endpoint `/api/v1/rules/test/test` and expects the content to contain the words "page not found", in order to determine whether the Prometheus Datasource implements the ruler-API, which would allow editing rules via the Grafana UI (which is not supported in vanilla Prometheus or GMP)

## References
- https://github.com/grafana/grafana/blob/65ce173d3fd4a98f7763200cdddb80009a23d59b/public/app/features/alerting/unified/api/buildInfo.ts#L150
- https://github.com/grafana/grafana/blob/65ce173d3fd4a98f7763200cdddb80009a23d59b/public/app/features/alerting/unified/api/buildInfo.ts#L196
- https://github.com/grafana/grafana/blob/65ce173d3fd4a98f7763200cdddb80009a23d59b/public/app/features/alerting/unified/api/ruler.ts#L142