### PR TITLE
feat: add hack script for fixing vulns on release branches

### DIFF
--- a/hack/release-lib.sh
+++ b/hack/release-lib.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Useful functions for release scripts.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${DEBUG_MODE:-}" ]]; then
+  set -o xtrace
+fi
+
+SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+release-lib::confirm() {
+  local prompt_message="${1:-Are you sure?}"
+
+  # -p: Display the prompt string.
+  # -r: Prevents backslash interpretation.
+  # -n 1: Read only one character.
+  read -p "$prompt_message [y/n]: " -r -n 1 response
+  echo # Ensures the cursor moves to the next line after input.
+  case "$response" in
+      [yY])
+          return 0
+          ;;
+      [nN])
+          echo "❌ The action has been cancelled as requested."
+          return 1
+          ;;
+      *)
+          echo "Invalid input. Exiting script." >&2
+          exit 1
+          ;;
+  esac
+}
+
+release-lib::idemp::clone() {
+  local clone_dir=$1
+  if [[ -z "${clone_dir}" ]]; then
+    echo "❌  clone_dir variable is not set." >&2
+    usage
+    return 1
+  fi
+  if [[ -z "${PR_BRANCH}" ]]; then
+    echo "❌  PR_BRANCH environment variable is not set." >&2
+    usage
+    return 1
+  fi
+  if [[ ! -d "${clone_dir}" ]]; then
+    release-lib::clone "${clone_dir}"
+  fi
+
+  pushd "${clone_dir}"
+  if [[ "$(git symbolic-ref --short HEAD)" != "${PR_BRANCH}" ]]; then
+      echo "❌  Malformed ${DIR}; expected ${PR_BRANCH} got $(git symbolic-ref --short HEAD); remove or fix manually the ${DIR} and rerun." >&2
+      return 1
+  fi
+  popd
+}
+
+release-lib::clone() {
+  local clone_dir=$1
+  if [[ -z "${clone_dir}" ]]; then
+    echo "❌  clone_dir variable is not set." >&2
+    usage
+    return 1
+  fi
+  if [[ -z "${BRANCH}" ]]; then
+    echo "❌  BRANCH environment variable is not set." >&2
+    usage
+    return 1
+  fi
+  if [[ -z "${REMOTE_URL}" ]]; then
+    echo "❌  REMOTE_URL environment variable is not set." >&2
+    usage
+    return 1
+  fi
+  if [[ -z "${PR_BRANCH}" ]]; then
+    echo "❌  PR_BRANCH environment variable is not set." >&2
+    usage
+    return 1
+  fi
+  # NOTE: We could add --single-branch but it would be a bit harder to use interactively.
+  git clone -b "${BRANCH}" "${REMOTE_URL}" "${clone_dir}"
+  if [[ "${BRANCH}" != "${PR_BRANCH}" ]]; then
+    pushd "${clone_dir}"
+      git checkout -b "${PR_BRANCH}"
+    popd
+  fi
+}
+
+release-lib::remote_url_from_branch() {
+  local branch=$1
+  # Check if the BRANCH environment variable is set.
+  if [[ -z "${branch}" ]]; then
+    echo "❌  branch is required." >&2
+    return 1
+  fi
+
+  if [[ "${branch}" =~ ^release-(2|3)\.[0-9]+\.[0-9]+-gmp$ ]]; then
+    echo "git@github.com:GoogleCloudPlatform/prometheus.git"
+  elif [[ "${branch}" =~ ^release-0\.[0-9]+\.[0-9]+-gmp$ ]]; then
+    echo "git@github.com:GoogleCloudPlatform/alertmanager.git"
+  elif [[ "${branch}" =~ ^release/0\.[0-9]+$ ]]; then
+    echo "git@github.com:GoogleCloudPlatform/prometheus-engine.git"
+  else
+    echo "❌  No matching remote URL found for branch='$BRANCH'" >&2
+    return 1
+  fi
+}
+
+release-lib::idemp::vulnlist() {
+  local dir=$1
+  if [[ -z "${dir}" ]]; then
+    echo "❌  dir is required." >&2
+    return 1
+  fi
+
+  if [[ ! -f "${dir}/vulnlist.txt" || -z $(cat "${dir}/vulnlist.txt") ]]; then
+    release-lib::vulnlist "${dir}"
+  else
+   echo "⚠️ Using existing ${dir}/vulnlist.txt"
+  fi
+}
+
+release-lib::vulnlist() {
+  local dir=$1
+  if [[ -z "${dir}" ]]; then
+    echo "❌  dir is required." >&2
+    return 1
+  fi
+
+  echo "🔄 Detecting Go vulnerabilities to fix..."
+  # TODO(bwplotka): Capture correct Go version.
+  # TODO(bwplotka): api.text is useful, document how to obtain it.
+  pushd "${SCRIPT_DIR}/vulnupdatelist/"
+    go run "./..." \
+      -go-version=1.23.4 \
+      -only-fixed \
+      -dir="${dir}" \
+      -nvd-api-key="$(cat "./api.text")" | tee "${dir}/vulnlist.txt"
+   if [[ -z $(cat "${dir}/vulnlist.txt") ]]; then
+      # Print this, otherwise error on the above might keep this file mistakenly empty.
+      echo "no vulnerabilities" > "${dir}/vu
+      }lnlist.txt"
+    fi
+  popd
+}
+
+release-lib::gomod_vulnfix() {
+  local dir=$1
+  if [[ -z "${dir}" ]]; then
+    echo "❌  dir is required." >&2
+    return 1
+  fi
+
+  local vuln_file="${dir}/vulnlist.txt"
+  if [[ ! -f "${vuln_file}" ]]; then
+    echo "❌  no ${vuln_file} file found" >&2
+    return 1
+  fi
+
+  if [[ "no vulnerabilities" == $(cat "${vuln_file}") ]]; then
+     echo "❌  ${vuln_file} shows no vulnerabilities" >&2
+     return 1
+  fi
+
+  # Read the vulnerability file line by line.
+  # The `|| [[ -n "$line" ]]` part handles the case where the last line doesn't have a newline.
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip any empty lines in the input file.
+    if [ -z "$line" ]; then
+      continue
+    fi
+
+   mod=$(echo "$line" | awk '{print $2}')
+   mod_path=$(echo "${mod}" | cut -d'@' -f1)
+   desired_version=$(echo "${mod}" | cut -d'@' -f2)
+
+    if [[ -z "${mod_path}" ]] || [[ -z "${desired_version}" ]]; then
+      echo "⚠️ Skipping malformed line: $line"
+      continue
+    fi
+
+    echo "🔄 Updating module '${mod_path}' to version '${desired_version}'..."
+    gsed -i.bak "s|\(	${mod_path} \).*|\1${desired_version}|" "${dir}/go.mod"
+  done < "${vuln_file}"
+  echo "🔄 Resolving ${dir}/go.mod..."
+  pushd "${dir}"
+    go mod tidy
+  popd
+  rm "${dir}/go.mod.bak"
+}
+
+release-lib::idemp::git_commit_amend_match() {
+  # Anything staged?
+  if ! git diff-index --quiet --cached HEAD; then
+      release-lib::git_commit_amend_match "${1}"
+  fi
+}
+
+release-lib::git_commit_amend_match() {
+  local message="${1}"
+  if [[ -z "${message}" ]]; then
+    echo "❌  message is required." >&2
+    return 1
+  fi
+  if [[ "$(git log -1 --pretty=%s)" == "${message}" ]]; then
+    git commit -s --amend -m "${message}"
+  else
+    git commit -sm "${message}"
+  fi
+}

