### PR TITLE
refactor: tune cel budgets

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusternodemonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusternodemonitorings.yaml
@@ -99,14 +99,18 @@ spec:
                           regex:
                             description: Regular expression against which the extracted
                               value is matched. Defaults to '(.*)'.
-                            maxLength: 100
+                            maxLength: 500
                             type: string
                             x-kubernetes-validations:
-                            - rule: '!''project_id''.matches(self) && !''location''.matches(self)
-                                && !''cluster''.matches(self) && !''namespace''.matches(self)
-                                && !''instance''.matches(self) && !''top_level_controller''.matches(self)
-                                && !''top_level_controller_type''.matches(self) &&
-                                !''__address__''.matches(self) && !''cluster''.matches(self)'
+                            - rule: '''project_id''.matches(self) == false'
+                            - rule: '''location''.matches(self) == false'
+                            - rule: '''cluster''.matches(self) == false'
+                            - rule: '''namespace''.matches(self) == false'
+                            - rule: '''instance''.matches(self) == false'
+                            - rule: '''top_level_controller''.matches(self) == false'
+                            - rule: '''top_level_controller_type''.matches(self) ==
+                                false'
+                            - rule: '''__address__''.matches(self) == false'
                           replacement:
                             description: |-
                               Replacement value against which a regex replace is performed if the
@@ -144,7 +148,7 @@ spec:
                         x-kubernetes-validations:
                         - rule: '!has(self.action) ||  self.action != ''labeldrop''
                             || has(self.regex)'
-                      maxItems: 50
+                      maxItems: 100
                       type: array
                     params:
                       additionalProperties:
