### PR TITLE
chore: fix cross-compile issues

### DIFF
--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -28,8 +28,8 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=1 CC=${CC} \
-      go build -tags boring -mod=vendor -o config-reloader -ldflags='-linkmode=external -extldflags=-static' cmd/config-reloader/*.go
+      go build -tags boring -mod=vendor -o config-reloader cmd/config-reloader/*.go
 
-FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20240307.00_p0@sha256:4f834e207f2721977094aeec4c9daee7032c5daec2083c0be97760f4306e4f88
+FROM gcr.io/distroless/base-nossl-debian12:nonroot
 COPY --from=buildbase /app/config-reloader /bin/config-reloader
 ENTRYPOINT ["/bin/config-reloader"]

--- a/cmd/datasource-syncer/Dockerfile
+++ b/cmd/datasource-syncer/Dockerfile
@@ -24,9 +24,9 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=1 CC=${CC} \
-      go build -tags boring -mod=vendor -o datasource-syncer -ldflags='-linkmode=external -extldflags=-static' cmd/datasource-syncer/*.go
+      go build -tags boring -mod=vendor -o datasource-syncer cmd/datasource-syncer/*.go
 
-FROM gcr.io/distroless/static-debian11:latest
+FROM gcr.io/distroless/base-nossl-debian12:nonroot
 COPY --from=buildbase /app/datasource-syncer /bin/datasource-syncer
 ENTRYPOINT ["/bin/datasource-syncer"]
 

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -31,10 +31,18 @@ COPY --from=assets /app/pkg/ui/static pkg/ui/static
 
 # Build the actual Go binary.
 FROM buildbase AS appbase
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /app
 COPY --from=assets /app ./
-RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -tags builtinassets -mod=vendor -o frontend ./cmd/frontend/*.go
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
+      apt install -y --no-install-recommends \
+        gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
+      CC=aarch64-linux-gnu-gcc; \
+    fi && \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=1 CC=${CC} \
+      go build -tags boring,builtinassets -mod=vendor -o frontend ./cmd/frontend/*.go
 
-FROM gcr.io/distroless/static-debian11:latest
+FROM gcr.io/distroless/base-nossl-debian12:nonroot
 COPY --from=appbase /app/frontend /bin/frontend
 ENTRYPOINT ["/bin/frontend"]

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -28,8 +28,8 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=1 CC=${CC} \
-      go build -tags boring -mod=vendor -o operator -ldflags='-linkmode=external -extldflags=-static' cmd/operator/*.go
+      go build -tags boring -mod=vendor -o operator cmd/operator/*.go
 
-FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20240307.00_p0@sha256:4f834e207f2721977094aeec4c9daee7032c5daec2083c0be97760f4306e4f88
+FROM gcr.io/distroless/base-nossl-debian12:nonroot
 COPY --from=buildbase /app/operator /bin/operator
 ENTRYPOINT ["/bin/operator"]

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -29,8 +29,8 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=1 CC=${CC} \
-      go build -tags boring -mod=vendor -o rule-evaluator -ldflags='-linkmode=external -extldflags=-static' cmd/rule-evaluator/*.go
+      go build -tags boring -mod=vendor -o rule-evaluator cmd/rule-evaluator/*.go
 
-FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20240307.00_p0@sha256:4f834e207f2721977094aeec4c9daee7032c5daec2083c0be97760f4306e4f88
+FROM gcr.io/distroless/base-nossl-debian12:nonroot
 COPY --from=buildbase /app/rule-evaluator /bin/rule-evaluator
 ENTRYPOINT ["/bin/rule-evaluator"]

--- a/examples/instrumentation/go-synthetic/Dockerfile
+++ b/examples/instrumentation/go-synthetic/Dockerfile
@@ -26,8 +26,8 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=1 CC=${CC} \
-      go build -tags boring -mod=vendor -o go-synthetic -ldflags='-linkmode=external -extldflags=-static' ./examples/instrumentation/go-synthetic
+      go build -tags boring -mod=vendor -o go-synthetic ./examples/instrumentation/go-synthetic
 
-FROM gcr.io/distroless/static-debian11:latest
+FROM gcr.io/distroless/base-nossl-debian12:nonroot
 COPY --from=appbase /app/go-synthetic /bin/go-synthetic
 ENTRYPOINT ["/bin/go-synthetic"]


### PR DESCRIPTION
Consistently use dynamically linked BoringCrypto with cross-compiling.