### PR TITLE
refactor: validate rules

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusterrules.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterrules.yaml
@@ -64,8 +64,10 @@ spec:
                     https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
                   properties:
                     interval:
+                      default: 1m
                       description: The interval at which to evaluate the rules. Must
                         be a valid Prometheus duration.
+                      format: duration
                       type: string
                     name:
                       description: The name of the rule group.
@@ -82,6 +84,7 @@ spec:
                             description: |-
                               Name of the alert to evaluate the expression as.
                               Only one of `record` and `alert` must be set.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                           annotations:
                             additionalProperties:
@@ -97,6 +100,7 @@ spec:
                             description: |-
                               The duration to wait before a firing alert produced by this rule is sent to Alertmanager.
                               Only valid if `alert` is set.
+                            format: duration
                             type: string
                           labels:
                             additionalProperties:
@@ -108,13 +112,20 @@ spec:
                             description: |-
                               Record the result of the expression to this metric name.
                               Only one of `record` and `alert` must be set.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                         required:
                         - expr
                         type: object
+                        x-kubernetes-validations:
+                        - message: Must set exactly one of Record or Alert
+                          rule: '(has(self.record) ? 1 : 0) + (has(self.alert) ? 1
+                            : 0) == 1'
+                        - message: Annotations are only allowed for alerting rules
+                          rule: '!has(self.annotations) || has(self.alert)'
+                      minItems: 1
                       type: array
                   required:
-                  - interval
                   - name
                   - rules
                   type: object

--- a/charts/operator/crds/monitoring.googleapis.com_globalrules.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_globalrules.yaml
@@ -63,8 +63,10 @@ spec:
                     https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
                   properties:
                     interval:
+                      default: 1m
                       description: The interval at which to evaluate the rules. Must
                         be a valid Prometheus duration.
+                      format: duration
                       type: string
                     name:
                       description: The name of the rule group.
@@ -81,6 +83,7 @@ spec:
                             description: |-
                               Name of the alert to evaluate the expression as.
                               Only one of `record` and `alert` must be set.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                           annotations:
                             additionalProperties:
@@ -96,6 +99,7 @@ spec:
                             description: |-
                               The duration to wait before a firing alert produced by this rule is sent to Alertmanager.
                               Only valid if `alert` is set.
+                            format: duration
                             type: string
                           labels:
                             additionalProperties:
@@ -107,13 +111,20 @@ spec:
                             description: |-
                               Record the result of the expression to this metric name.
                               Only one of `record` and `alert` must be set.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                         required:
                         - expr
                         type: object
+                        x-kubernetes-validations:
+                        - message: Must set exactly one of Record or Alert
+                          rule: '(has(self.record) ? 1 : 0) + (has(self.alert) ? 1
+                            : 0) == 1'
+                        - message: Annotations are only allowed for alerting rules
+                          rule: '!has(self.annotations) || has(self.alert)'
+                      minItems: 1
                       type: array
                   required:
-                  - interval
                   - name
                   - rules
                   type: object

--- a/charts/operator/crds/monitoring.googleapis.com_rules.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_rules.yaml
@@ -64,8 +64,10 @@ spec:
                     https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
                   properties:
                     interval:
+                      default: 1m
                       description: The interval at which to evaluate the rules. Must
                         be a valid Prometheus duration.
+                      format: duration
                       type: string
                     name:
                       description: The name of the rule group.
@@ -82,6 +84,7 @@ spec:
                             description: |-
                               Name of the alert to evaluate the expression as.
                               Only one of `record` and `alert` must be set.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                           annotations:
                             additionalProperties:
@@ -97,6 +100,7 @@ spec:
                             description: |-
                               The duration to wait before a firing alert produced by this rule is sent to Alertmanager.
                               Only valid if `alert` is set.
+                            format: duration
                             type: string
                           labels:
                             additionalProperties:
@@ -108,13 +112,20 @@ spec:
                             description: |-
                               Record the result of the expression to this metric name.
                               Only one of `record` and `alert` must be set.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                         required:
                         - expr
                         type: object
+                        x-kubernetes-validations:
+                        - message: Must set exactly one of Record or Alert
+                          rule: '(has(self.record) ? 1 : 0) + (has(self.alert) ? 1
+                            : 0) == 1'
+                        - message: Annotations are only allowed for alerting rules
+                          rule: '!has(self.annotations) || has(self.alert)'
+                      minItems: 1
                       type: array
                   required:
-                  - interval
                   - name
                   - rules
                   type: object

--- a/e2e/crd_validation_test.go
+++ b/e2e/crd_validation_test.go
@@ -865,4 +865,155 @@ func TestCRDValidation(t *testing.T) {
 		}
 		run(t, tests)
 	})
