### PR TITLE
fix: rule name patterns

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusterrules.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterrules.yaml
@@ -84,7 +84,6 @@ spec:
                             description: |-
                               Name of the alert to evaluate the expression as.
                               Only one of `record` and `alert` must be set.
-                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                           annotations:
                             additionalProperties:
@@ -112,7 +111,7 @@ spec:
                             description: |-
                               Record the result of the expression to this metric name.
                               Only one of `record` and `alert` must be set.
-                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            pattern: ^[a-zA-Z_:][a-zA-Z0-9_:]*$
                             type: string
                         required:
                         - expr

--- a/charts/operator/crds/monitoring.googleapis.com_globalrules.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_globalrules.yaml
@@ -83,7 +83,6 @@ spec:
                             description: |-
                               Name of the alert to evaluate the expression as.
                               Only one of `record` and `alert` must be set.
-                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                           annotations:
                             additionalProperties:
@@ -111,7 +110,7 @@ spec:
                             description: |-
                               Record the result of the expression to this metric name.
                               Only one of `record` and `alert` must be set.
-                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            pattern: ^[a-zA-Z_:][a-zA-Z0-9_:]*$
                             type: string
                         required:
                         - expr

--- a/charts/operator/crds/monitoring.googleapis.com_rules.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_rules.yaml
@@ -84,7 +84,6 @@ spec:
                             description: |-
                               Name of the alert to evaluate the expression as.
                               Only one of `record` and `alert` must be set.
-                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                           annotations:
                             additionalProperties:
@@ -112,7 +111,7 @@ spec:
                             description: |-
                               Record the result of the expression to this metric name.
                               Only one of `record` and `alert` must be set.
-                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            pattern: ^[a-zA-Z_:][a-zA-Z0-9_:]*$
                             type: string
                         required:
                         - expr

--- a/e2e/crd_validation_test.go
+++ b/e2e/crd_validation_test.go
@@ -867,10 +867,30 @@ func TestCRDValidation(t *testing.T) {
 	})
 	t.Run("Rules", func(t *testing.T) {
 		tests := map[string]test{
-			"minimal": {
+			"minimal-alerting": {
 				obj: &monitoringv1.Rules{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "minimal",
+						Name:      "minimal-alerting",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.RulesSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Rules: []monitoringv1.Rule{
+									{
+										Alert: "Any-characters:Allowed!?#@",
+									},
+								},
+							},
+						},
+					},
+				},
+				wantErr: false,
+			},
+			"minimal-recording": {
+				obj: &monitoringv1.Rules{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "minimal-recording",
 						Namespace: "default",
 					},
 					Spec: monitoringv1.RulesSpec{
@@ -927,6 +947,46 @@ func TestCRDValidation(t *testing.T) {
 					},
 				},
 				wantErr: true,
+			},
+			"invalid-rule-name-dash": {
+				obj: &monitoringv1.Rules{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "invalid-rule-name-dash",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.RulesSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Rules: []monitoringv1.Rule{
+									{
+										Record: "dashes-not-allowed",
+									},
+								},
+							},
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"valid-rule-name-colon": {
+				obj: &monitoringv1.Rules{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "valid-rule-name-colon",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.RulesSpec{
+						Groups: []monitoringv1.RuleGroup{
+							{
+								Rules: []monitoringv1.Rule{
+									{
+										Record: "colon:allowed",
+									},
+								},
+							},
+						},
+					},
+				},
+				wantErr: false,
 			},
 			"invalid-annotation": {
 				obj: &monitoringv1.Rules{

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -1392,7 +1392,6 @@ spec:
                               description: |-
                                 Name of the alert to evaluate the expression as.
                                 Only one of `record` and `alert` must be set.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             annotations:
                               additionalProperties:
@@ -1419,7 +1418,7 @@ spec:
                               description: |-
                                 Record the result of the expression to this metric name.
                                 Only one of `record` and `alert` must be set.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                              pattern: ^[a-zA-Z_:][a-zA-Z0-9_:]*$
                               type: string
                           required:
                             - expr
@@ -1659,7 +1658,6 @@ spec:
                               description: |-
                                 Name of the alert to evaluate the expression as.
                                 Only one of `record` and `alert` must be set.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             annotations:
                               additionalProperties:
@@ -1686,7 +1684,7 @@ spec:
                               description: |-
                                 Record the result of the expression to this metric name.
                                 Only one of `record` and `alert` must be set.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                              pattern: ^[a-zA-Z_:][a-zA-Z0-9_:]*$
                               type: string
                           required:
                             - expr
@@ -3769,7 +3767,6 @@ spec:
                               description: |-
                                 Name of the alert to evaluate the expression as.
                                 Only one of `record` and `alert` must be set.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             annotations:
                               additionalProperties:
@@ -3796,7 +3793,7 @@ spec:
                               description: |-
                                 Record the result of the expression to this metric name.
                                 Only one of `record` and `alert` must be set.
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                              pattern: ^[a-zA-Z_:][a-zA-Z0-9_:]*$
                               type: string
                           required:
                             - expr

--- a/pkg/operator/apis/monitoring/v1/rules_types.go
+++ b/pkg/operator/apis/monitoring/v1/rules_types.go
@@ -191,11 +191,10 @@ type RuleGroup struct {
 type Rule struct {
 	// Record the result of the expression to this metric name.
 	// Only one of `record` and `alert` must be set.
-	// +kubebuilder:validation:Pattern=^[a-zA-Z_][a-zA-Z0-9_]*$
+	// +kubebuilder:validation:Pattern="^[a-zA-Z_:][a-zA-Z0-9_:]*$"
 	Record string `json:"record,omitempty"`
 	// Name of the alert to evaluate the expression as.
 	// Only one of `record` and `alert` must be set.
-	// +kubebuilder:validation:Pattern=^[a-zA-Z_][a-zA-Z0-9_]*$
 	Alert string `json:"alert,omitempty"`
 	// The PromQL expression to evaluate.
 	Expr string `json:"expr"`


### PR DESCRIPTION
In a rule, the Record and Alert fields were validated incorrectly.

Record must be a valid metric name, which allows colons in additional to valid label name characters.

Alert must be a valid label value, which allows any UTF-8 character.