### PR TITLE
feat: add workflow to prepare a release candidate

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -1,0 +1,191 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release bot
+
+on:
+  workflow_call:
+    inputs:
+      branch_name:
+        required: true
+        type: string
+      commit_sha:
+        required: true
+        type: string
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/gmp-hermetic
+  BRANCH_NAME: ${{ inputs.branch_name }} 
+concurrency: 
+  group: ${{inputs.branch_name}}
+  cancel-in-progress: true
+jobs:
+  auto_tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency: 
+      group: ${{inputs.commit_sha}}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.BRANCH_NAME }}
+      - name: Setup git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Get the other commit from the merge if there is one
+        id: merge
+        run: |
+          parents=$(git log --pretty=%P -n 1 ${{ inputs.commit_sha }})
+          IFS=' ' read -r parent1 parent2 <<< "$parents"
+          echo "sha=$parent2" >> $GITHUB_OUTPUT
+      - name: Check if commit is tagged
+        if: ${{ steps.merge.outputs.sha != '' }}
+        id: check
+        run: |
+          TAG=$(git tag --points-at ${{ steps.merge.outputs.sha }} | grep releasebot || true)
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+      - name: Push tag
+        if: ${{ steps.check.outputs.tag != '' }}
+        run: |
+          set -ex
+          NEW_TAG=$(echo "${{ steps.check.outputs.tag }}" | awk '{gsub(/releasebot\//, ""); print}')
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+          echo "::notice::Successfully created and pushed new tag: '$NEW_TAG'."
+    
+  build_and_push_image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_tag: ${{ steps.create_tag.outputs.image_tag }}
+    steps:
+      - name: Get docker tag
+        id: create_tag
+        run: |
+          TAG=$(echo "${{ env.BRANCH_NAME }}" | awk '{gsub(/\//, "-"); print}')
+          echo "image_tag=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$TAG" >> $GITHUB_OUTPUT
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./hack/Dockerfile
+          target: hermetic
+          push: true
+          tags: ${{ steps.create_tag.outputs.image_tag }}
+          cache-from: type=registry,ref=${{ steps.create_tag.outputs.image_tag }}-cache
+          cache-to: type=registry,ref=${{ steps.create_tag.outputs.image_tag }}-cache,mode=max
+  prepare_rc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+    needs:
+      - build_and_push_image
+      - auto_tag
+    outputs:
+      full_rc_version: ${{ steps.prepare.outputs.full_rc_version }}
+      bot_branch: ${{ steps.push.outputs.bot_branch }}
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+          path: release_branch
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main_branch
+      - name: Set up Git Identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+        working-directory: ./release_branch
+      - name: Create RC Version and Update Files
+        id: prepare
+        working-directory: ./main_branch
+        run: |
+          go run ./hack/prepare_rc ${{ env.BRANCH_NAME }} ../release_branch
+      - name: Regen files
+        working-directory: ./release_branch
+        # Workflows can't edit workflows. Better to create PR and let tests fail.
+        run: |
+          mv .github ..
+          make regen CACHE_IMAGE_FROM=${{ needs.build_and_push_image.outputs.image_tag }}-cache
+          mv ../.github .
+      - name: Commit and Tag Release Candidate
+        if: steps.prepare.outputs.full_rc_version != ''
+        id: push
+        working-directory: ./release_branch
+        run: |
+          set -e
+          BOT_BRANCH=$(echo "${{ env.BRANCH_NAME }}" | awk '{gsub(/release/, "releasebot"); print}')
+          echo "bot_branch=$BOT_BRANCH" >> $GITHUB_OUTPUT
+          git checkout -b "$BOT_BRANCH"
+          git add .
+          RC="${{ steps.prepare.outputs.full_rc_version }}"
+          git commit -as -m"chore: prepare for $RC release"
+          git tag -a "releasebot/$RC" -m "releasebot release candidate $RC"
+          git push -f origin "$BOT_BRANCH" "releasebot/$RC"
+  manage_pr:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs:
+      prepare_rc
+    steps:
+    - name: Checkout main
+      uses: actions/checkout@v4
+      with:
+        ref: ${{needs.prepare_rc.outputs.bot_branch}}
+    - name: Manage Release PR
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        BOT_BRANCH=${{needs.prepare_rc.outputs.bot_branch}}
+        RC=${{ needs.prepare_rc.outputs.full_rc_version }}
+        EXISTING_PR_NUMBER=$(gh pr list \
+          --base ${{ env.BRANCH_NAME }} \
+          --head $BOT_BRANCH \
+          --state open \
+          --json number \
+          -q '.[0].number // empty')
+        
+        if [[ -z "$EXISTING_PR_NUMBER" ]]; then
+          gh pr create \
+            --base ${{ env.BRANCH_NAME }} \
+            --head $BOT_BRANCH \
+            --title "chore: prepare for $RC release" \
+            --body "Beep boop. Merging activates deployment. A fresh PR appears on merge. Boop beep."
+        fi

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,9 @@ define update_manifests
 	find manifests examples -type f -name "*.yaml" -exec sed -i "s#image: .*/$(1):.*#image: ${IMAGE_REGISTRY}/$(1):${TAG_NAME}#g" {} \;
 endef
 
