### PR TITLE
chore: fix datasource syncer image ref

### DIFF
--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -41,7 +41,7 @@ spec:
                 - linux
       containers:
       - name: datasource-syncer-init
-        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.15.1-gke.0
+        image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.13.2-gke.0
         args:
         - "--datasource-uids=$DATASOURCE_UIDS"
         - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
@@ -79,7 +79,7 @@ spec:
                     - linux
           containers:
           - name: datasource-syncer
-            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.15.1-gke.0
+            image: gcr.io/gke-release/prometheus-engine/datasource-syncer:v0.13.2-gke.0
             args:
             - "--datasource-uids=$DATASOURCE_UIDS"
             - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"


### PR DESCRIPTION
0.13 incorrectly references 0.15 images, due to bad dependabot PR.