### PR TITLE
feat: Add .gitattributes to minimize diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+vendor/** linguist-generated
+go.sum linguist-generated


### PR DESCRIPTION
In theory this should help by minimizing diffs view for tagged files by default in the GitHub UI . See [the docs here](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md)

The following files/directories are now marked as generated to reduce diffs:
- `vendor/**`
- `go.sum`