### PR TITLE
chore: bump images

### DIFF
--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -30,16 +30,16 @@ images:
     tag: "v2.45.3-gmp.9-gke.0"
   configReloader:
     image: gke.gcr.io/prometheus-engine/config-reloader
-    tag: "v0.15.0-gke.8"
+    tag: "v0.15.0-gke.12"
   operator:
     image: gke.gcr.io/prometheus-engine/operator
-    tag: "v0.15.0-gke.8"
+    tag: "v0.15.0-gke.12"
   ruleEvaluator:
     image: gke.gcr.io/prometheus-engine/rule-evaluator
-    tag: "v0.15.0-gke.8"
+    tag: "v0.15.0-gke.12"
   datasourceSyncer:
     image: gcr.io/gke-release/prometheus-engine/datasource-syncer
-    tag: "v0.15.0-gke.8"
+    tag: "v0.15.0-gke.12"
 resources:
   alertManager:
     limits:

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -41,7 +41,7 @@ spec:
                 - linux
       containers:
       - name: datasource-syncer-init
-        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.15.0-gke.8
+        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.15.0-gke.12
         args:
         - "--datasource-uids=$DATASOURCE_UIDS"
         - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
@@ -79,7 +79,7 @@ spec:
                     - linux
           containers:
           - name: datasource-syncer
-            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.15.0-gke.8
+            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.15.0-gke.12
             args:
             - "--datasource-uids=$DATASOURCE_UIDS"
             - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -373,7 +373,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.0-gke.8
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.0-gke.12
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -550,7 +550,7 @@ spec:
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.15.0-gke.8
+        image: gke.gcr.io/prometheus-engine/operator:v0.15.0-gke.12
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"
@@ -670,7 +670,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.0-gke.8
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.0-gke.12
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -711,7 +711,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.0-gke.8
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.0-gke.12
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
@@ -876,7 +876,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.0-gke.8
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.0-gke.12
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -131,7 +131,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.0-gke.8
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.0-gke.12
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -169,7 +169,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.0-gke.8
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.0-gke.12
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"


### PR DESCRIPTION
gke.8 failed to build, so current version is broken.