### PR TITLE
test: add large podmonitoring

### DIFF
--- a/charts/operator/templates/validating-admission-policy.yaml
+++ b/charts/operator/templates/validating-admission-policy.yaml
@@ -73,3 +73,30 @@ metadata:
 spec:
   policyName: "protected-labels.monitoring.googleapis.com"
   validationActions: [Deny]
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "unique-ports.monitoring.googleapis.com"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["monitoring.googleapis.com"]
+      apiVersions: ["*"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["clusterpodmonitorings", "podmonitorings"]
+  variables:
+    - name: "ports"
+      expression: "object.spec.endpoints.map(e, e.port)"
+  validations:
+    - expression: "variables.ports.all(p, variables.ports.exists_one(ep, ep == p))"
+      message: "Ports must be unique across all endpoints"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "unique-ports.monitoring.googleapis.com"
+spec:
+  policyName: "unique-ports.monitoring.googleapis.com"
+  validationActions: [Deny]

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -1059,6 +1059,26 @@ spec:
 ---
 # Source: operator/templates/validating-admission-policy.yaml
 apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "unique-ports.monitoring.googleapis.com"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["monitoring.googleapis.com"]
+      apiVersions: ["*"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["clusterpodmonitorings", "podmonitorings"]
+  variables:
+    - name: "ports"
+      expression: "object.spec.endpoints.map(e, e.port)"
+  validations:
+    - expression: "variables.ports.all(p, variables.ports.exists_one(ep, ep == p))"
+      message: "Ports must be unique across all endpoints"
+---
+# Source: operator/templates/validating-admission-policy.yaml
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "operatorconfigs.monitoring.googleapis.com"
@@ -1073,6 +1093,15 @@ metadata:
   name: "protected-labels.monitoring.googleapis.com"
 spec:
   policyName: "protected-labels.monitoring.googleapis.com"
+  validationActions: [Deny]
+---
+# Source: operator/templates/validating-admission-policy.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "unique-ports.monitoring.googleapis.com"
+spec:
+  policyName: "unique-ports.monitoring.googleapis.com"
   validationActions: [Deny]
 ---
 # Source: operator/templates/validatingwebhookconfiguration.yaml


### PR DESCRIPTION
Add a test for validation of a large PodMonitoring with various intervals and actions.

Note: it is possible to exceed actual validation budget if you max out all fields...however, it's also close to the etcd limit for how big a single resource can be. So, real use cases should comfortably fit within the CEL runtime cost budget.