### PR TITLE
test: fix flaky crd test

### DIFF
--- a/e2e/crd_validation_test.go
+++ b/e2e/crd_validation_test.go
@@ -1168,7 +1168,7 @@ func generateRelabelingRules(n uint) []monitoringv1.RelabelingRule {
 
 	for i := range rules {
 		rules[i] = monitoringv1.RelabelingRule{
-			Regex:  rand.String(rand.Intn(1_000)),
+			Regex:  rand.String(1000),
 			Action: actions[rand.Intn(len(actions))],
 		}
 	}


### PR DESCRIPTION
The CRD test for a large podmonitoring introduced in #1437 would periodically fail because it could create short regex expressions that would match protected labels. This fix generates regex expressions that will never match protected labels.