@@ -183,7 +187,7 @@ spec:
                   - messageExpression: '''scrape timeout (%s) must not be greater
                       than scrape interval (%s)''.format([self.timeout, self.interval])'
                     rule: '!has(self.timeout) || self.timeout <= self.interval'
-                maxItems: 100
+                maxItems: 10
                 minItems: 1
                 type: array
               limits:

--- a/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -170,14 +170,18 @@ spec:
                           regex:
                             description: Regular expression against which the extracted
                               value is matched. Defaults to '(.*)'.
-                            maxLength: 100
+                            maxLength: 500
                             type: string
                             x-kubernetes-validations:
-                            - rule: '!''project_id''.matches(self) && !''location''.matches(self)
-                                && !''cluster''.matches(self) && !''namespace''.matches(self)
-                                && !''instance''.matches(self) && !''top_level_controller''.matches(self)
-                                && !''top_level_controller_type''.matches(self) &&
-                                !''__address__''.matches(self) && !''cluster''.matches(self)'
+                            - rule: '''project_id''.matches(self) == false'
+                            - rule: '''location''.matches(self) == false'
+                            - rule: '''cluster''.matches(self) == false'
+                            - rule: '''namespace''.matches(self) == false'
+                            - rule: '''instance''.matches(self) == false'
+                            - rule: '''top_level_controller''.matches(self) == false'
+                            - rule: '''top_level_controller_type''.matches(self) ==
+                                false'
+                            - rule: '''__address__''.matches(self) == false'
                           replacement:
                             description: |-
                               Replacement value against which a regex replace is performed if the
@@ -215,7 +219,7 @@ spec:
                         x-kubernetes-validations:
                         - rule: '!has(self.action) ||  self.action != ''labeldrop''
                             || has(self.regex)'
-                      maxItems: 50
+                      maxItems: 100
                       type: array
                     oauth2:
                       description: OAuth2 is the OAuth2 client credentials used to
@@ -566,7 +570,7 @@ spec:
                     rule: '!has(self.timeout) || self.timeout <= self.interval'
                   - rule: '((has(self.authorization) ? 1 : 0) + (has(self.basicAuth)
                       ? 1 : 0) + (has(self.oauth2) ? 1 : 0)) <= 1'
-                maxItems: 100
+                maxItems: 10
                 minItems: 1
                 type: array
               filterRunning:

--- a/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -170,14 +170,18 @@ spec:
                           regex:
                             description: Regular expression against which the extracted
                               value is matched. Defaults to '(.*)'.
-                            maxLength: 100
+                            maxLength: 500
                             type: string
                             x-kubernetes-validations:
-                            - rule: '!''project_id''.matches(self) && !''location''.matches(self)
-                                && !''cluster''.matches(self) && !''namespace''.matches(self)
-                                && !''instance''.matches(self) && !''top_level_controller''.matches(self)
-                                && !''top_level_controller_type''.matches(self) &&
-                                !''__address__''.matches(self) && !''cluster''.matches(self)'
+                            - rule: '''project_id''.matches(self) == false'
+                            - rule: '''location''.matches(self) == false'
+                            - rule: '''cluster''.matches(self) == false'
+                            - rule: '''namespace''.matches(self) == false'
+                            - rule: '''instance''.matches(self) == false'
+                            - rule: '''top_level_controller''.matches(self) == false'
+                            - rule: '''top_level_controller_type''.matches(self) ==
+                                false'
+                            - rule: '''__address__''.matches(self) == false'
                           replacement:
                             description: |-
                               Replacement value against which a regex replace is performed if the
@@ -215,7 +219,7 @@ spec:
                         x-kubernetes-validations:
                         - rule: '!has(self.action) ||  self.action != ''labeldrop''
                             || has(self.regex)'
-                      maxItems: 50
+                      maxItems: 100
                       type: array
                     oauth2:
                       description: OAuth2 is the OAuth2 client credentials used to
@@ -566,7 +570,7 @@ spec:
                     rule: '!has(self.timeout) || self.timeout <= self.interval'
                   - rule: '((has(self.authorization) ? 1 : 0) + (has(self.basicAuth)
                       ? 1 : 0) + (has(self.oauth2) ? 1 : 0)) <= 1'
-                maxItems: 100
+                maxItems: 10
                 minItems: 1
                 type: array
               filterRunning:

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -96,10 +96,17 @@ spec:
                               type: integer
                             regex:
                               description: Regular expression against which the extracted value is matched. Defaults to '(.*)'.
-                              maxLength: 100
+                              maxLength: 500
                               type: string
                               x-kubernetes-validations:
-                                - rule: '!''project_id''.matches(self) && !''location''.matches(self) && !''cluster''.matches(self) && !''namespace''.matches(self) && !''instance''.matches(self) && !''top_level_controller''.matches(self) && !''top_level_controller_type''.matches(self) && !''__address__''.matches(self) && !''cluster''.matches(self)'
+                                - rule: '''project_id''.matches(self) == false'
+                                - rule: '''location''.matches(self) == false'
+                                - rule: '''cluster''.matches(self) == false'
+                                - rule: '''namespace''.matches(self) == false'
+                                - rule: '''instance''.matches(self) == false'
+                                - rule: '''top_level_controller''.matches(self) == false'
+                                - rule: '''top_level_controller_type''.matches(self) == false'
+                                - rule: '''__address__''.matches(self) == false'
                             replacement:
                               description: |-
                                 Replacement value against which a regex replace is performed if the
@@ -130,7 +137,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - rule: '!has(self.action) ||  self.action != ''labeldrop'' || has(self.regex)'
-                        maxItems: 50
+                        maxItems: 100
                         type: array
                       params:
                         additionalProperties:
@@ -167,7 +174,7 @@ spec:
                     x-kubernetes-validations:
                       - messageExpression: '''scrape timeout (%s) must not be greater than scrape interval (%s)''.format([self.timeout, self.interval])'
                         rule: '!has(self.timeout) || self.timeout <= self.interval'
-                  maxItems: 100
+                  maxItems: 10
                   minItems: 1
                   type: array
                 limits:
@@ -438,10 +445,17 @@ spec:
                               type: integer
                             regex:
                               description: Regular expression against which the extracted value is matched. Defaults to '(.*)'.
-                              maxLength: 100
+                              maxLength: 500
                               type: string
                               x-kubernetes-validations:
