### PR TITLE
feat: add log level flag to rules-evaluator & frontend

### DIFF
--- a/cmd/frontend/README.md
+++ b/cmd/frontend/README.md
@@ -45,6 +45,8 @@ Access the frontend UI in your browser at http://localhost:19090.
 
 ```bash mdox-exec="bash hack/format_help.sh frontend"
 Usage of frontend:
+  -log.level string
+    	The level of logging. Can be one of 'debug', 'info', 'warn', 'error' (default "info")
   -query.credentials-file string
     	JSON-encoded credentials (service account or refresh token). Can be left empty if default credentials have sufficient permission.
   -query.project-id string

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -88,6 +88,7 @@ func main() {
 	case "info":
 		logger = level.NewFilter(logger, level.AllowInfo())
 	default:
+		//nolint:errcheck
 		level.Error(logger).Log("msg",
 			"--log.level can only be one of 'debug', 'info', 'warn', 'error'")
 		os.Exit(1)

--- a/cmd/rule-evaluator/README.md
+++ b/cmd/rule-evaluator/README.md
@@ -52,7 +52,7 @@ The Prometheus Rule Evaluator
 Flags:
   -h, --[no-]help                Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --log.level=info           The level of logging
+      --log.level=info           The level of logging. Can be one of 'debug', 'info', 'warn', 'error'
       --[no-]export.disable      Disable exporting to GCM.
       --export.endpoint="monitoring.googleapis.com:443"  
                                  GCM API endpoint to send metric data to.

--- a/cmd/rule-evaluator/README.md
+++ b/cmd/rule-evaluator/README.md
@@ -52,7 +52,8 @@ The Prometheus Rule Evaluator
 Flags:
   -h, --[no-]help                Show context-sensitive help (also try
                                  --help-long and --help-man).
-      --log.level=info           The level of logging. Can be one of 'debug', 'info', 'warn', 'error'
+      --log.level=info           The level of logging. Can be one of 'debug',
+                                 'info', 'warn', 'error'
       --[no-]export.disable      Disable exporting to GCM.
       --export.endpoint="monitoring.googleapis.com:443"  
                                  GCM API endpoint to send metric data to.

--- a/cmd/rule-evaluator/README.md
+++ b/cmd/rule-evaluator/README.md
@@ -52,6 +52,7 @@ The Prometheus Rule Evaluator
 Flags:
   -h, --[no-]help                Show context-sensitive help (also try
                                  --help-long and --help-man).
+      --log.level=info           The level of logging
       --[no-]export.disable      Disable exporting to GCM.
       --export.endpoint="monitoring.googleapis.com:443"  
                                  GCM API endpoint to send metric data to.

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -102,6 +102,7 @@ func main() {
 	logger = log.With(logger, "caller", log.DefaultCaller)
 
 	a := kingpin.New("rule", "The Prometheus Rule Evaluator")
+	logLevel := a.Flag("log-level", "The level of logging").Default("info").Enum("debug", "info", "warn", "error")
 
 	a.HelpFlag.Short('h')
 
@@ -158,6 +159,16 @@ func main() {
 		_ = level.Error(logger).Log("msg", "Error parsing commandline arguments", "err", err)
 		a.Usage(os.Args[1:])
 		os.Exit(2)
+	}
+	switch strings.ToLower(*logLevel) {
+	case "debug":
+		logger = level.NewFilter(logger, level.AllowDebug())
+	case "warn":
+		logger = level.NewFilter(logger, level.AllowWarn())
+	case "error":
+		logger = level.NewFilter(logger, level.AllowError())
+	default:
+		logger = level.NewFilter(logger, level.AllowInfo())
 	}
 
 	if err := defaultEvaluatorOpts.validate(); err != nil {

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -102,7 +102,7 @@ func main() {
 	logger = log.With(logger, "caller", log.DefaultCaller)
 
 	a := kingpin.New("rule", "The Prometheus Rule Evaluator")
-	logLevel := a.Flag("log-level", "The level of logging").Default("info").Enum("debug", "info", "warn", "error")
+	logLevel := a.Flag("log.level", "The level of logging").Default("info").Enum("debug", "info", "warn", "error")
 
 	a.HelpFlag.Short('h')
 

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -102,7 +102,9 @@ func main() {
 	logger = log.With(logger, "caller", log.DefaultCaller)
 
 	a := kingpin.New("rule", "The Prometheus Rule Evaluator")
-	logLevel := a.Flag("log.level", "The level of logging").Default("info").Enum("debug", "info", "warn", "error")
+	logLevel := a.Flag("log.level",
+		"The level of logging. Can be one of 'debug', 'info', 'warn', 'error'").Default(
+		"info").Enum("debug", "info", "warn", "error")
 
 	a.HelpFlag.Short('h')
 


### PR DESCRIPTION
Adding a log level flags to both `rules-evaluator` & `frontend` binaries. The flag is named `--log.level`
