### PR TITLE
chore: rename release-bot job

### DIFF
--- a/.github/workflows/trigger-release-bot.yml
+++ b/.github/workflows/trigger-release-bot.yml
@@ -17,7 +17,7 @@ on:
     branches:
       - 'release/*'
 jobs:
-  call-workflow-passing-data:
+  release-bot:
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Give the release bot job a better name, used to test new PR automation