-                                - rule: '!''project_id''.matches(self) && !''location''.matches(self) && !''cluster''.matches(self) && !''namespace''.matches(self) && !''instance''.matches(self) && !''top_level_controller''.matches(self) && !''top_level_controller_type''.matches(self) && !''__address__''.matches(self) && !''cluster''.matches(self)'
+                                - rule: '''project_id''.matches(self) == false'
+                                - rule: '''location''.matches(self) == false'
+                                - rule: '''cluster''.matches(self) == false'
+                                - rule: '''namespace''.matches(self) == false'
+                                - rule: '''instance''.matches(self) == false'
+                                - rule: '''top_level_controller''.matches(self) == false'
+                                - rule: '''top_level_controller_type''.matches(self) == false'
+                                - rule: '''__address__''.matches(self) == false'
                             replacement:
                               description: |-
                                 Replacement value against which a regex replace is performed if the
@@ -472,7 +486,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - rule: '!has(self.action) ||  self.action != ''labeldrop'' || has(self.regex)'
-                        maxItems: 50
+                        maxItems: 100
                         type: array
                       oauth2:
                         description: OAuth2 is the OAuth2 client credentials used to fetch a token for the targets.
@@ -793,7 +807,7 @@ spec:
                       - messageExpression: '''scrape timeout (%s) must not be greater than scrape interval (%s)''.format([self.timeout, self.interval])'
                         rule: '!has(self.timeout) || self.timeout <= self.interval'
                       - rule: '((has(self.authorization) ? 1 : 0) + (has(self.basicAuth) ? 1 : 0) + (has(self.oauth2) ? 1 : 0)) <= 1'
-                  maxItems: 100
+                  maxItems: 10
                   minItems: 1
                   type: array
                 filterRunning:
@@ -2784,10 +2798,17 @@ spec:
                               type: integer
                             regex:
                               description: Regular expression against which the extracted value is matched. Defaults to '(.*)'.
-                              maxLength: 100
+                              maxLength: 500
                               type: string
                               x-kubernetes-validations:
-                                - rule: '!''project_id''.matches(self) && !''location''.matches(self) && !''cluster''.matches(self) && !''namespace''.matches(self) && !''instance''.matches(self) && !''top_level_controller''.matches(self) && !''top_level_controller_type''.matches(self) && !''__address__''.matches(self) && !''cluster''.matches(self)'
+                                - rule: '''project_id''.matches(self) == false'
+                                - rule: '''location''.matches(self) == false'
+                                - rule: '''cluster''.matches(self) == false'
+                                - rule: '''namespace''.matches(self) == false'
+                                - rule: '''instance''.matches(self) == false'
+                                - rule: '''top_level_controller''.matches(self) == false'
+                                - rule: '''top_level_controller_type''.matches(self) == false'
+                                - rule: '''__address__''.matches(self) == false'
                             replacement:
                               description: |-
                                 Replacement value against which a regex replace is performed if the
@@ -2818,7 +2839,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - rule: '!has(self.action) ||  self.action != ''labeldrop'' || has(self.regex)'
-                        maxItems: 50
+                        maxItems: 100
                         type: array
                       oauth2:
                         description: OAuth2 is the OAuth2 client credentials used to fetch a token for the targets.
@@ -3139,7 +3160,7 @@ spec:
                       - messageExpression: '''scrape timeout (%s) must not be greater than scrape interval (%s)''.format([self.timeout, self.interval])'
                         rule: '!has(self.timeout) || self.timeout <= self.interval'
                       - rule: '((has(self.authorization) ? 1 : 0) + (has(self.basicAuth) ? 1 : 0) + (has(self.oauth2) ? 1 : 0)) <= 1'
-                  maxItems: 100
+                  maxItems: 10
                   minItems: 1
                   type: array
                 filterRunning:

--- a/pkg/operator/apis/monitoring/v1/node_types.go
+++ b/pkg/operator/apis/monitoring/v1/node_types.go
@@ -54,7 +54,7 @@ type ScrapeNodeEndpoint struct {
 	// override protected target labels (project_id, location, cluster, namespace, job,
 	// instance, or __address__) are not permitted. The labelmap action is not permitted
 	// in general.
-	// +kubebuilder:validation:MaxItems=50
+	// +kubebuilder:validation:MaxItems=100
 	MetricRelabeling []RelabelingRule `json:"metricRelabeling,omitempty"`
 	// TLS configures the scrape request's TLS settings.
 	// +optional
@@ -74,7 +74,7 @@ type ClusterNodeMonitoringSpec struct {
 	Selector metav1.LabelSelector `json:"selector,omitempty"`
 	// The endpoints to scrape on the selected nodes.
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=10
 	Endpoints []ScrapeNodeEndpoint `json:"endpoints"`
 	// Limits to apply at scrape time.
 	Limits *ScrapeLimits `json:"limits,omitempty"`

--- a/pkg/operator/apis/monitoring/v1/pod_types.go
+++ b/pkg/operator/apis/monitoring/v1/pod_types.go
@@ -179,7 +179,7 @@ type PodMonitoringSpec struct {
 	Selector metav1.LabelSelector `json:"selector"`
 	// The endpoints to scrape on the selected pods.
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=10
 	Endpoints []ScrapeEndpoint `json:"endpoints"`
 	// Labels to add to the Prometheus target for discovered endpoints.
 	// The `instance` label is always set to `<pod_name>:<port>` or `<node_name>:<port>`
@@ -217,7 +217,7 @@ type ClusterPodMonitoringSpec struct {
 	Selector metav1.LabelSelector `json:"selector"`
 	// The endpoints to scrape on the selected pods.
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=10
 	Endpoints []ScrapeEndpoint `json:"endpoints"`
 	// Labels to add to the Prometheus target for discovered endpoints.
 	// The `instance` label is always set to `<pod_name>:<port>` or `<node_name>:<port>`
@@ -269,7 +269,7 @@ type ScrapeEndpoint struct {
 	// override protected target labels (project_id, location, cluster, namespace, job,
 	// instance, top_level_controller, top_level_controller_type, or __address__) are
 	// not permitted. The labelmap action is not permitted in general.
-	// +kubebuilder:validation:MaxItems=50
+	// +kubebuilder:validation:MaxItems=100
 	MetricRelabeling []RelabelingRule `json:"metricRelabeling,omitempty"`
 	// Prometheus HTTP client configuration.
 	HTTPClientConfig `json:",inline"`
@@ -328,8 +328,15 @@ type RelabelingRule struct {
 	// +kubebuilder:validation:XValidation:rule="self != 'project_id' && self != 'location' && self != 'cluster' && self != 'namespace' && self != 'job' && self != 'instance' && self != 'top_level_controller' && self != 'top_level_controller_type' && self != '__address__'",messageExpression="'cannot relabel onto protected label \"%s\"'.format([self])"
 	TargetLabel string `json:"targetLabel,omitempty"`
 	// Regular expression against which the extracted value is matched. Defaults to '(.*)'.
-	// +kubebuilder:validation:MaxLength=100
-	// +kubebuilder:validation:XValidation:rule="!'project_id'.matches(self) && !'location'.matches(self) && !'cluster'.matches(self) && !'namespace'.matches(self) && !'instance'.matches(self) && !'top_level_controller'.matches(self) && !'top_level_controller_type'.matches(self) && !'__address__'.matches(self) && !'cluster'.matches(self)"
+	// +kubebuilder:validation:MaxLength=500
+	// +kubebuilder:validation:XValidation:rule='project_id'.matches(self) == false
+	// +kubebuilder:validation:XValidation:rule='location'.matches(self) == false
+	// +kubebuilder:validation:XValidation:rule='cluster'.matches(self) == false
+	// +kubebuilder:validation:XValidation:rule='namespace'.matches(self) == false
+	// +kubebuilder:validation:XValidation:rule='instance'.matches(self) == false
+	// +kubebuilder:validation:XValidation:rule='top_level_controller'.matches(self) == false
+	// +kubebuilder:validation:XValidation:rule='top_level_controller_type'.matches(self) == false
+	// +kubebuilder:validation:XValidation:rule='__address__'.matches(self) == false
 	Regex string `json:"regex,omitempty"`
 	// Modulus to take of the hash of the source label values.
 	Modulus uint64 `json:"modulus,omitempty"`


### PR DESCRIPTION
By dividing validation of the regex on RelabelingRules into multiple rules, it frees up [CEL runtime cost budget](https://github.com/GoogleCloudPlatform/prometheus-engine/actions/runs/13201663124/job/36854930524). In turn, this allows us to accept longer regex patterns and more rules.

Endpoints have been reduced, as it is much easier to work around that limitation by adding additional PodMonitorings. Whereas, it is more difficult to condense a regex or remove relabeling rules.