+CACHE_FROM_ARG := $(if $(strip $(CACHE_IMAGE_FROM)),--cache-from $(CACHE_IMAGE_FROM),)
 define docker_build
-	DOCKER_BUILDKIT=1 docker build --label "part-of=gmp" $(1)
+	DOCKER_BUILDKIT=1 docker build --label "part-of=gmp" $(CACHE_FROM_ARG) $(1)
 endef
 
 define docker_tag_push

--- a/hack/prepare_rc/cmd.go
+++ b/hack/prepare_rc/cmd.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Command struct {
+	command string
+	args    []string
+}
+
+func Cmd(command string, args ...string) *Command {
+	return &Command{
+		command: command,
+		args:    args,
+	}
+}
+
+func (c *Command) String() string {
+	if c == nil {
+		return "<nil Command>"
+	}
+	return fmt.Sprintf("%s %s", c.command, strings.Join(c.args, " "))
+}
+
+func (c *Command) run() (string, error) {
+	cmd := exec.Command(c.command, c.args...)
+
+	var stdoutBuf bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stderr, &stdoutBuf)
+	cmd.Stderr = os.Stdout
+
+	err := cmd.Start()
+	if err != nil {
+		return "", fmt.Errorf("failed to start command '%s': %w",
+			c, err)
+	}
+	waitErr := cmd.Wait()
+	result := strings.TrimSpace(stdoutBuf.String())
+
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			return result, fmt.Errorf("command '%s' exited with code %d: %w",
+				c, exitErr.ExitCode(), exitErr)
+		}
+		return result, fmt.Errorf("command '%s' failed after starting: %w",
+			c, waitErr)
+	}
+
+	return result, nil
+}
+
+func (c *Command) Run() (string, error) {
+	fmt.Printf("::group::Running: %s\n", c)
+	res, err := c.run()
+	fmt.Println("::endgroup::")
+	if err != nil {
+		fmt.Printf("::info::Command '%s' failed: %v\n", c, err)
+	}
+	return res, err
+}

