### PR TITLE
refactor: move regex validation to VAP

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusternodemonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusternodemonitorings.yaml
@@ -99,18 +99,8 @@ spec:
                           regex:
                             description: Regular expression against which the extracted
                               value is matched. Defaults to '(.*)'.
-                            maxLength: 500
+                            maxLength: 10000
                             type: string
-                            x-kubernetes-validations:
-                            - rule: '''project_id''.matches(self) == false'
-                            - rule: '''location''.matches(self) == false'
-                            - rule: '''cluster''.matches(self) == false'
-                            - rule: '''namespace''.matches(self) == false'
-                            - rule: '''instance''.matches(self) == false'
-                            - rule: '''top_level_controller''.matches(self) == false'
-                            - rule: '''top_level_controller_type''.matches(self) ==
-                                false'
-                            - rule: '''__address__''.matches(self) == false'
                           replacement:
                             description: |-
                               Replacement value against which a regex replace is performed if the
@@ -148,7 +138,7 @@ spec:
                         x-kubernetes-validations:
                         - rule: '!has(self.action) ||  self.action != ''labeldrop''
                             || has(self.regex)'
-                      maxItems: 100
+                      maxItems: 250
                       type: array
                     params:
                       additionalProperties:

--- a/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -170,18 +170,8 @@ spec:
                           regex:
                             description: Regular expression against which the extracted
                               value is matched. Defaults to '(.*)'.
-                            maxLength: 500
+                            maxLength: 10000
                             type: string
-                            x-kubernetes-validations:
-                            - rule: '''project_id''.matches(self) == false'
-                            - rule: '''location''.matches(self) == false'
-                            - rule: '''cluster''.matches(self) == false'
-                            - rule: '''namespace''.matches(self) == false'
-                            - rule: '''instance''.matches(self) == false'
-                            - rule: '''top_level_controller''.matches(self) == false'
-                            - rule: '''top_level_controller_type''.matches(self) ==
-                                false'
-                            - rule: '''__address__''.matches(self) == false'
                           replacement:
                             description: |-
                               Replacement value against which a regex replace is performed if the
@@ -219,7 +209,7 @@ spec:
                         x-kubernetes-validations:
                         - rule: '!has(self.action) ||  self.action != ''labeldrop''
                             || has(self.regex)'
-                      maxItems: 100
+                      maxItems: 250
                       type: array
                     oauth2:
                       description: OAuth2 is the OAuth2 client credentials used to

--- a/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -170,18 +170,8 @@ spec:
                           regex:
                             description: Regular expression against which the extracted
                               value is matched. Defaults to '(.*)'.
-                            maxLength: 500
+                            maxLength: 10000
                             type: string
-                            x-kubernetes-validations:
-                            - rule: '''project_id''.matches(self) == false'
-                            - rule: '''location''.matches(self) == false'
-                            - rule: '''cluster''.matches(self) == false'
-                            - rule: '''namespace''.matches(self) == false'
-                            - rule: '''instance''.matches(self) == false'
-                            - rule: '''top_level_controller''.matches(self) == false'
-                            - rule: '''top_level_controller_type''.matches(self) ==
-                                false'
-                            - rule: '''__address__''.matches(self) == false'
                           replacement:
                             description: |-
                               Replacement value against which a regex replace is performed if the
@@ -219,7 +209,7 @@ spec:
                         x-kubernetes-validations:
                         - rule: '!has(self.action) ||  self.action != ''labeldrop''
                             || has(self.regex)'
-                      maxItems: 100
+                      maxItems: 250
                       type: array
                     oauth2:
                       description: OAuth2 is the OAuth2 client credentials used to