+	t.Run("Rules", func(t *testing.T) {
+		tests := map[string]test{
+			"minimal": {
+				obj: &monitoringv1.Rules{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "minimal",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.RulesSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Rules: []monitoringv1.Rule{
+									{
+										Record: "test",
+									},
+								},
+							},
+						},
+					},
+				},
+				wantErr: false,
+			},
+			"invalid-interval": {
+				obj: &monitoringv1.Rules{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "invalid-interval",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.RulesSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Interval: "foo",
+								Rules: []monitoringv1.Rule{
+									{
+										Record: "test",
+									},
+								},
+							},
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"invalid-rule-name": {
+				obj: &monitoringv1.Rules{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "invalid-rule-name",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.RulesSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Rules: []monitoringv1.Rule{
+									{
+										Record: "dots.not.allowed",
+									},
+								},
+							},
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"invalid-annotation": {
+				obj: &monitoringv1.Rules{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "invalid-annotation",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.RulesSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Rules: []monitoringv1.Rule{
+									{
+										Record: "test",
+										Annotations: map[string]string{
+											"test": "annotation",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"valid-annotation": {
+				obj: &monitoringv1.Rules{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "valid-annotation",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.RulesSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Rules: []monitoringv1.Rule{
+									{
+										Alert: "test",
+										Annotations: map[string]string{
+											"test": "annotation",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				wantErr: false,
+			},
+			"alert-and-record-both-set": {
+				obj: &monitoringv1.Rules{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "alert-and-record-set",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.RulesSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Rules: []monitoringv1.Rule{
+									{
+										Alert:  "alert",
+										Record: "record",
+									},
+								},
+							},
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"neither-alert-nor-record-set": {
+				obj: &monitoringv1.Rules{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "neither-alert-nor-record-set",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.RulesSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Rules: []monitoringv1.Rule{
+									{},
+								},
+							},
+						},
+					},
+				},
+				wantErr: true,
+			},
+		}
+		run(t, tests)
+	})
 }

--- a/e2e/ruler_test.go
+++ b/e2e/ruler_test.go
@@ -500,6 +500,7 @@ func testCreateRules(
 			"empty.yaml": "",
 			replace("globalrules__{namespace}-global-rules.yaml"): replace(`groups:
     - name: group-1
+      interval: 1m
       rules:
         - record: bar
           expr: avg(up)
@@ -508,6 +509,7 @@ func testCreateRules(
 `),
 			replace("clusterrules__{namespace}-cluster-rules.yaml"): replace(`groups:
     - name: group-1
+      interval: 1m
       rules:
         - record: foo
           expr: sum(up{cluster="{cluster}",location="{location}",project_id="{project_id}"})
@@ -519,6 +521,7 @@ func testCreateRules(
 `),
 			replace("rules__{namespace}__rules.yaml"): replace(`groups:
     - name: group-1
+      interval: 1m
       rules:
         - alert: Bar
           expr: avg(down{cluster="{cluster}",location="{location}",namespace="{namespace}",project_id="{project_id}"}) > 1

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -1374,7 +1374,9 @@ spec:
                       https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
                     properties:
                       interval:
+                        default: 1m
                         description: The interval at which to evaluate the rules. Must be a valid Prometheus duration.
+                        format: duration
                         type: string
                       name:
                         description: The name of the rule group.
@@ -1390,6 +1392,7 @@ spec:
                               description: |-
                                 Name of the alert to evaluate the expression as.
                                 Only one of `record` and `alert` must be set.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             annotations:
                               additionalProperties:
@@ -1405,6 +1408,7 @@ spec:
                               description: |-
                                 The duration to wait before a firing alert produced by this rule is sent to Alertmanager.
                                 Only valid if `alert` is set.
+                              format: duration
                               type: string
                             labels:
                               additionalProperties:
@@ -1415,13 +1419,19 @@ spec:
                               description: |-
                                 Record the result of the expression to this metric name.
                                 Only one of `record` and `alert` must be set.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                           required:
                             - expr
                           type: object
+                          x-kubernetes-validations:
+                            - message: Must set exactly one of Record or Alert
+                              rule: '(has(self.record) ? 1 : 0) + (has(self.alert) ? 1 : 0) == 1'
+                            - message: Annotations are only allowed for alerting rules
+                              rule: '!has(self.annotations) || has(self.alert)'
+                        minItems: 1
                         type: array
                     required:
-                      - interval
                       - name
                       - rules
                     type: object
@@ -1631,7 +1641,9 @@ spec:
                       https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
                     properties:
                       interval:
+                        default: 1m
                         description: The interval at which to evaluate the rules. Must be a valid Prometheus duration.
+                        format: duration
                         type: string
                       name:
                         description: The name of the rule group.
@@ -1647,6 +1659,7 @@ spec:
                               description: |-
                                 Name of the alert to evaluate the expression as.
                                 Only one of `record` and `alert` must be set.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             annotations:
                               additionalProperties:
@@ -1662,6 +1675,7 @@ spec:
                               description: |-
                                 The duration to wait before a firing alert produced by this rule is sent to Alertmanager.
                                 Only valid if `alert` is set.
+                              format: duration
                               type: string
                             labels:
                               additionalProperties:
@@ -1672,13 +1686,19 @@ spec:
                               description: |-
                                 Record the result of the expression to this metric name.
                                 Only one of `record` and `alert` must be set.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                           required:
                             - expr
                           type: object
+                          x-kubernetes-validations:
+                            - message: Must set exactly one of Record or Alert
+                              rule: '(has(self.record) ? 1 : 0) + (has(self.alert) ? 1 : 0) == 1'
+                            - message: Annotations are only allowed for alerting rules
+                              rule: '!has(self.annotations) || has(self.alert)'
+                        minItems: 1
                         type: array
                     required:
-                      - interval
                       - name
                       - rules
                     type: object
@@ -3731,7 +3751,9 @@ spec:
                       https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
                     properties:
                       interval:
+                        default: 1m
                         description: The interval at which to evaluate the rules. Must be a valid Prometheus duration.
+                        format: duration
                         type: string
                       name:
                         description: The name of the rule group.
@@ -3747,6 +3769,7 @@ spec:
                               description: |-
                                 Name of the alert to evaluate the expression as.
                                 Only one of `record` and `alert` must be set.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             annotations:
                               additionalProperties:
@@ -3762,6 +3785,7 @@ spec:
                               description: |-
                                 The duration to wait before a firing alert produced by this rule is sent to Alertmanager.
                                 Only valid if `alert` is set.
+                              format: duration
                               type: string
                             labels:
                               additionalProperties:
@@ -3772,13 +3796,19 @@ spec:
                               description: |-
                                 Record the result of the expression to this metric name.
                                 Only one of `record` and `alert` must be set.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                           required:
                             - expr
                           type: object
+                          x-kubernetes-validations:
+                            - message: Must set exactly one of Record or Alert
+                              rule: '(has(self.record) ? 1 : 0) + (has(self.alert) ? 1 : 0) == 1'
+                            - message: Annotations are only allowed for alerting rules
+                              rule: '!has(self.annotations) || has(self.alert)'
+                        minItems: 1
                         type: array
                     required:
-                      - interval
                       - name
                       - rules
                     type: object

--- a/pkg/operator/apis/monitoring/v1/rules_types.go
+++ b/pkg/operator/apis/monitoring/v1/rules_types.go
@@ -176,24 +176,32 @@ type RuleGroup struct {
 	// The name of the rule group.
 	Name string `json:"name"`
 	// The interval at which to evaluate the rules. Must be a valid Prometheus duration.
-	Interval string `json:"interval"`
+	// +kubebuilder:validation:Format=duration
+	// +kubebuilder:default="1m"
+	Interval string `json:"interval,omitempty"`
 	// A list of rules that are executed sequentially as part of this group.
+	// +kubebuilder:validation:MinItems=1
 	Rules []Rule `json:"rules"`
 }
 
 // Rule is a single rule in the Prometheus format:
 // https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
+// +kubebuilder:validation:XValidation:rule="(has(self.record) ? 1 : 0) + (has(self.alert) ? 1 : 0) == 1",message="Must set exactly one of Record or Alert"
+// +kubebuilder:validation:XValidation:rule="!has(self.annotations) || has(self.alert)",message="Annotations are only allowed for alerting rules"
 type Rule struct {
 	// Record the result of the expression to this metric name.
 	// Only one of `record` and `alert` must be set.
+	// +kubebuilder:validation:Pattern=^[a-zA-Z_][a-zA-Z0-9_]*$
 	Record string `json:"record,omitempty"`
 	// Name of the alert to evaluate the expression as.
 	// Only one of `record` and `alert` must be set.
+	// +kubebuilder:validation:Pattern=^[a-zA-Z_][a-zA-Z0-9_]*$
 	Alert string `json:"alert,omitempty"`
 	// The PromQL expression to evaluate.
 	Expr string `json:"expr"`
 	// The duration to wait before a firing alert produced by this rule is sent to Alertmanager.
 	// Only valid if `alert` is set.
+	// +kubebuilder:validation:Format=duration
 	For string `json:"for,omitempty"`
 	// A set of labels to attach to the result of the query expression.
 	Labels map[string]string `json:"labels,omitempty"`


### PR DESCRIPTION
Validate Rules/ClusterRules/GlobalRules with CRD/CEL validations.

Adds default Interval of `1m` for rules, consistent with Prometheus default and requires Interval field. Previously, this was allowed to be explicitly unset (empty string) which fell back to a value that is not configurable in GMP.

Implements:

- Interval must be a valid duration
- Must set exactly one of Record or Alert
- Annotations are only allowed for alerting rules
- Rule group name must be a valid Prometheus label name
- Tests covering this logic