### PR TITLE
chore: remove unneeded exclude directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -336,33 +336,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-// Exclude pre-go-mod kubernetes tags, as they are older
-// than v0.x releases but are picked when we update the dependencies.
-exclude (
-	k8s.io/client-go v1.4.0
-	k8s.io/client-go v1.4.0+incompatible
-	k8s.io/client-go v1.5.0
-	k8s.io/client-go v1.5.0+incompatible
-	k8s.io/client-go v1.5.1
-	k8s.io/client-go v1.5.1+incompatible
-	k8s.io/client-go v2.0.0-alpha.1+incompatible
-	k8s.io/client-go v2.0.0+incompatible
-	k8s.io/client-go v3.0.0-beta.0+incompatible
-	k8s.io/client-go v3.0.0+incompatible
-	k8s.io/client-go v4.0.0-beta.0+incompatible
-	k8s.io/client-go v4.0.0+incompatible
-	k8s.io/client-go v5.0.0+incompatible
-	k8s.io/client-go v5.0.1+incompatible
-	k8s.io/client-go v6.0.0+incompatible
-	k8s.io/client-go v7.0.0+incompatible
-	k8s.io/client-go v8.0.0+incompatible
-	k8s.io/client-go v9.0.0-invalid+incompatible
-	k8s.io/client-go v9.0.0+incompatible
-	k8s.io/client-go v10.0.0+incompatible
-	k8s.io/client-go v11.0.0+incompatible
-	k8s.io/client-go v12.0.0+incompatible
-)
-
 replace (
 	// Go modules keeps resetting the version to a random unversioned commit.
 	// So this is required for unknown reasons.


### PR DESCRIPTION
These versions of client-go have been retracted, and do not need to be excluded.