### PR TITLE
fix: e2e test timeout

### DIFF
--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.23.5@sha256:ae5399149210a73ea34a8cb1f4812947b72da9f1d8b5463abb92c63e6826e838 AS buildbase
+FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.23.6@sha256:ca93722bc2549978ca5041d80da3bd8fd64b1e6ca773d778cdc74cb2fc767f4b AS buildbase
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /app

--- a/hack/kind-test.sh
+++ b/hack/kind-test.sh
@@ -123,7 +123,7 @@ connect_registry
 echo ">>> executing gmp e2e tests: ${GO_TEST}"
 # Note: a test failure here should exit non-zero and leave the cluster running
 # for debugging.
-go test -v -timeout 10m "${REPO_ROOT}/e2e" -run "${GO_TEST:-.}" -args ${TEST_ARGS}
+go test -v -timeout 30m "${REPO_ROOT}/e2e" -run "${GO_TEST:-.}" -args ${TEST_ARGS}
 
 # Delete cluster if it's not set to clean up post-test.
 # Otherwise, leave cluster running (e.g. for debugging).


### PR DESCRIPTION
DO NOT MERGE.

This PR is meant to test the timeout of the e2e tests for a dependabot PR which is timing out (https://github.com/GoogleCloudPlatform/prometheus-engine/pull/1367)