--- a/hack/release-vulnfix.sh
+++ b/hack/release-vulnfix.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${DEBUG_MODE:-}" ]]; then
+  set -o xtrace
+fi
+
+# TODO(bwplotka): Clean err on missing deps e.g. gsed.
+# TODO(bwplotka): Consider automation for npm and docker images (Go, debian, similar to bump-go.sh)
+
+SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+source "${SCRIPT_DIR}/release-lib.sh"
+
+usage() {
+    local me
+    me=$(basename "${BASH_SOURCE[0]}")
+    cat <<_EOM
+usage: ${me}
+
+Attempt a minimal dependency upgrade to solve fixable vulnerabilities.
+
+NOTE: The script is idempotent; to force it to recreate local artifacts (e.g. local clones, remote branches it created), remove the artifact you want to recreate.
+
+Example use:
+ * BRANCH=release/0.15 CHECKOUT_DIR=~/Repos/tmp-release bash hack/release-vulnfix.sh
+ * BRANCH=release-2.45.3-gmp CHECKOUT_DIR=~/Repos/tmp-release bash hack/release-vulnfix.sh
+ * BRANCH=release-0.27.0-gmp CHECKOUT_DIR=~/Repos/tmp-release bash hack/release-vulnfix.sh
+
+Variables:
+* BRANCH (required) - Release branch to work on; Project is auto-detected from this.
+* CHECKOUT_DIR (required) - Local working directory e.g. for local clones.
+* PR_BRANCH (default: $USER/$BRANCH-vulnfix) - Upstream branch to push to.
+_EOM
+}
+
+if (( $# > 0 )); then
+  case $1 in
+  help)
+      usage
+      ;;
+  esac
+fi
+
+# Check if the BRANCH environment variable is set.
+if [[ -z "${BRANCH}" ]]; then
+  echo "❌  BRANCH environment variable is not set." >&2
+  usage
+  return 1
+fi
+
+REMOTE_URL=$(release-lib::remote_url_from_branch "${BRANCH}")
+PROJECT=$(tmp=${REMOTE_URL##*/}; echo ${tmp%.git})
+PR_BRANCH=${PR_BRANCH:-"${USER}/${BRANCH}-vulnfix"}
+
+echo "🔄 Assuming ${PROJECT} with remote ${REMOTE_URL}; changes will be pushed to ${PR_BRANCH}"
+
+# Check if the BRANCH environment variable is set.
+if [[ -z "${CHECKOUT_DIR}" ]]; then
+  echo "❌  CHECKOUT_DIR environment variable is not set." >&2
+  usage
+  return 1
+fi
+
+DIR="${CHECKOUT_DIR}/${PROJECT}"
+release-lib::idemp::clone "${DIR}"
+
+pushd "${DIR}"
+
+# TODO: Make every command idempotent inside each function?
+# TODO: Make it multi-module aware?
+release-lib::idemp::vulnlist "${DIR}"
+
+if [[ "no vulnerabilities" != $(cat "${DIR}/vulnlist.txt") ]]; then
+  # Attempt to update + go mod tidy.
+  release-lib::gomod_vulnfix "${DIR}"
+  git add go.mod go.sum
+
+  # Check if that helped.
+  echo "⚠️ This will fail on older branches with vendoring; in this case, simply go to ${DIR}, run 'go mod vendor' and rerun."
+  release-lib::vulnlist "${DIR}"
+  if [[ "no vulnerabilities" != $(cat "${DIR}/vulnlist.txt") ]]; then
+     echo "❌  After go mod update some vulnerabilities are still found; go to ${DIR} and resolve it manually and remove the ./vulnlist.txt file and rerun." >&2
+     exit 1
+  fi
+fi
+
+# Commit if anything is staged.
+msg="google patch[deps]: fix Go ${BRANCH} vulnerabilities"
+if [[ "${PROJECT}" == "prometheus-engine" ]]; then
+  msg="fix: fix ${BRANCH} vulnerabilities"
+fi
+release-lib::idemp::git_commit_amend_match "${msg}"
+
+# Anything to push?
+if [[ "$(git rev-parse HEAD)" != "$(git fetch && git rev-parse "origin/${PR_BRANCH}")" ]]; then
+  # TODO: Potentially use ghclient for PR ops
+  if release-lib::confirm "About to FORCE git push from ${DIR} to origin/${PR_BRANCH}; are you sure?"; then
+      # TODO: Consider using leasing to check for stales etc
+      git push --force origin "${PR_BRANCH}"
+  fi
+else
+  echo "⚠️ Nothing to do; no vulnerabilities and nothing to commit"
+  exit 1
+fi

--- a/hack/vulnupdatelist/main.go
+++ b/hack/vulnupdatelist/main.go
@@ -48,7 +48,7 @@ type UpdateList struct {
 func (u UpdateList) String() string {
 	fixedVersion := "???"
 	if u.FixedVersion != nil {
-		fixedVersion = u.FixedVersion.String()
+		fixedVersion = "v" + u.FixedVersion.String()
 	}
 	if u.AdditionalCVEs > 0 {
 		return fmt.Sprintf("%s %s@%s %s(+%d more) now@%s", u.CVE.Severity, u.Module, fixedVersion, u.CVE.ID, u.AdditionalCVEs, u.Version)


### PR DESCRIPTION
A manual, idempotent script that updates Go vuln on our release branches.

We can hook it to Louhi or GH action at some point; the plan is to extend this to Docker/Go and npm one day.

Dependabot is doing similar, but IMO the eventual dependabot approach does not scale here (too many PRs, no way to bulk approve it, too long to wait for things to rebase/pass test); we need on-demand or at least atomic automation. Also we want portability to Louhi.

Depends on https://github.com/GoogleCloudPlatform/prometheus-engine/pull/1685

