### PR TITLE
feat: auto-trigger RC PR creation on release/0.16 branch

### DIFF
--- a/.github/workflows/trigger-release-bot.yml
+++ b/.github/workflows/trigger-release-bot.yml
@@ -1,0 +1,28 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Trigger ReleaseBot
+on:
+  push:
+    branches:
+      - 'release/*'
+jobs:
+  call-workflow-passing-data:
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
+    uses: GoogleCloudPlatform/prometheus-engine/.github/workflows/release-bot.yml@main
+    with:
+      branch_name: ${{ github.head_ref || github.ref_name }} 
+      commit_sha: ${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,9 @@ define update_manifests
 	find manifests examples -type f -name "*.yaml" -exec sed -i "s#image: .*/$(1):.*#image: ${IMAGE_REGISTRY}/$(1):${TAG_NAME}#g" {} \;
 endef
 
+CACHE_FROM_ARG := $(if $(strip $(CACHE_IMAGE_FROM)),--cache-from $(CACHE_IMAGE_FROM),)
 define docker_build
-	DOCKER_BUILDKIT=1 docker build --label "part-of=gmp" $(1)
+	DOCKER_BUILDKIT=1 docker build --label "part-of=gmp" $(CACHE_FROM_ARG) $(1)
 endef
 
 define docker_tag_push


### PR DESCRIPTION
New workflow triggers `.github/workflows/release-bot.yml` from `main` in a centralized way. See #1664 for the PR this depends on.