--- a/charts/operator/templates/validating-admission-policy.yaml
+++ b/charts/operator/templates/validating-admission-policy.yaml
@@ -35,3 +35,41 @@ metadata:
 spec:
   policyName: "operatorconfigs.monitoring.googleapis.com"
   validationActions: [Deny]
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "protected-labels.monitoring.googleapis.com"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["monitoring.googleapis.com"]
+      apiVersions: ["*"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["clusternodemonitorings", "clusterpodmonitorings", "podmonitorings"]
+  validations:
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'project_id'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"project_id\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'location'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"location\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'cluster'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"cluster\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'namespace'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"namespace\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'instance'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"instance\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'top_level_controller'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"top_level_controller\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'top_level_controller_type'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"top_level_controller_type\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || '__address__'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"__address__\""
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "protected-labels.monitoring.googleapis.com"
+spec:
+  policyName: "protected-labels.monitoring.googleapis.com"
+  validationActions: [Deny]

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -1028,11 +1028,51 @@ spec:
 ---
 # Source: operator/templates/validating-admission-policy.yaml
 apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "protected-labels.monitoring.googleapis.com"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["monitoring.googleapis.com"]
+      apiVersions: ["*"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["clusternodemonitorings", "clusterpodmonitorings", "podmonitorings"]
+  validations:
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'project_id'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"project_id\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'location'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"location\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'cluster'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"cluster\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'namespace'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"namespace\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'instance'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"instance\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'top_level_controller'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"top_level_controller\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || 'top_level_controller_type'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"top_level_controller_type\""
+    - expression: "object.spec.endpoints.all(e, !has(e.metricRelabeling) || e.metricRelabeling.all(m, !has(m.regex) || '__address__'.matches(m.regex) == false))"
+      message: "Relabeling rule regex would match protected label: \"__address__\""
+---
+# Source: operator/templates/validating-admission-policy.yaml
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "operatorconfigs.monitoring.googleapis.com"
 spec:
   policyName: "operatorconfigs.monitoring.googleapis.com"
+  validationActions: [Deny]
+---
+# Source: operator/templates/validating-admission-policy.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "protected-labels.monitoring.googleapis.com"
+spec:
+  policyName: "protected-labels.monitoring.googleapis.com"
   validationActions: [Deny]
 ---
 # Source: operator/templates/validatingwebhookconfiguration.yaml

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -96,17 +96,8 @@ spec:
                               type: integer
                             regex:
                               description: Regular expression against which the extracted value is matched. Defaults to '(.*)'.
-                              maxLength: 500
+                              maxLength: 10000
                               type: string
-                              x-kubernetes-validations:
-                                - rule: '''project_id''.matches(self) == false'
-                                - rule: '''location''.matches(self) == false'
-                                - rule: '''cluster''.matches(self) == false'
-                                - rule: '''namespace''.matches(self) == false'
-                                - rule: '''instance''.matches(self) == false'
-                                - rule: '''top_level_controller''.matches(self) == false'
-                                - rule: '''top_level_controller_type''.matches(self) == false'
-                                - rule: '''__address__''.matches(self) == false'
                             replacement:
                               description: |-
                                 Replacement value against which a regex replace is performed if the
@@ -137,7 +128,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - rule: '!has(self.action) ||  self.action != ''labeldrop'' || has(self.regex)'
-                        maxItems: 100
+                        maxItems: 250
                         type: array
                       params:
                         additionalProperties:
@@ -445,17 +436,8 @@ spec:
                               type: integer
                             regex:
                               description: Regular expression against which the extracted value is matched. Defaults to '(.*)'.
-                              maxLength: 500
+                              maxLength: 10000
                               type: string
-                              x-kubernetes-validations:
-                                - rule: '''project_id''.matches(self) == false'
-                                - rule: '''location''.matches(self) == false'
-                                - rule: '''cluster''.matches(self) == false'
-                                - rule: '''namespace''.matches(self) == false'
-                                - rule: '''instance''.matches(self) == false'
-                                - rule: '''top_level_controller''.matches(self) == false'
-                                - rule: '''top_level_controller_type''.matches(self) == false'
-                                - rule: '''__address__''.matches(self) == false'
                             replacement:
                               description: |-
                                 Replacement value against which a regex replace is performed if the
@@ -486,7 +468,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - rule: '!has(self.action) ||  self.action != ''labeldrop'' || has(self.regex)'
-                        maxItems: 100
+                        maxItems: 250
                         type: array
                       oauth2:
                         description: OAuth2 is the OAuth2 client credentials used to fetch a token for the targets.
@@ -2798,17 +2780,8 @@ spec:
                               type: integer
                             regex:
                               description: Regular expression against which the extracted value is matched. Defaults to '(.*)'.
-                              maxLength: 500
+                              maxLength: 10000
                               type: string
-                              x-kubernetes-validations:
-                                - rule: '''project_id''.matches(self) == false'
-                                - rule: '''location''.matches(self) == false'
-                                - rule: '''cluster''.matches(self) == false'
-                                - rule: '''namespace''.matches(self) == false'
-                                - rule: '''instance''.matches(self) == false'
-                                - rule: '''top_level_controller''.matches(self) == false'
-                                - rule: '''top_level_controller_type''.matches(self) == false'
-                                - rule: '''__address__''.matches(self) == false'
                             replacement:
                               description: |-
                                 Replacement value against which a regex replace is performed if the
@@ -2839,7 +2812,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - rule: '!has(self.action) ||  self.action != ''labeldrop'' || has(self.regex)'
-                        maxItems: 100
+                        maxItems: 250
                         type: array
                       oauth2:
                         description: OAuth2 is the OAuth2 client credentials used to fetch a token for the targets.

--- a/pkg/operator/apis/monitoring/v1/node_types.go
+++ b/pkg/operator/apis/monitoring/v1/node_types.go
@@ -51,7 +51,7 @@ type ScrapeNodeEndpoint struct {
 	// override protected target labels (project_id, location, cluster, namespace, job,
 	// instance, or __address__) are not permitted. The labelmap action is not permitted
 	// in general.
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=250
 	MetricRelabeling []RelabelingRule `json:"metricRelabeling,omitempty"`
 	// TLS configures the scrape request's TLS settings.
 	// +optional

--- a/pkg/operator/apis/monitoring/v1/pod_types.go
+++ b/pkg/operator/apis/monitoring/v1/pod_types.go
@@ -236,7 +236,7 @@ type ScrapeEndpoint struct {
 	// override protected target labels (project_id, location, cluster, namespace, job,
 	// instance, top_level_controller, top_level_controller_type, or __address__) are
 	// not permitted. The labelmap action is not permitted in general.
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=250
 	MetricRelabeling []RelabelingRule `json:"metricRelabeling,omitempty"`
 	// Prometheus HTTP client configuration.
 	HTTPClientConfig `json:",inline"`
@@ -295,15 +295,7 @@ type RelabelingRule struct {
 	// +kubebuilder:validation:XValidation:rule="self != 'project_id' && self != 'location' && self != 'cluster' && self != 'namespace' && self != 'job' && self != 'instance' && self != 'top_level_controller' && self != 'top_level_controller_type' && self != '__address__'",messageExpression="'cannot relabel onto protected label \"%s\"'.format([self])"
 	TargetLabel string `json:"targetLabel,omitempty"`
 	// Regular expression against which the extracted value is matched. Defaults to '(.*)'.
-	// +kubebuilder:validation:MaxLength=500
-	// +kubebuilder:validation:XValidation:rule='project_id'.matches(self) == false
-	// +kubebuilder:validation:XValidation:rule='location'.matches(self) == false
-	// +kubebuilder:validation:XValidation:rule='cluster'.matches(self) == false
-	// +kubebuilder:validation:XValidation:rule='namespace'.matches(self) == false
-	// +kubebuilder:validation:XValidation:rule='instance'.matches(self) == false
-	// +kubebuilder:validation:XValidation:rule='top_level_controller'.matches(self) == false
-	// +kubebuilder:validation:XValidation:rule='top_level_controller_type'.matches(self) == false
-	// +kubebuilder:validation:XValidation:rule='__address__'.matches(self) == false
+	// +kubebuilder:validation:MaxLength=10000
 	Regex string `json:"regex,omitempty"`
 	// Modulus to take of the hash of the source label values.
 	Modulus uint64 `json:"modulus,omitempty"`


### PR DESCRIPTION
Move Relabling Regex validation to Validating Admission Policy, effectively circumventing the CEL runtime cost constraints.

Expand limits to 250 relabeling rules, 10,000 characters in regex.