### PR TITLE
fix: remove validation on frompod source label

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -667,7 +667,6 @@ spec:
                       properties:
                         from:
                           description: Kubernetes resource label to remap.
-                          pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                           type: string
                         to:
                           description: |-

--- a/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -662,7 +662,6 @@ spec:
                       properties:
                         from:
                           description: Kubernetes resource label to remap.
-                          pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                           type: string
                         to:
                           description: |-

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -894,7 +894,6 @@ spec:
                         properties:
                           from:
                             description: Kubernetes resource label to remap.
-                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                           to:
                             description: |-
@@ -3247,7 +3246,6 @@ spec:
                         properties:
                           from:
                             description: Kubernetes resource label to remap.
-                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                             type: string
                           to:
                             description: |-

--- a/pkg/operator/apis/monitoring/v1/pod_types.go
+++ b/pkg/operator/apis/monitoring/v1/pod_types.go
@@ -282,7 +282,6 @@ type ClusterTargetLabels struct {
 // onto a Prometheus target.
 type LabelMapping struct {
 	// Kubernetes resource label to remap.
-	// +kubebuilder:validation:Pattern=^[a-zA-Z_][a-zA-Z0-9_]*$
 	From string `json:"from"`
 	// Remapped Prometheus target label.
 	// Defaults to the same name as `From`.


### PR DESCRIPTION
The source label name does not need to be valid for the scrape config, just the destination label.