### PR TITLE
chore: security updates only on release branches

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -56,6 +56,7 @@ updates:
         - "sigs.k8s.io/*"
 # Duplicate config for release/0.16
 - package-ecosystem: docker
+  open-pull-requests-limit: 0 # Security updates only
   directories:
     - /cmd/config-reloader
     - /cmd/datasource-syncer
@@ -79,6 +80,7 @@ updates:
         - "*"
   target-branch: release/0.16
 - package-ecosystem: gomod
+  open-pull-requests-limit: 0 # Security updates only
   directory: /
   schedule:
     interval: weekly
@@ -102,6 +104,7 @@ updates:
   target-branch: release/0.16
 # Duplicate config for release/0.15
 - package-ecosystem: docker
+  open-pull-requests-limit: 0 # Security updates only
   directories:
     - /cmd/config-reloader
     - /cmd/datasource-syncer
@@ -125,6 +128,7 @@ updates:
         - "*"
   target-branch: release/0.15
 - package-ecosystem: gomod
+  open-pull-requests-limit: 0 # Security updates only
   directory: /
   schedule:
     interval: weekly
@@ -148,6 +152,7 @@ updates:
   target-branch: release/0.15
 # Duplicate config for release/0.14
 - package-ecosystem: docker
+  open-pull-requests-limit: 0 # Security updates only
   directories:
     - /cmd/config-reloader
     - /cmd/datasource-syncer
@@ -171,6 +176,7 @@ updates:
         - "*"
   target-branch: release/0.14
 - package-ecosystem: gomod
+  open-pull-requests-limit: 0 # Security updates only
   directory: /
   schedule:
     interval: weekly
@@ -194,6 +200,7 @@ updates:
   target-branch: release/0.14
 # Duplicate config for release/0.13
 - package-ecosystem: docker
+  open-pull-requests-limit: 0 # Security updates only
   directories:
     - /cmd/config-reloader
     - /cmd/datasource-syncer
@@ -217,6 +224,7 @@ updates:
         - "*"
   target-branch: release/0.13
 - package-ecosystem: gomod
+  open-pull-requests-limit: 0 # Security updates only
   directory: /
   schedule:
     interval: weekly
@@ -240,6 +248,7 @@ updates:
   target-branch: release/0.13
 # Duplicate config for release/0.12
 - package-ecosystem: docker
+  open-pull-requests-limit: 0 # Security updates only
   directories:
     - /cmd/config-reloader
     - /cmd/datasource-syncer
@@ -263,6 +272,7 @@ updates:
         - "*"
   target-branch: release/0.12
 - package-ecosystem: gomod
+  open-pull-requests-limit: 0 # Security updates only
   directory: /
   schedule:
     interval: weekly
@@ -286,6 +296,7 @@ updates:
   target-branch: release/0.12
 # Duplicate config for release/0.11
 - package-ecosystem: docker
+  open-pull-requests-limit: 0 # Security updates only
   directories:
     - /cmd/config-reloader
     - /cmd/datasource-syncer
@@ -309,6 +320,7 @@ updates:
         - "*"
   target-branch: release/0.11
 - package-ecosystem: gomod
+  open-pull-requests-limit: 0 # Security updates only
   directory: /
   schedule:
     interval: weekly


### PR DESCRIPTION
[Only apply security updates to release
branches](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file).