### PR TITLE
feat: validate scrape configs

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusternodemonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusternodemonitorings.yaml
@@ -79,6 +79,18 @@ spec:
                           action:
                             description: Action to perform based on regex matching.
                               Defaults to 'replace'.
+                            enum:
+                            - replace
+                            - lowercase
+                            - uppercase
+                            - keep
+                            - drop
+                            - keepequal
+                            - dropequal
+                            - hashmod
+                            - labeldrop
+                            - labelkeep
+                            format: relabel_action
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -104,12 +116,16 @@ spec:
                               using the configured separator and matched against the configured regular expression
                               for the replace, keep, and drop actions.
                             items:
+                              format: labelname
+                              pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                               type: string
                             type: array
                           targetLabel:
                             description: |-
                               Label to which the resulting value is written in a replace action.
                               It is mandatory for replace actions. Regex capture groups are available.
+                            format: labelname
+                            pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                             type: string
                         type: object
                       type: array

--- a/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -129,9 +129,9 @@ spec:
                           type: string
                       type: object
                     interval:
-                      default: 1m
                       description: Interval at which to scrape metrics. Must be a
                         valid Prometheus duration.
+                      format: duration
                       pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                       type: string
                     metricRelabeling:
@@ -147,6 +147,18 @@ spec:
                           action:
                             description: Action to perform based on regex matching.
                               Defaults to 'replace'.
+                            enum:
+                            - replace
+                            - lowercase
+                            - uppercase
+                            - keep
+                            - drop
+                            - keepequal
+                            - dropequal
+                            - hashmod
+                            - labeldrop
+                            - labelkeep
+                            format: relabel_action
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -172,12 +184,16 @@ spec:
                               using the configured separator and matched against the configured regular expression
                               for the replace, keep, and drop actions.
                             items:
+                              format: labelname
+                              pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                               type: string
                             type: array
                           targetLabel:
                             description: |-
                               Label to which the resulting value is written in a replace action.
                               It is mandatory for replace actions. Regex capture groups are available.
+                            format: labelname
+                            pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                             type: string
                         type: object
                       type: array
@@ -366,11 +382,16 @@ spec:
                       type: string
                     scheme:
                       description: Protocol scheme to use to scrape.
+                      enum:
+                      - http
+                      - https
                       type: string
                     timeout:
                       description: |-
                         Timeout for metrics scrapes. Must be a valid Prometheus duration.
                         Must not be larger than the scrape interval.
+                      format: duration
+                      pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                       type: string
                     tls:
                       description: TLS configures the scrape request's TLS settings.
@@ -479,6 +500,11 @@ spec:
                   required:
                   - port
                   type: object
+                  x-kubernetes-validations:
+                  - messageExpression: '''"scrape timeout " + self.timeout + "must
+                      not be greater than scrape interval" + self.interval'''
+                    rule: '!has(self.interval) || !has(self.timeout) || self.interval
+                      <= self.timeout'
                 minItems: 1
                 type: array
               filterRunning:
@@ -592,11 +618,15 @@ spec:
                       properties:
                         from:
                           description: Kubernetes resource label to remap.
+                          format: labelname
+                          pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                           type: string
                         to:
                           description: |-
                             Remapped Prometheus target label.
                             Defaults to the same name as `From`.
+                          format: labelname
+                          pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                           type: string
                       required:
                       - from
@@ -615,8 +645,16 @@ spec:
                       and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
                       only.
                     items:
+                      enum:
+                      - pod
+                      - container
+                      - node
+                      - namespace
+                      - top_level_controller_name
+                      - top_level_controller_type
                       type: string
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
             required:
             - endpoints

--- a/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -129,9 +129,9 @@ spec:
                           type: string
                       type: object
                     interval:
-                      default: 1m
                       description: Interval at which to scrape metrics. Must be a
                         valid Prometheus duration.
+                      format: duration
                       pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                       type: string
                     metricRelabeling:
@@ -147,6 +147,18 @@ spec:
                           action:
                             description: Action to perform based on regex matching.
                               Defaults to 'replace'.
+                            enum:
+                            - replace
+                            - lowercase
+                            - uppercase
+                            - keep
+                            - drop
+                            - keepequal
+                            - dropequal
+                            - hashmod
+                            - labeldrop
+                            - labelkeep
+                            format: relabel_action
                             type: string
                           modulus:
                             description: Modulus to take of the hash of the source
