### PR TITLE
feat(operator): deprecate operatorconfig.collection.filter.matchOneOf

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_operatorconfigs.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_operatorconfigs.yaml
@@ -92,10 +92,9 @@ spec:
                 properties:
                   matchOneOf:
                     description: |-
-                      A list of Prometheus time series matchers. Every time series must match at least one
-                      of the matchers to be exported. This field can be used equivalently to the match[]
-                      parameter of the Prometheus federation endpoint to selectively export data.
-                      Example: `["{job!='foobar'}", "{__name__!~'container_foo.*|container_bar.*'}"]`
+                      DEPRECATED: From the 0.14 GMP version, this functionality is no longer implemented.
+                      Specifying this field has no effect, other than a warning message.
+                      See https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#filter-metrics for alternatives.
                     items:
                       type: string
                     type: array

--- a/doc/api.md
+++ b/doc/api.md
@@ -937,6 +937,7 @@ CompressionType
 (<em>Appears in: </em><a href="#monitoring.googleapis.com/v1.CollectionSpec">CollectionSpec</a>, <a href="#monitoring.googleapis.com/v1.ConfigSpec">ConfigSpec</a>)
 </p>
 <div>
+<p>CompressionType represents compression type used e.g. for network requests.</p>
 </div>
 <table>
 <thead>
@@ -1012,10 +1013,10 @@ ClusterPodMonitoring, PodMonitoring, GlobalRules, ClusterRules, and/or Rules.</p
 </em>
 </td>
 <td>
-<p>A list of Prometheus time series matchers. Every time series must match at least one
-of the matchers to be exported. This field can be used equivalently to the match[]
-parameter of the Prometheus federation endpoint to selectively export data.
-Example: <code>[&quot;{job!='foobar'}&quot;, &quot;{__name__!~'container_foo.*|container_bar.*'}&quot;]</code></p>
+<p>DEPRECATED: From the 0.14 GMP version, this functionality is no longer implemented.
+Specifying this field has no effect, other than a warning message.
+See <a href="https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#filter-metrics">https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#filter-metrics</a> for alternatives.
+TODO: Add a native CRD deprecation when possible, see: <a href="https://github.com/kubernetes/kubernetes/issues/131817">https://github.com/kubernetes/kubernetes/issues/131817</a></p>
 </td>
 </tr>
 </tbody>

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -1926,10 +1926,9 @@ spec:
                   properties:
                     matchOneOf:
                       description: |-
-                        A list of Prometheus time series matchers. Every time series must match at least one
-                        of the matchers to be exported. This field can be used equivalently to the match[]
-                        parameter of the Prometheus federation endpoint to selectively export data.
-                        Example: `["{job!='foobar'}", "{__name__!~'container_foo.*|container_bar.*'}"]`
+                        DEPRECATED: From the 0.14 GMP version, this functionality is no longer implemented.
+                        Specifying this field has no effect, other than a warning message.
+                        See https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#filter-metrics for alternatives.
                       items:
                         type: string
                       type: array

--- a/pkg/operator/apis/monitoring/v1/operator_types.go
+++ b/pkg/operator/apis/monitoring/v1/operator_types.go
@@ -210,11 +210,14 @@ type TargetStatusSpec struct {
 	Enabled bool `json:"enabled,omitempty"`
 }
 
+// CompressionType represents compression type used e.g. for network requests.
 // +kubebuilder:validation:Enum=none;gzip
 type CompressionType string
 
-const CompressionNone CompressionType = "none"
-const CompressionGzip CompressionType = "gzip"
+const (
+	CompressionNone CompressionType = "none"
+	CompressionGzip CompressionType = "gzip"
+)
 
 // KubeletScraping allows enabling scraping of the Kubelets' metric endpoints.
 type KubeletScraping struct {
@@ -227,10 +230,10 @@ type KubeletScraping struct {
 
 // ExportFilters provides mechanisms to filter the scraped data that's sent to GMP.
 type ExportFilters struct {
-	// A list of Prometheus time series matchers. Every time series must match at least one
-	// of the matchers to be exported. This field can be used equivalently to the match[]
-	// parameter of the Prometheus federation endpoint to selectively export data.
-	// Example: `["{job!='foobar'}", "{__name__!~'container_foo.*|container_bar.*'}"]`
+	// DEPRECATED: From the 0.14 GMP version, this functionality is no longer implemented.
+	// Specifying this field has no effect, other than a warning message.
+	// See https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#filter-metrics for alternatives.
+	// TODO: Add a native CRD deprecation when possible, see: https://github.com/kubernetes/kubernetes/issues/131817
 	MatchOneOf []string `json:"matchOneOf,omitempty"`
 }
 

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -274,9 +274,9 @@ func (r *collectionReconciler) ensureCollectorConfig(ctx context.Context, spec *
 		return fmt.Errorf("generate Prometheus config: %w", err)
 	}
 
-	// NOTE(bwplotka): Match logic will be removed in https://github.com/GoogleCloudPlatform/prometheus-engine/pull/1688
-	// nolint:staticcheck
-	cfg.GoogleCloud.Export.Match = spec.Filter.MatchOneOf
+	// NOTE(bwplotka): cfg.GoogleCloud.Export.Match is deprecated (and not working),
+	// since 0.14, so we don't set this config field anymore.
+
 	if string(spec.Compression) != "" {
 		cfg.GoogleCloud.Export.Compression = string(spec.Compression)
 	}


### PR DESCRIPTION
After time we realized that a bug caused the operator config export filtering logic to be not used from the GMP 0.14 release onwards. We decided to keep this field NOT applicable (changing this field being noop) going forward, so this PR makes the deprecation/removal of this functionality clear with the operation and export code removed.

* This feature since the beginning was extremely hard to use and confusing to users, users constantly assumed list of matchers are "AND-ed" while they are "OR-ed" or they are were filtering partial histograms ([demo](https://github.com/GoogleCloudPlatform/prometheus-engine/commit/a74a72f3e8d4f91375397c4a6c12856b4e1f9413)).
* This feature is not stopping collectors (Prometheus) to scrape the filtered out series, it only NOT send them forward. This limits the use of them for collector efficiency scenarios.
* We have evidences of users already starting to "misconfigure" their collection with this field, but they were "lucky" those filters are accidently turned off. "Fixing" them will immediately break those users in a hidden way.
* Finally, better alternatives exists https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#filter-metrics

This feature, for dynamic config based setting in export pkg is already deprecated: https://github.com/GoogleCloudPlatform/prometheus/pull/237

## Post-mortem

For security hardening, when introducing reloadable config pieces (compression, credentials and matchers) in 0.14 we updated export package to load things from the correct place, but the matchers are initialized and copied into seriesCache and never updated later: https://github.com/GoogleCloudPlatform/prometheus-engine/blob/10c5314b02cc99bd0ee2e71f2588b7aac870c329/pkg/export/export.go#L419

This affects both collector and rule-eval AFAIK.

We didn't have a good tests to test this e2e too.

AIs: 
* [X] Update public docs
* [x] Remove this functionality (this PR and future)
* [x] Ensure proper e2e test coverage of compression option (credentialFile is tested).
* [X] Add this deprecation to the 0.14 changelog

NOTE: We don't plan to add deprecation warning to 0.15.



