### PR TITLE
chore: match casing for from and as in dockerfiles

### DIFF
--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.2@sha256:adee809c2d0009a4199a11a1b2618990b244c6515149fe609e2788ddf164bd10 as buildbase
+FROM golang:1.23.2@sha256:adee809c2d0009a4199a11a1b2618990b244c6515149fe609e2788ddf164bd10 AS buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -20,7 +20,7 @@ COPY cmd cmd
 COPY pkg pkg
 COPY vendor vendor
 
-FROM buildbase as appbase
+FROM buildbase AS appbase
 RUN CGO_ENABLED=1 GOEXPERIMENT=boringcrypto \
     go build -tags boring -mod=vendor -o config-reloader cmd/config-reloader/*.go
 

--- a/cmd/datasource-syncer/Dockerfile
+++ b/cmd/datasource-syncer/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.1@sha256:4a3c2bcd243d3dbb7b15237eecb0792db3614900037998c2cd6a579c46888c1e as buildbase
+FROM golang:1.23.1@sha256:4a3c2bcd243d3dbb7b15237eecb0792db3614900037998c2cd6a579c46888c1e AS buildbase
 WORKDIR /app
 COPY . ./
 
-FROM buildbase as appbase
+FROM buildbase AS appbase
 RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -mod=vendor -o datasource-syncer cmd/datasource-syncer/*.go
 
 FROM gcr.io/distroless/static-debian11:latest

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.2-bullseye as buildbase
+FROM golang:1.23.2-bullseye AS buildbase
 
 # Compile the UI assets.
-FROM gcr.io/google-appengine/nodejs as assets
+FROM gcr.io/google-appengine/nodejs AS assets
 # To build the UI we need a recent node version and the go toolchain.
 RUN install_node v17.9.0
 COPY --from=buildbase /usr/local/go /usr/local/
@@ -25,7 +25,7 @@ RUN pkg/ui/build.sh
 
 # sync is used to copy all auto-generated files to a different context.
 # Usually this is used to mirror the changes back to the host machine.
-FROM scratch as sync
+FROM scratch AS sync
 COPY --from=assets /app/pkg/ui/embed.go pkg/ui/embed.go
 COPY --from=assets /app/pkg/ui/static pkg/ui/static
 

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.2@sha256:adee809c2d0009a4199a11a1b2618990b244c6515149fe609e2788ddf164bd10 as buildbase
+FROM golang:1.23.2@sha256:adee809c2d0009a4199a11a1b2618990b244c6515149fe609e2788ddf164bd10 AS buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -20,7 +20,7 @@ COPY cmd cmd
 COPY pkg pkg
 COPY vendor vendor
 
-FROM buildbase as appbase
+FROM buildbase AS appbase
 RUN CGO_ENABLED=1 GOEXPERIMENT=boringcrypto \
     go build -tags boring -mod=vendor -o operator cmd/operator/*.go
 

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.2@sha256:adee809c2d0009a4199a11a1b2618990b244c6515149fe609e2788ddf164bd10 as buildbase
+FROM golang:1.23.2@sha256:adee809c2d0009a4199a11a1b2618990b244c6515149fe609e2788ddf164bd10 AS buildbase
 WORKDIR /app
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -21,7 +21,7 @@ COPY pkg pkg
 COPY internal internal
 COPY vendor vendor
 
-FROM buildbase as appbase
+FROM buildbase AS appbase
 RUN CGO_ENABLED=1 GOEXPERIMENT=boringcrypto \
     go build -tags boring -mod=vendor -o rule-evaluator cmd/rule-evaluator/*.go
 

--- a/examples/instrumentation/go-synthetic/Dockerfile
+++ b/examples/instrumentation/go-synthetic/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.1-bullseye as buildbase
+FROM golang:1.23.1-bullseye AS buildbase
 WORKDIR /app
 COPY . ./
 
-FROM buildbase as appbase
+FROM buildbase AS appbase
 
 RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -o go-synthetic ./examples/instrumentation/go-synthetic
 

--- a/examples/varnish/Dockerfile
+++ b/examples/varnish/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stable-slim as stage
+FROM debian:stable-slim AS stage
 WORKDIR /exporter
 ADD https://github.com/jonnenauha/prometheus_varnish_exporter/releases/download/1.6.1/prometheus_varnish_exporter-1.6.1.linux-amd64.tar.gz /exporter/exporter.tar.gz
 RUN tar -xvf exporter.tar.gz

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -14,7 +14,7 @@
 
 # deps builds binaries in an isolated environment to avoid
 # funkiness in the hermetic build.
-FROM golang:1.23.2-bullseye as deps
+FROM golang:1.23.2-bullseye AS deps
 WORKDIR /workspace
 # Have to clone and install this as the go.mod uses replace directives.
 # RUN git clone --depth 1 --branch v0.53.1 https://github.com/prometheus-operator/prometheus-operator  \
@@ -63,7 +63,7 @@ RUN echo ${RUNCMD} | sh && echo 'done'
 
 # sync is used to copy all auto-generated files to a different context.
 # Usually this is used to mirror the changes back to the host machine.
-FROM scratch as sync
+FROM scratch AS sync
 COPY --from=hermetic /workspace/go.mod go.mod
 COPY --from=hermetic /workspace/go.sum go.sum
 COPY --from=hermetic /workspace/cmd cmd
@@ -75,9 +75,9 @@ COPY --from=hermetic /workspace/e2e e2e
 COPY --from=hermetic /workspace/vendor vendor.tmp
 
 ## kindtest image for running tests against kind cluster in hermetic environment.
-FROM golang:1.23.2-bullseye as buildbase
-FROM docker:27.2-cli as docker
-FROM debian:stable-slim as kindtest
+FROM golang:1.23.2-bullseye AS buildbase
+FROM docker:27.2-cli AS docker
+FROM debian:stable-slim AS kindtest
 
 WORKDIR /build
 


### PR DESCRIPTION
Having different casing for FROM and AS in Dockerfiles generates a warning in Louhi.