### PR TITLE
chore: enable comment-spacing linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,13 +95,6 @@ linters-settings:
         severity: warning
         disabled: true
         arguments: [7]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comment-spacings
-      - name: comment-spacings
-        severity: warning
-        disabled: true
-        arguments:
-          - mypragma
-          - otherpragma
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-naming
       - name: confusing-naming
         severity: warning

--- a/internal/promapi/promapi_test.go
+++ b/internal/promapi/promapi_test.go
@@ -178,7 +178,6 @@ func TestWriteErrorResponse(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			WriteError(log.NewNopLogger(), recorder, tt.errType, tt.errMsg, tt.httpResponseCode, "")
 
-			//require.JSONEq(t, tt.wantBody, recorder.Body.String())
 			require.Equal(t, tt.wantBody, recorder.Body.String())
 			require.Equal(t, tt.wantStatus, recorder.Code)
 		})

--- a/pkg/export/transform_test.go
+++ b/pkg/export/transform_test.go
@@ -1225,7 +1225,7 @@ func TestSampleBuilder(t *testing.T) {
 					{Ref: 1, T: 1000, V: 10}, // count
 					{Ref: 2, T: 1000, V: 3},  // sum
 				}, {
-					{Ref: 3, T: 2000, V: 13}, //+Inf
+					{Ref: 3, T: 2000, V: 13}, // +Inf
 					{Ref: 4, T: 2000, V: 7},  // 1
 					{Ref: 6, T: 2000, V: 0},  // 0.1
 					{Ref: 5, T: 2000, V: 1},  // 0.5


### PR DESCRIPTION
Enforce consistent spacing after comment delimiter.

https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comment-spacings