### PR TITLE
feat: enforce policy on operatorconfig

### DIFF
--- a/charts/operator/templates/validating-admission-policy.yaml
+++ b/charts/operator/templates/validating-admission-policy.yaml
@@ -1,0 +1,37 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "operatorconfigs.monitoring.googleapis.com"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["monitoring.googleapis.com"]
+      apiVersions: ["*"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["operatorconfigs"]
+  validations:
+    - expression: "object.metadata.name == 'config'"
+    - expression: "object.metadata.namespace == 'gmp-public'"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "operatorconfigs.monitoring.googleapis.com"
+spec:
+  policyName: "operatorconfigs.monitoring.googleapis.com"
+  validationActions: [Deny]

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -995,6 +995,46 @@ metadata:
   name: config
   namespace: gmp-public
 ---
+# Source: operator/templates/validating-admission-policy.yaml
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "operatorconfigs.monitoring.googleapis.com"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["monitoring.googleapis.com"]
+      apiVersions: ["*"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["operatorconfigs"]
+  validations:
+    - expression: "object.metadata.name == 'config'"
+    - expression: "object.metadata.namespace == 'gmp-public'"
+---
+# Source: operator/templates/validating-admission-policy.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "operatorconfigs.monitoring.googleapis.com"
+spec:
+  policyName: "operatorconfigs.monitoring.googleapis.com"
+  validationActions: [Deny]
+---
 # Source: operator/templates/validatingwebhookconfiguration.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
Establish ValidatingAdmissionPolicy for OperatorConfig.

Namespace cannot be enforced on regular CRD.

Compatibility Note: [ValidatingAdmissionPolicy reached stable in Kubernetes 1.30](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/), and 1.27-1.29 are still maintained in various GKE release channels. This change should not be backported beyond 1.30.