### PR TITLE
chore: scan release branches with dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -75,3 +75,343 @@ updates:
         - "github.com/prometheus/prometheus"
         - "k8s.io/*"
         - "sigs.k8s.io/*"
+# Duplicate config for release/0.15
+- package-ecosystem: docker
+  directory: /hack
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.15
+- package-ecosystem: docker
+  directory: /cmd/rule-evaluator
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.15
+- package-ecosystem: docker
+  directory: /cmd/operator
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.15
+- package-ecosystem: docker
+  directory: /cmd/frontend
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.15
+- package-ecosystem: docker
+  directory: /cmd/config-reloader
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.15
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  groups:
+    # Group dep updates into one PR as single update already updates co-located deps.
+    # Skip biggest and the most complex deps: Thanos and Prometheus.
+    go-deps:
+      patterns:
+        - "*"
+      exclude-patterns:
+        # All of below deps has to be updated carefully as they are large, impacting
+        # our ability to import export pkg into Prometheus forks. They also often break compatibilty.
+        - "github.com/thanos-io/thanos"
+        - "github.com/prometheus/prometheus"
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
+  target-branch: release/0.15
+# Duplicate config for release/0.14
+- package-ecosystem: docker
+  directory: /hack
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.14
+- package-ecosystem: docker
+  directory: /cmd/rule-evaluator
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.14
+- package-ecosystem: docker
+  directory: /cmd/operator
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.14
+- package-ecosystem: docker
+  directory: /cmd/frontend
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.14
+- package-ecosystem: docker
+  directory: /cmd/config-reloader
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.14
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  groups:
+    # Group dep updates into one PR as single update already updates co-located deps.
+    # Skip biggest and the most complex deps: Thanos and Prometheus.
+    go-deps:
+      patterns:
+        - "*"
+      exclude-patterns:
+        # All of below deps has to be updated carefully as they are large, impacting
+        # our ability to import export pkg into Prometheus forks. They also often break compatibilty.
+        - "github.com/thanos-io/thanos"
+        - "github.com/prometheus/prometheus"
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
+  target-branch: release/0.14
+# Duplicate config for release/0.13
+- package-ecosystem: docker
+  directory: /hack
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.13
+- package-ecosystem: docker
+  directory: /cmd/rule-evaluator
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.13
+- package-ecosystem: docker
+  directory: /cmd/operator
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.13
+- package-ecosystem: docker
+  directory: /cmd/frontend
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.13
+- package-ecosystem: docker
+  directory: /cmd/config-reloader
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.13
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  groups:
+    # Group dep updates into one PR as single update already updates co-located deps.
+    # Skip biggest and the most complex deps: Thanos and Prometheus.
+    go-deps:
+      patterns:
+        - "*"
+      exclude-patterns:
+        # All of below deps has to be updated carefully as they are large, impacting
+        # our ability to import export pkg into Prometheus forks. They also often break compatibilty.
+        - "github.com/thanos-io/thanos"
+        - "github.com/prometheus/prometheus"
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
+  target-branch: release/0.13
+# Duplicate config for release/0.12
+- package-ecosystem: docker
+  directory: /hack
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.12
+- package-ecosystem: docker
+  directory: /cmd/rule-evaluator
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.12
+- package-ecosystem: docker
+  directory: /cmd/operator
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.12
+- package-ecosystem: docker
+  directory: /cmd/frontend
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.12
+- package-ecosystem: docker
+  directory: /cmd/config-reloader
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.12
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  groups:
+    # Group dep updates into one PR as single update already updates co-located deps.
+    # Skip biggest and the most complex deps: Thanos and Prometheus.
+    go-deps:
+      patterns:
+        - "*"
+      exclude-patterns:
+        # All of below deps has to be updated carefully as they are large, impacting
+        # our ability to import export pkg into Prometheus forks. They also often break compatibilty.
+        - "github.com/thanos-io/thanos"
+        - "github.com/prometheus/prometheus"
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
+  target-branch: release/0.12
+# Duplicate config for release/0.11
+- package-ecosystem: docker
+  directory: /hack
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.11
+- package-ecosystem: docker
+  directory: /cmd/rule-evaluator
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.11
+- package-ecosystem: docker
+  directory: /cmd/operator
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.11
+- package-ecosystem: docker
+  directory: /cmd/frontend
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.11
+- package-ecosystem: docker
+  directory: /cmd/config-reloader
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.11
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  groups:
+    # Group dep updates into one PR as single update already updates co-located deps.
+    # Skip biggest and the most complex deps: Thanos and Prometheus.
+    go-deps:
+      patterns:
+        - "*"
+      exclude-patterns:
+        # All of below deps has to be updated carefully as they are large, impacting
+        # our ability to import export pkg into Prometheus forks. They also often break compatibilty.
+        - "github.com/thanos-io/thanos"
+        - "github.com/prometheus/prometheus"
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
+  target-branch: release/0.11


### PR DESCRIPTION
Duplicate Dependabot config to scan all active release branches in addition to `main`.