### PR TITLE
chore: ignore next gmp minor images on release branches

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -64,6 +64,9 @@ updates:
     - /cmd/rule-evaluator
     - /examples/instrumentation/go-synthetic
     - /hack
+  ignore:
+    - dependency-name: "gcr.io/gke-release/prometheus-engine/*:*"
+      versions: [ ">=0.17.0" ]
   schedule:
     interval: weekly
   commit-message:
@@ -107,6 +110,9 @@ updates:
     - /cmd/rule-evaluator
     - /examples/instrumentation/go-synthetic
     - /hack
+  ignore:
+    - dependency-name: "gcr.io/gke-release/prometheus-engine/*:*"
+      versions: [ ">=0.16.0" ]
   schedule:
     interval: weekly
   commit-message:
@@ -150,6 +156,9 @@ updates:
     - /cmd/rule-evaluator
     - /examples/instrumentation/go-synthetic
     - /hack
+  ignore:
+    - dependency-name: "gcr.io/gke-release/prometheus-engine/*:*"
+      versions: [ ">=0.15.0" ]
   schedule:
     interval: weekly
   commit-message:
@@ -193,6 +202,9 @@ updates:
     - /cmd/rule-evaluator
     - /examples/instrumentation/go-synthetic
     - /hack
+  ignore:
+    - dependency-name: "gcr.io/gke-release/prometheus-engine/*:*"
+      versions: [ ">=0.14.0" ]
   schedule:
     interval: weekly
   commit-message:
@@ -236,6 +248,9 @@ updates:
     - /cmd/rule-evaluator
     - /examples/instrumentation/go-synthetic
     - /hack
+  ignore:
+    - dependency-name: "gcr.io/gke-release/prometheus-engine/*:*"
+      versions: [ ">=0.13.0" ]
   schedule:
     interval: weekly
   commit-message:
@@ -279,6 +294,9 @@ updates:
     - /cmd/rule-evaluator
     - /examples/instrumentation/go-synthetic
     - /hack
+  ignore:
+    - dependency-name: "gcr.io/gke-release/prometheus-engine/*:*"
+      versions: [ ">=0.12.0" ]
   schedule:
     interval: weekly
   commit-message:


### PR DESCRIPTION
Dependabot is trying to update GMP images (example: #1535) to the next minor on release branches. Bad dependabot.