### PR TITLE
Add new sample manifests for GKE AI workloads

### DIFF
--- a/examples/nvidia-triton/README.md
+++ b/examples/nvidia-triton/README.md
@@ -1,0 +1,3 @@
+# NVIDIA Triton sample manifests
+
+Please refer to the [Google Cloud documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/nvidia-triton) for how to use these manifests.

--- a/examples/nvidia-triton/pod-monitoring.yaml
+++ b/examples/nvidia-triton/pod-monitoring.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: triton
+  labels:
+    app.kubernetes.io/name: triton
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  endpoints:
+  - port: 8002
+    scheme: http
+    interval: 30s
+    path: /metrics
+  selector:
+    matchLabels:
+      app: triton

--- a/examples/tgi/README.md
+++ b/examples/tgi/README.md
@@ -1,0 +1,3 @@
+# Text Generation Inference (TGI) sample manifests
+
+Please refer to the [Google Cloud documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/tgi) for how to use these manifests.

--- a/examples/tgi/pod-monitoring.yaml
+++ b/examples/tgi/pod-monitoring.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: tgi
+  labels:
+    app.kubernetes.io/name: tgi
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  endpoints:
+  - port: 8080
+    scheme: http
+    interval: 30s
+    path: /metrics
+  selector:
+    matchLabels:
+      app: tgi-gemma-server

--- a/examples/vllm/README.md
+++ b/examples/vllm/README.md
@@ -1,0 +1,3 @@
+# vLLM sample manifests
+
+Please refer to the [Google Cloud documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/vllm) for how to use these manifests.

--- a/examples/vllm/pod-monitoring.yaml
+++ b/examples/vllm/pod-monitoring.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: vllm
+  labels:
+    app.kubernetes.io/name: vllm
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  endpoints:
+  - port: 8000
+    scheme: http
+    interval: 30s
+    path: /metrics
+  selector:
+    matchLabels:
+      app: vllm-gemma-server


### PR DESCRIPTION
These will be embedded in new docs at https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/introduction for how to instrument and observe these workloads.