### PR TITLE
chore: prepare v0.14.0 release candidate

### DIFF
--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -16,7 +16,7 @@ commonLabels: false
 namespace:
   public: gmp-public
   system: gmp-system
-version: 0.13.1
+version: 0.14.0
 images:
   # NOTE: All tags have to be quoted otherwise they might be treated as a number.
   bash:
@@ -24,22 +24,22 @@ images:
     tag: "gke_distroless_20240907.00_p0"
   alertmanager:
     image: gke.gcr.io/prometheus-engine/alertmanager
-    tag: "v0.25.1-gmp.8-gke.0"
+    tag: "v0.27.0-gmp.1-gke.1"
   prometheus:
     image: gke.gcr.io/prometheus-engine/prometheus
     tag: "v2.45.3-gmp.9-gke.0"
   configReloader:
     image: gke.gcr.io/prometheus-engine/config-reloader
-    tag: "v0.13.1-gke.0"
+    tag: "v0.14.0-gke.0"
   operator:
     image: gke.gcr.io/prometheus-engine/operator
-    tag: "v0.13.1-gke.0"
+    tag: "v0.14.0-gke.0"
   ruleEvaluator:
     image: gke.gcr.io/prometheus-engine/rule-evaluator
-    tag: "v0.13.1-gke.0"
+    tag: "v0.14.0-gke.0"
   datasourceSyncer:
     image: gcr.io/gke-release/prometheus-engine/datasource-syncer
-    tag: "v0.13.1-gke.0"
+    tag: "v0.14.0-gke.0"
 resources:
   alertManager:
     limits:

--- a/cmd/datasource-syncer/Dockerfile
+++ b/cmd/datasource-syncer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.1-bullseye as buildbase
+FROM golang:1.23.1@sha256:4a3c2bcd243d3dbb7b15237eecb0792db3614900037998c2cd6a579c46888c1e as buildbase
 WORKDIR /app
 COPY . ./
 

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -41,7 +41,7 @@ spec:
                 - linux
       containers:
       - name: datasource-syncer-init
-        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.13.1-gke.0
+        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.14.0-gke.0
         args:
         - "--datasource-uids=$DATASOURCE_UIDS"
         - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
@@ -79,7 +79,7 @@ spec:
                     - linux
           containers:
           - name: datasource-syncer
-            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.13.1-gke.0
+            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.14.0-gke.0
             args:
             - "--datasource-uids=$DATASOURCE_UIDS"
             - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"

--- a/examples/frontend.yaml
+++ b/examples/frontend.yaml
@@ -43,7 +43,7 @@ spec:
                 - linux
       containers:
       - name: frontend
-        image: gke.gcr.io/prometheus-engine/frontend:v0.13.1-gke.0
+        image: gke.gcr.io/prometheus-engine/frontend:v0.14.0-gke.0
         args:
         - "--web.listen-address=:9090"
         - "--query.project-id=$PROJECT_ID"

--- a/examples/instrumentation/go-synthetic/go-synthetic-basic-auth.yaml
+++ b/examples/instrumentation/go-synthetic/go-synthetic-basic-auth.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: go-synthetic
         # TODO(bwplotka): Rename image to go-synthetic (example-app is misleading, we actually use go-synthetic).
-        image: gke.gcr.io/prometheus-engine/example-app:v0.13.1-gke.0
+        image: gke.gcr.io/prometheus-engine/example-app:v0.14.0-gke.0
         args:
         - "--listen-address=:8080"
         - "--cpu-burn-ops=75"

--- a/examples/instrumentation/go-synthetic/go-synthetic.yaml
+++ b/examples/instrumentation/go-synthetic/go-synthetic.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: go-synthetic
         # TODO(bwplotka): Rename image to go-synthetic (example-app is misleading, we actually use go-synthetic).
-        image: gke.gcr.io/prometheus-engine/example-app@sha256:40658e4aff1f5c696f08037f1cb3f3b947096e378f4cbe89fe4187de72cd9358
+        image: gke.gcr.io/prometheus-engine/example-app:v0.14.0-gke.0
         args:
         - "--listen-address=:8080"
         - "--cpu-burn-ops=75"

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -347,7 +347,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.13.1
+        app.kubernetes.io/version: 0.14.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -373,7 +373,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.14.0-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -543,14 +543,14 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.13.1
+        app.kubernetes.io/version: 0.14.0
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.13.1-gke.0
+        image: gke.gcr.io/prometheus-engine/operator:v0.14.0-gke.0
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"
@@ -644,7 +644,7 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
         app: managed-prometheus-rule-evaluator
-        app.kubernetes.io/version: 0.13.1
+        app.kubernetes.io/version: 0.14.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -670,7 +670,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.14.0-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -711,7 +711,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.13.1-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.14.0-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
@@ -817,7 +817,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.13.1
+        app.kubernetes.io/version: 0.14.0
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
@@ -840,7 +840,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: alertmanager
-        image: gke.gcr.io/prometheus-engine/alertmanager:v0.25.1-gmp.8-gke.0
+        image: gke.gcr.io/prometheus-engine/alertmanager:v0.27.0-gmp.1-gke.1
         args:
         - --config.file=/alertmanager/config_out/config.yaml
         - --storage.path=/alertmanager-data
@@ -876,7 +876,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.14.0-gke.0
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -118,7 +118,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.13.1
+        app.kubernetes.io/version: 0.14.0
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
@@ -131,7 +131,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.13.1-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.14.0-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -169,7 +169,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.13.1-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.14.0-gke.0
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -630,7 +630,7 @@ const (
 	ClientName = "prometheus-engine-export"
 	// mainModuleVersion is the version of the main module. Align with git tag.
 	// TODO(TheSpiritXIII): Remove with https://github.com/golang/go/issues/50603
-	mainModuleVersion = "v0.13.0-rc.0" // x-release-please-version
+	mainModuleVersion = "v0.14.0-rc.0" // x-release-please-version
 	// mainModuleName is the name of the main module. Align with go.mod.
 	mainModuleName = "github.com/GoogleCloudPlatform/prometheus-engine"
 )


### PR DESCRIPTION
(also bumped DS go version)

cherry-pick of 84b958e3c862488bdbaeb60bd5ef0a7b9c4688fb