### PR TITLE
fix: tolerate gke-managed-component nodes

### DIFF
--- a/charts/operator/templates/alertmanager.yaml
+++ b/charts/operator/templates/alertmanager.yaml
@@ -156,6 +156,8 @@ spec:
                 values:
                 - linux
       tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Exists"
       - value: "amd64"
         effect: "NoSchedule"
         key: "kubernetes.io/arch"

--- a/charts/operator/templates/collector.yaml
+++ b/charts/operator/templates/collector.yaml
@@ -179,6 +179,8 @@ spec:
                 values:
                 - linux
       tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Exists"
       - effect: NoExecute
         operator: Exists
       - effect: NoSchedule

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -101,6 +101,8 @@ spec:
                 values:
                 - linux
       tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Exists"
       - value: "amd64"
         effect: "NoSchedule"
         key: "kubernetes.io/arch"

--- a/charts/operator/templates/rule-evaluator.yaml
+++ b/charts/operator/templates/rule-evaluator.yaml
@@ -161,6 +161,8 @@ spec:
                 values:
                 - linux
       tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Exists"
       - value: "amd64"
         effect: "NoSchedule"
         key: "kubernetes.io/arch"

--- a/charts/rule-evaluator/templates/deployment.yaml
+++ b/charts/rule-evaluator/templates/deployment.yaml
@@ -130,6 +130,8 @@ spec:
                 values:
                 - linux
       tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Exists"
       - value: "amd64"
         effect: "NoSchedule"
         key: "kubernetes.io/arch"

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -100,7 +100,7 @@ RUN install -o root -g root -m 07555 jq /usr/local/bin/jq \
   && rm jq
 
 # Install kind.
-RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-linux-amd64
 RUN install -o root -g root -m 0755 kind /usr/local/bin/kind \
   && rm kind
 

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -505,6 +505,8 @@ spec:
                 values:
                 - linux
       tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Exists"
       - effect: NoExecute
         operator: Exists
       - effect: NoSchedule
@@ -609,6 +611,8 @@ spec:
                 values:
                 - linux
       tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Exists"
       - value: "amd64"
         effect: "NoSchedule"
         key: "kubernetes.io/arch"
@@ -784,6 +788,8 @@ spec:
                 values:
                 - linux
       tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Exists"
       - value: "amd64"
         effect: "NoSchedule"
         key: "kubernetes.io/arch"
@@ -934,6 +940,8 @@ spec:
                 values:
                 - linux
       tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Exists"
       - value: "amd64"
         effect: "NoSchedule"
         key: "kubernetes.io/arch"

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -232,6 +232,8 @@ spec:
                 values:
                 - linux
       tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Exists"
       - value: "amd64"
         effect: "NoSchedule"
         key: "kubernetes.io/arch"


### PR DESCRIPTION
Make GMP comply with gke-managed-component standard.

https://cloud.google.com/kubernetes-engine/docs/how-to/isolate-workloads-dedicated-nodes#recommendations-best-practices