@@ -172,12 +184,16 @@ spec:
                               using the configured separator and matched against the configured regular expression
                               for the replace, keep, and drop actions.
                             items:
+                              format: labelname
+                              pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                               type: string
                             type: array
                           targetLabel:
                             description: |-
                               Label to which the resulting value is written in a replace action.
                               It is mandatory for replace actions. Regex capture groups are available.
+                            format: labelname
+                            pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                             type: string
                         type: object
                       type: array
@@ -366,11 +382,16 @@ spec:
                       type: string
                     scheme:
                       description: Protocol scheme to use to scrape.
+                      enum:
+                      - http
+                      - https
                       type: string
                     timeout:
                       description: |-
                         Timeout for metrics scrapes. Must be a valid Prometheus duration.
                         Must not be larger than the scrape interval.
+                      format: duration
+                      pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                       type: string
                     tls:
                       description: TLS configures the scrape request's TLS settings.
@@ -479,6 +500,11 @@ spec:
                   required:
                   - port
                   type: object
+                  x-kubernetes-validations:
+                  - messageExpression: '''"scrape timeout " + self.timeout + "must
+                      not be greater than scrape interval" + self.interval'''
+                    rule: '!has(self.interval) || !has(self.timeout) || self.interval
+                      <= self.timeout'
                 minItems: 1
                 type: array
               filterRunning:
@@ -586,11 +612,15 @@ spec:
                       properties:
                         from:
                           description: Kubernetes resource label to remap.
+                          format: labelname
+                          pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                           type: string
                         to:
                           description: |-
                             Remapped Prometheus target label.
                             Defaults to the same name as `From`.
+                          format: labelname
+                          pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                           type: string
                       required:
                       - from
@@ -609,8 +639,16 @@ spec:
                       and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
                       only.
                     items:
+                      enum:
+                      - pod
+                      - container
+                      - node
+                      - namespace
+                      - top_level_controller_name
+                      - top_level_controller_type
                       type: string
                     type: array
+                    x-kubernetes-list-type: set
                 type: object
             required:
             - endpoints

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -78,6 +78,18 @@ spec:
                           properties:
                             action:
                               description: Action to perform based on regex matching. Defaults to 'replace'.
+                              enum:
+                                - replace
+                                - lowercase
+                                - uppercase
+                                - keep
+                                - drop
+                                - keepequal
+                                - dropequal
+                                - hashmod
+                                - labeldrop
+                                - labelkeep
+                              format: relabel_action
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source label values.
@@ -100,12 +112,16 @@ spec:
                                 using the configured separator and matched against the configured regular expression
                                 for the replace, keep, and drop actions.
                               items:
+                                format: labelname
+                                pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                                 type: string
                               type: array
                             targetLabel:
                               description: |-
                                 Label to which the resulting value is written in a replace action.
                                 It is mandatory for replace actions. Regex capture groups are available.
+                              format: labelname
+                              pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                               type: string
                           type: object
                         type: array
@@ -369,8 +385,8 @@ spec:
                             type: string
                         type: object
                       interval:
-                        default: 1m
                         description: Interval at which to scrape metrics. Must be a valid Prometheus duration.
+                        format: duration
                         pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                         type: string
                       metricRelabeling:
@@ -384,6 +400,18 @@ spec:
                           properties:
                             action:
                               description: Action to perform based on regex matching. Defaults to 'replace'.
+                              enum:
+                                - replace
+                                - lowercase
+                                - uppercase
+                                - keep
+                                - drop
+                                - keepequal
+                                - dropequal
+                                - hashmod
+                                - labeldrop
+                                - labelkeep
+                              format: relabel_action
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source label values.
@@ -406,12 +434,16 @@ spec:
                                 using the configured separator and matched against the configured regular expression
                                 for the replace, keep, and drop actions.
                               items:
+                                format: labelname
+                                pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                                 type: string
                               type: array
                             targetLabel:
                               description: |-
                                 Label to which the resulting value is written in a replace action.
                                 It is mandatory for replace actions. Regex capture groups are available.
+                              format: labelname
+                              pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                               type: string
                           type: object
                         type: array
@@ -584,11 +616,16 @@ spec:
                         type: string
                       scheme:
                         description: Protocol scheme to use to scrape.
