### PR TITLE
chore: simplify dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,39 +15,14 @@
 version: 2
 updates:
 - package-ecosystem: docker
-  directory: /hack
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-- package-ecosystem: docker
-  directory: /cmd/rule-evaluator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-- package-ecosystem: docker
-  directory: /cmd/operator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-- package-ecosystem: docker
-  directory: /cmd/frontend
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-- package-ecosystem: docker
-  directory: /cmd/config-reloader
+  directories:
+    - /cmd/config-reloader
+    - /cmd/datasource-syncer
+    - /cmd/frontend
+    - /cmd/operator
+    - /cmd/rule-evaluator
+    - /examples/instrumentation/go-synthetic
+    - /hack
   schedule:
     interval: weekly
   commit-message:
@@ -75,45 +50,55 @@ updates:
         - "github.com/prometheus/prometheus"
         - "k8s.io/*"
         - "sigs.k8s.io/*"
+# Duplicate config for release/0.16
+- package-ecosystem: docker
+  directories:
+    - /cmd/config-reloader
+    - /cmd/datasource-syncer
+    - /cmd/frontend
+    - /cmd/operator
+    - /cmd/rule-evaluator
+    - /examples/instrumentation/go-synthetic
+    - /hack
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  target-branch: release/0.16
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  groups:
+    # Group dep updates into one PR as single update already updates co-located deps.
+    # Skip biggest and the most complex deps: Thanos and Prometheus.
+    go-deps:
+      patterns:
+        - "*"
+      exclude-patterns:
+        # All of below deps has to be updated carefully as they are large, impacting
+        # our ability to import export pkg into Prometheus forks. They also often break compatibilty.
+        - "github.com/thanos-io/thanos"
+        - "github.com/prometheus/prometheus"
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
+  target-branch: release/0.16
 # Duplicate config for release/0.15
 - package-ecosystem: docker
-  directory: /hack
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.15
-- package-ecosystem: docker
-  directory: /cmd/rule-evaluator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.15
-- package-ecosystem: docker
-  directory: /cmd/operator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.15
-- package-ecosystem: docker
-  directory: /cmd/frontend
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.15
-- package-ecosystem: docker
-  directory: /cmd/config-reloader
+  directories:
+    - /cmd/config-reloader
+    - /cmd/datasource-syncer
+    - /cmd/frontend
+    - /cmd/operator
+    - /cmd/rule-evaluator
+    - /examples/instrumentation/go-synthetic
+    - /hack
   schedule:
     interval: weekly
   commit-message:
@@ -145,43 +130,14 @@ updates:
   target-branch: release/0.15
 # Duplicate config for release/0.14
 - package-ecosystem: docker
-  directory: /hack
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.14
-- package-ecosystem: docker
-  directory: /cmd/rule-evaluator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.14
-- package-ecosystem: docker
-  directory: /cmd/operator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.14
-- package-ecosystem: docker
-  directory: /cmd/frontend
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.14
-- package-ecosystem: docker
-  directory: /cmd/config-reloader
+  directories:
+    - /cmd/config-reloader
+    - /cmd/datasource-syncer
+    - /cmd/frontend
+    - /cmd/operator
+    - /cmd/rule-evaluator
+    - /examples/instrumentation/go-synthetic
+    - /hack
   schedule:
     interval: weekly
   commit-message:
@@ -213,43 +169,14 @@ updates:
   target-branch: release/0.14
 # Duplicate config for release/0.13
 - package-ecosystem: docker
-  directory: /hack
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.13
-- package-ecosystem: docker
-  directory: /cmd/rule-evaluator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.13
-- package-ecosystem: docker
-  directory: /cmd/operator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.13
-- package-ecosystem: docker
-  directory: /cmd/frontend
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.13
-- package-ecosystem: docker
-  directory: /cmd/config-reloader
+  directories:
+    - /cmd/config-reloader
+    - /cmd/datasource-syncer
+    - /cmd/frontend
+    - /cmd/operator
+    - /cmd/rule-evaluator
+    - /examples/instrumentation/go-synthetic
+    - /hack
   schedule:
     interval: weekly
   commit-message:
@@ -281,43 +208,14 @@ updates:
   target-branch: release/0.13
 # Duplicate config for release/0.12
 - package-ecosystem: docker
-  directory: /hack
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.12
-- package-ecosystem: docker
-  directory: /cmd/rule-evaluator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.12
-- package-ecosystem: docker
-  directory: /cmd/operator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.12
-- package-ecosystem: docker
-  directory: /cmd/frontend
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.12
-- package-ecosystem: docker
-  directory: /cmd/config-reloader
+  directories:
+    - /cmd/config-reloader
+    - /cmd/datasource-syncer
+    - /cmd/frontend
+    - /cmd/operator
+    - /cmd/rule-evaluator
+    - /examples/instrumentation/go-synthetic
+    - /hack
   schedule:
     interval: weekly
   commit-message:
@@ -349,43 +247,14 @@ updates:
   target-branch: release/0.12
 # Duplicate config for release/0.11
 - package-ecosystem: docker
-  directory: /hack
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.11
-- package-ecosystem: docker
-  directory: /cmd/rule-evaluator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.11
-- package-ecosystem: docker
-  directory: /cmd/operator
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.11
-- package-ecosystem: docker
-  directory: /cmd/frontend
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  target-branch: release/0.11
-- package-ecosystem: docker
-  directory: /cmd/config-reloader
+  directories:
+    - /cmd/config-reloader
+    - /cmd/datasource-syncer
+    - /cmd/frontend
+    - /cmd/operator
+    - /cmd/rule-evaluator
+    - /examples/instrumentation/go-synthetic
+    - /hack
   schedule:
     interval: weekly
   commit-message:

--- a/examples/scripts/go.mod
+++ b/examples/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/prometheus-engine/scripts
 
-go 1.20
+go 1.23.0
 
 require (
 	cloud.google.com/go/monitoring v1.16.3


### PR DESCRIPTION
Use [directories instead of directory](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--) to simplify Dependabot configuration.

Add `release/0.16` branch to scanning list.

Scan `datasource-syncer` and `go-synthetic`.