### PR TITLE
feat: expand VPA to all GMP components

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_operatorconfigs.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_operatorconfigs.yaml
@@ -480,7 +480,7 @@ spec:
                 properties:
                   enabled:
                     description: |-
-                      Enabled configures whether the operator configures Vertical Pod Autoscaling for the collector pods.
+                      Enabled configures whether the operator configures Vertical Pod Autoscaling for GMP workloads.
                       In GKE, installing Vertical Pod Autoscaling requires a cluster restart, and therefore it also results in an operator restart.
                       In other environments, the operator may need to be restarted to enable VPA to run the following check again and watch for the objects.
                     type: boolean

--- a/doc/api.md
+++ b/doc/api.md
@@ -3479,7 +3479,7 @@ bool
 </em>
 </td>
 <td>
-<p>Enabled configures whether the operator configures Vertical Pod Autoscaling for the collector pods.
+<p>Enabled configures whether the operator configures Vertical Pod Autoscaling for GMP workloads.
 In GKE, installing Vertical Pod Autoscaling requires a cluster restart, and therefore it also results in an operator restart.
 In other environments, the operator may need to be restarted to enable VPA to run the following check again and watch for the objects.</p>
 </td>

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -2154,7 +2154,7 @@ spec:
                   properties:
                     enabled:
                       description: |-
-                        Enabled configures whether the operator configures Vertical Pod Autoscaling for the collector pods.
+                        Enabled configures whether the operator configures Vertical Pod Autoscaling for GMP workloads.
                         In GKE, installing Vertical Pod Autoscaling requires a cluster restart, and therefore it also results in an operator restart.
                         In other environments, the operator may need to be restarted to enable VPA to run the following check again and watch for the objects.
                       type: boolean

--- a/pkg/operator/apis/monitoring/v1/operator_types.go
+++ b/pkg/operator/apis/monitoring/v1/operator_types.go
@@ -328,7 +328,7 @@ type ScalingSpec struct {
 
 // VPASpec defines configuration options for vertical pod autoscaling.
 type VPASpec struct {
-	// Enabled configures whether the operator configures Vertical Pod Autoscaling for the collector pods.
+	// Enabled configures whether the operator configures Vertical Pod Autoscaling for GMP workloads.
 	// In GKE, installing Vertical Pod Autoscaling requires a cluster restart, and therefore it also results in an operator restart.
 	// In other environments, the operator may need to be restarted to enable VPA to run the following check again and watch for the objects.
 	Enabled bool `json:"enabled,omitempty"`

--- a/pkg/operator/scaling_test.go
+++ b/pkg/operator/scaling_test.go
@@ -28,9 +28,24 @@ import (
 )
 
 func TestApplyVPA(t *testing.T) {
-	vpa := autoscalingv1.VerticalPodAutoscaler{
+	alertmanagerVPA := autoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: alertmanagerVPAName,
+		},
+	}
+	collectorVPA := autoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: collectorVPAName,
+		},
+	}
+	operatorVPA := autoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: operatorVPAName,
+		},
+	}
+	ruleEvaluatorVPA := autoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ruleEvaluatorVPAName,
 		},
 	}
 
@@ -59,7 +74,7 @@ func TestApplyVPA(t *testing.T) {
 			wantErr: true,
 		},
 		"update": {
-			c: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&vpa).Build(),
+			c: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&alertmanagerVPA, &collectorVPA, &operatorVPA, &ruleEvaluatorVPA).Build(),
 		},
 	}
 
@@ -74,16 +89,42 @@ func TestApplyVPA(t *testing.T) {
 			case err != nil && tc.wantErr:
 				// Ok
 			case err == nil && !tc.wantErr:
-				// Ok
+				if err := tc.c.Get(context.TODO(), client.ObjectKey{Name: alertmanagerVPAName}, &autoscalingv1.VerticalPodAutoscaler{}); err != nil {
+					t.Error(err)
+				}
+				if err := tc.c.Get(context.TODO(), client.ObjectKey{Name: collectorVPAName}, &autoscalingv1.VerticalPodAutoscaler{}); err != nil {
+					t.Error(err)
+				}
+				if err := tc.c.Get(context.TODO(), client.ObjectKey{Name: operatorVPAName}, &autoscalingv1.VerticalPodAutoscaler{}); err != nil {
+					t.Error(err)
+				}
+				if err := tc.c.Get(context.TODO(), client.ObjectKey{Name: ruleEvaluatorVPAName}, &autoscalingv1.VerticalPodAutoscaler{}); err != nil {
+					t.Error(err)
+				}
 			}
 		})
 	}
 }
 
 func TestDeleteVPA(t *testing.T) {
-	vpa := autoscalingv1.VerticalPodAutoscaler{
+	alertmanagerVPA := autoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: alertmanagerVPAName,
+		},
+	}
+	collectorVPA := autoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: collectorVPAName,
+		},
+	}
+	operatorVPA := autoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: operatorVPAName,
+		},
+	}
+	ruleEvaluatorVPA := autoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ruleEvaluatorVPAName,
 		},
 	}
 
@@ -113,7 +154,7 @@ func TestDeleteVPA(t *testing.T) {
 			c: fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(deleteInterceptorWithNotFoundError).Build(),
 		},
 		"ok": {
-			c: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&vpa).Build(),
+			c: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&alertmanagerVPA, &collectorVPA, &operatorVPA, &ruleEvaluatorVPA).Build(),
 		},
 		"err": {
 			c:       fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(deleteInterceptorWithError).Build(),
@@ -132,7 +173,18 @@ func TestDeleteVPA(t *testing.T) {
 			case err != nil && tc.wantErr:
 				// Ok
 			case err == nil && !tc.wantErr:
-				// Ok
+				if err := tc.c.Get(context.TODO(), client.ObjectKey{Name: alertmanagerVPAName}, &autoscalingv1.VerticalPodAutoscaler{}); !apierrors.IsNotFound(err) {
+					t.Errorf("expected not found, got %s", err)
+				}
+				if err := tc.c.Get(context.TODO(), client.ObjectKey{Name: collectorVPAName}, &autoscalingv1.VerticalPodAutoscaler{}); !apierrors.IsNotFound(err) {
+					t.Errorf("expected not found, got %s", err)
+				}
+				if err := tc.c.Get(context.TODO(), client.ObjectKey{Name: operatorVPAName}, &autoscalingv1.VerticalPodAutoscaler{}); !apierrors.IsNotFound(err) {
+					t.Errorf("expected not found, got %s", err)
+				}
+				if err := tc.c.Get(context.TODO(), client.ObjectKey{Name: ruleEvaluatorVPAName}, &autoscalingv1.VerticalPodAutoscaler{}); !apierrors.IsNotFound(err) {
+					t.Errorf("expected not found, got %s", err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Prior to this change, when the VPA feature is enabled, it is only used to autoscale the collector pods.

This change expands the VPA feature to autoscale the alertmanager, rule-evaluator, and operator.

Fixes #975 