### PR TITLE
build: fix xarch frontend build

### DIFF
--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -15,7 +15,7 @@
 FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.24.0@sha256:f0ed15de6a2c1d1e595b8b3dfaf2dc6af66a38c1891591c4903bd3e1b2e76518 AS buildbase
 
 # Compile the UI assets.
-FROM gcr.io/google-appengine/nodejs AS assets
+FROM --platform=$BUILDPLATFORM gcr.io/google-appengine/nodejs AS assets
 # To build the UI we need a recent node version and the go toolchain.
 RUN install_node v17.9.0
 COPY --from=buildbase /usr/local/go /usr/local/


### PR DESCRIPTION
Use BUILDPLATFORM for frontend build. This fixes cross-architecture builds.