### PR TITLE
fix: use lower case for image name

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -25,7 +25,7 @@ on:
         type: string
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/gmp-hermetic
+  IMAGE_NAME: googlecloudplatform/gmp/hermetic-build
   BRANCH_NAME: ${{ inputs.branch_name }} 
 concurrency: 
   group: ${{inputs.branch_name}}


### PR DESCRIPTION
The `github.repository_owner` expands to upper case letters when used, so we have to hardcode it