### PR TITLE
chore: bump golangci-lint action to v6

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -42,10 +42,10 @@ jobs:
       with:
         go-version: '~1.23'
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.63.4
-        args: --timeout=5m
+        args: --out-format=colored-line-number --timeout=5m --verbose
   validate:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Bump the GitHub action version for golangci-lint to latest.