+                        enum:
+                          - http
+                          - https
                         type: string
                       timeout:
                         description: |-
                           Timeout for metrics scrapes. Must be a valid Prometheus duration.
                           Must not be larger than the scrape interval.
+                        format: duration
+                        pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                         type: string
                       tls:
                         description: TLS configures the scrape request's TLS settings.
@@ -687,6 +724,9 @@ spec:
                     required:
                       - port
                     type: object
+                    x-kubernetes-validations:
+                      - messageExpression: '''"scrape timeout " + self.timeout + "must not be greater than scrape interval" + self.interval'''
+                        rule: '!has(self.interval) || !has(self.timeout) || self.interval <= self.timeout'
                   minItems: 1
                   type: array
                 filterRunning:
@@ -798,11 +838,15 @@ spec:
                         properties:
                           from:
                             description: Kubernetes resource label to remap.
+                            format: labelname
+                            pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                             type: string
                           to:
                             description: |-
                               Remapped Prometheus target label.
                               Defaults to the same name as `From`.
+                            format: labelname
+                            pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                             type: string
                         required:
                           - from
@@ -821,8 +865,16 @@ spec:
                         and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
                         only.
                       items:
+                        enum:
+                          - pod
+                          - container
+                          - node
+                          - namespace
+                          - top_level_controller_name
+                          - top_level_controller_type
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                   type: object
               required:
                 - endpoints
@@ -2628,8 +2680,8 @@ spec:
                             type: string
                         type: object
                       interval:
-                        default: 1m
                         description: Interval at which to scrape metrics. Must be a valid Prometheus duration.
+                        format: duration
                         pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                         type: string
                       metricRelabeling:
@@ -2643,6 +2695,18 @@ spec:
                           properties:
                             action:
                               description: Action to perform based on regex matching. Defaults to 'replace'.
+                              enum:
+                                - replace
+                                - lowercase
+                                - uppercase
+                                - keep
+                                - drop
+                                - keepequal
+                                - dropequal
+                                - hashmod
+                                - labeldrop
+                                - labelkeep
+                              format: relabel_action
                               type: string
                             modulus:
                               description: Modulus to take of the hash of the source label values.
@@ -2665,12 +2729,16 @@ spec:
                                 using the configured separator and matched against the configured regular expression
                                 for the replace, keep, and drop actions.
                               items:
+                                format: labelname
+                                pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                                 type: string
                               type: array
                             targetLabel:
                               description: |-
                                 Label to which the resulting value is written in a replace action.
                                 It is mandatory for replace actions. Regex capture groups are available.
+                              format: labelname
+                              pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                               type: string
                           type: object
                         type: array
@@ -2843,11 +2911,16 @@ spec:
                         type: string
                       scheme:
                         description: Protocol scheme to use to scrape.
+                        enum:
+                          - http
+                          - https
                         type: string
                       timeout:
                         description: |-
                           Timeout for metrics scrapes. Must be a valid Prometheus duration.
                           Must not be larger than the scrape interval.
+                        format: duration
+                        pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
                         type: string
                       tls:
                         description: TLS configures the scrape request's TLS settings.
@@ -2946,6 +3019,9 @@ spec:
                     required:
                       - port
                     type: object
+                    x-kubernetes-validations:
+                      - messageExpression: '''"scrape timeout " + self.timeout + "must not be greater than scrape interval" + self.interval'''
+                        rule: '!has(self.interval) || !has(self.timeout) || self.interval <= self.timeout'
                   minItems: 1
                   type: array
                 filterRunning:
@@ -3051,11 +3127,15 @@ spec:
                         properties:
                           from:
                             description: Kubernetes resource label to remap.
+                            format: labelname
+                            pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                             type: string
                           to:
                             description: |-
                               Remapped Prometheus target label.
                               Defaults to the same name as `From`.
+                            format: labelname
+                            pattern: '[a-zA-Z_][a-zA-Z0-9_]*'
                             type: string
                         required:
                           - from
@@ -3074,8 +3154,16 @@ spec:
                         and to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility
                         only.
                       items:
+                        enum:
+                          - pod
+                          - container
+                          - node
+                          - namespace
+                          - top_level_controller_name
+                          - top_level_controller_type
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                   type: object
               required:
                 - endpoints


### PR DESCRIPTION
Add additional validation for scrape configs. Incremental progress toward removing validating webhooks for PodMonitoring/ClusterPodMonitoring.