### PR TITLE
feat: validate cert/key pairs

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -351,6 +351,10 @@ spec:
                                 for the targets.
                               type: string
                           type: object
+                          x-kubernetes-validations:
+                          - message: client cert and client key must be provided together,
+                              when either is provided
+                            rule: has(self.cert) == has(self.key)
                         tokenURL:
                           description: TokenURL is the URL to fetch the token from.
                           type: string
@@ -497,6 +501,10 @@ spec:
                             the targets.
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: client cert and client key must be provided together,
+                          when either is provided
+                        rule: has(self.cert) == has(self.key)
                   required:
                   - port
                   type: object

--- a/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -351,6 +351,10 @@ spec:
                                 for the targets.
                               type: string
                           type: object
+                          x-kubernetes-validations:
+                          - message: client cert and client key must be provided together,
+                              when either is provided
+                            rule: has(self.cert) == has(self.key)
                         tokenURL:
                           description: TokenURL is the URL to fetch the token from.
                           type: string
@@ -497,6 +501,10 @@ spec:
                             the targets.
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                      - message: client cert and client key must be provided together,
+                          when either is provided
+                        rule: has(self.cert) == has(self.key)
                   required:
                   - port
                   type: object

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -585,6 +585,9 @@ spec:
                                 description: ServerName is used to verify the hostname for the targets.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                              - message: client cert and client key must be provided together, when either is provided
+                                rule: has(self.cert) == has(self.key)
                           tokenURL:
                             description: TokenURL is the URL to fetch the token from.
                             type: string
@@ -721,6 +724,9 @@ spec:
                             description: ServerName is used to verify the hostname for the targets.
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                          - message: client cert and client key must be provided together, when either is provided
+                            rule: has(self.cert) == has(self.key)
                     required:
                       - port
                     type: object
@@ -2880,6 +2886,9 @@ spec:
                                 description: ServerName is used to verify the hostname for the targets.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                              - message: client cert and client key must be provided together, when either is provided
+                                rule: has(self.cert) == has(self.key)
                           tokenURL:
                             description: TokenURL is the URL to fetch the token from.
                             type: string
@@ -3016,6 +3025,9 @@ spec:
                             description: ServerName is used to verify the hostname for the targets.
                             type: string
                         type: object
+                        x-kubernetes-validations:
+                          - message: client cert and client key must be provided together, when either is provided
+                            rule: has(self.cert) == has(self.key)
                     required:
                       - port
                     type: object

--- a/pkg/operator/apis/monitoring/v1/http_types.go
+++ b/pkg/operator/apis/monitoring/v1/http_types.go
@@ -161,6 +161,7 @@ func (c *BasicAuth) ToPrometheusConfig(m PodMonitoringCRD, pool PrometheusSecret
 }
 
 // TLS specifies TLS configuration used for HTTP requests.
+// +kubebuilder:validation:XValidation:rule=has(self.cert) == has(self.key),message="client cert and client key must be provided together, when either is provided"
 type TLS struct {
 	// ServerName is used to verify the hostname for the targets.
 	// +optional


### PR DESCRIPTION
This rule is consistent with [checks conducted by promtool](https://github.com/prometheus/prometheus/blob/cb3b17a14c162cce051ae944d06c2c1a742a9211/cmd/promtool/main.go#L761-L766) when validating config files.