--- a/hack/prepare_rc/main.go
+++ b/hack/prepare_rc/main.go
@@ -1,0 +1,219 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const VersionFile = "pkg/export/export.go"
+const ValuesFile = "charts/values.global.yaml"
+
+type Branch struct {
+	major int
+	minor int
+}
+
+func getBranch(branch string) (*Branch, error) {
+	re := regexp.MustCompile(`^release/(\d+)\.(\d+)$`)
+	matches := re.FindStringSubmatch(branch)
+	if matches == nil {
+		return nil, errors.New("branch name must match regex release/([0-9]+).([0-9]+)")
+	}
+	majorRaw, minorRaw := matches[1], matches[2]
+	major, err := strconv.Atoi(majorRaw)
+	if err != nil {
+		return nil, fmt.Errorf("malformatted branch %q", branch)
+	}
+	minor, err := strconv.Atoi(minorRaw)
+	if err != nil {
+		return nil, fmt.Errorf("malformatted branch %q", branch)
+	}
+
+	return &Branch{
+		major: major,
+		minor: minor,
+	}, nil
+}
+
+type ReleaseCandidate struct {
+	branch *Branch
+	patch  int
+	rc     int
+}
+
+func (b *Branch) lastTag() (string, error) {
+	tagRegex := fmt.Sprintf("v%d.%d.*", b.major, b.minor)
+	tags, err := Cmd("git", "tag", "--list", tagRegex, "--sort=-v:refname").Run()
+	return strings.SplitN(tags, "\n", 2)[0], err
+}
+
+func (b *Branch) lastReleaseCandidate() (*ReleaseCandidate, error) {
+	tag, err := b.lastTag()
+	if err != nil {
+		return nil, err
+	}
+	if tag == "" {
+		return nil, nil
+	}
+	re := regexp.MustCompile(`^v\d+.\d+.(\d+)-rc.(\d+)$`)
+	matches := re.FindStringSubmatch(tag)
+	if matches == nil {
+		return nil, fmt.Errorf("malformatted tag name %q", tag)
+	}
+	patchRaw, rcRaw := matches[1], matches[2]
+	patch, err := strconv.Atoi(patchRaw)
+	if err != nil {
+		return nil, fmt.Errorf("malformatted tag name %q", tag)
+	}
+	rc, err := strconv.Atoi(rcRaw)
+	if err != nil {
+		return nil, fmt.Errorf("malformatted tag name %q", tag)
+	}
+	return &ReleaseCandidate{
+		branch: b,
+		patch:  patch,
+		rc:     rc,
+	}, nil
+}
+
+func (b *Branch) nextReleaseCandidate() (*ReleaseCandidate, error) {
+	last, err := b.lastReleaseCandidate()
+	if err != nil {
+		return nil, err
+	}
+	if last == nil {
+		return &ReleaseCandidate{
+			branch: b,
+			patch:  0,
+			rc:     0,
+		}, nil
+	}
+	hasRelease, err := last.hasRelease()
+	if err != nil {
+		return nil, err
+	}
+	if hasRelease {
+		return &ReleaseCandidate{
+			branch: last.branch,
+			patch:  last.patch + 1,
+			rc:     0,
+		}, nil
+	}
+	return &ReleaseCandidate{
+		branch: last.branch,
+		patch:  last.patch,
+		rc:     last.rc + 1,
+	}, nil
+}
+
+func (rc *ReleaseCandidate) version() string {
+	return fmt.Sprintf("v%d.%d.%d", rc.branch.major, rc.branch.minor, rc.patch)
+}
+
+func (rc *ReleaseCandidate) hasRelease() (bool, error) {
+	out, err := Cmd("git", "tag", "--list", rc.version()).Run()
+	return out != "", err
+}
+
+func (rc *ReleaseCandidate) updateVersionFile(repoPath string) error {
+	path := filepath.Join(repoPath, VersionFile)
+	contentBytes, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+	content := string(contentBytes)
+	re := regexp.MustCompile(`(mainModuleVersion\s*=\s*)".*"`)
+	replacement := fmt.Sprintf(`${1}"%s"`, rc.version())
+	newContent := re.ReplaceAllString(content, replacement)
+
+	err = os.WriteFile(path, []byte(newContent), 0664)
+	if err != nil {
+		return fmt.Errorf("failed to write updated content to %s: %w", path, err)
+	}
+	return nil
+}
+
+func (rc *ReleaseCandidate) updateValuesFile(repoPath string) error {
+	path := filepath.Join(repoPath, ValuesFile)
+	_, err := Cmd("go", "tool", "yq", "e",
+		fmt.Sprintf(`.version = "%d.%d.%d"`, rc.branch.major, rc.branch.minor, rc.patch),
+		"-i", path,
+	).Run()
+	if err != nil {
+		return err
+	}
+	for _, image := range []string{"configReloader", "operator", "ruleEvaluator", "datasourceSyncer"} {
+		_, err := Cmd("go", "tool", "yq", "e",
+			fmt.Sprintf(`.images.%s.tag = "%s-gke.%d"`, image, rc.version(), rc.rc),
+			"-i", path,
+		).Run()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Printf("::error::Usage: %s <branch-name> <repo-path>\n", os.Args[0])
+		fmt.Println("::error::Error: Missing arguments")
+		os.Exit(1)
+	}
+	if _, err := Cmd("git", "fetch", "--tags", "-f").Run(); err != nil {
+		fmt.Printf("::error::Failed to fetch tags: %v\n", err)
+	}
+	branch, err := getBranch(os.Args[1])
+	if err != nil {
+		fmt.Printf("::error::Failed to parse branch: %v\n", err)
+	}
+	nextRc, err := branch.nextReleaseCandidate()
+	if err != nil {
+		fmt.Printf("::error::Failed to get next release candidate: %v\n", err)
+	}
+
+	repoPath := os.Args[2]
+	if err := nextRc.updateVersionFile(repoPath); err != nil {
+		fmt.Printf("::error::Failed to update version file: %v\n", err)
+	}
+	if err := nextRc.updateValuesFile(repoPath); err != nil {
+		fmt.Printf("::error::Failed to update value file: %v\n", err)
+	}
+	// For GH actions
+	outputPath := os.Getenv("GITHUB_OUTPUT")
+	if outputPath == "" {
+		fmt.Println("::error::GITHUB_OUTPUT environment variable not set.")
+		os.Exit(1)
+	}
+	outputFile, err := os.OpenFile(outputPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Printf("::error::Failed to open GITHUB_OUTPUT: %v\n", err)
+		return
+	}
+	defer outputFile.Close()
+
+	s := fmt.Sprintf("full_rc_version=%s-rc.%d\n", nextRc.version(), nextRc.rc)
+	_, err = outputFile.WriteString(s)
+	if err != nil {
+		fmt.Printf("::error::Failed to write to GITHUB_OUTPUT: %v\n", err)
+	}
+}


### PR DESCRIPTION
This PR introduces a new script `hack/prepare_rc` and workflow `release-bot.yml` that automates the process of preparing a release candidate. It does the following when passed in a new commit and branch from another workflow:

- Checks if the commit is a merge of a RC prep PR and if so tags it correctly
- Detects the new RC version by looking at the last rc tag and last release tag
  - Note that a release tag of the format `vX.Y.Z` must be present before it bumps up the patch version, otherwise it will bump the RC version
- Updates the `mainModuleVersion` in `pkg/export/export.go` to the new version (should differ only if there has been a patch bump).
- Updates the `version` and image tags in `charts/values.global.yaml` to the new RC version.
- Runs `make regen` (ignoring `.github/` due to self modification issues)
- Pushes code to a parallel branch
- Creates a PR to merge the parallel branch into the release branch if it doesn't exist

Note that this PR does not do anything by itself. It needs to be triggered by another workflow. These other workflows will be added in another PR (eg. #1665 for release/0.16). [Here](https://github.com/hsmatulis/prometheus-engine/actions/runs/15206686102) is a successful run of the two combined workflows in my fork