### PR TITLE
feat: add release scripts

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -135,7 +135,8 @@ jobs:
         id: prepare
         working-directory: ./main_branch
         run: |
-          go run ./hack/prepare_rc ${{ env.BRANCH_NAME }} ../release_branch
+          alias yq=go tool yq
+          go run ./hack/prepare_rc -branch ${{ env.BRANCH_NAME }} -dir ../release_branch
       - name: Regen files
         working-directory: ./release_branch
         # Workflows can't edit workflows. Better to create PR and let tests fail.

--- a/hack/docker-bump-images.sh
+++ b/hack/docker-bump-images.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${DEBUG_MODE:-}" ]]; then
+	set -o xtrace
+fi
+
+SCRIPT_DIR="$(
+	cd -- "$(dirname "$0")" >/dev/null 2>&1
+	pwd -P
+)"
+
+usage() {
+	local me
+	me=$(basename "${BASH_SOURCE[0]}")
+	cat <<_EOM
+usage: ${me} <Dockerfile>
+
+Update google-go.pkg.dev/golang base images in the given Dockerfile to the latest.
+
+Example use:
+* ${me} ./Dockerfile
+
+Variables:
+* LATEST_MINOR (optional) - only update to the given latest minor version.
+* INCLUDE_RC (optional) - if set update update to the latest RC
+_EOM
+}
+
+if (($# > 0)); then
+	case $1 in
+	help)
+		usage
+		;;
+	esac
+fi
+
+if (($# != 1)); then
+	echo "❌  Expected exactly one argument"
+	usage
+	exit 1
+fi
+
+DOCKERFILE="${1}"
+echo "🔄  Detecting google-go.pkg.dev/golang image references..."
+if grep -E "google-go\.pkg\.dev/golang" "${DOCKERFILE}"; then
+	golang_tags=$(gcrane ls "google-go.pkg.dev/golang" --json | jq --raw-output '.tags[]' | sort -V)
+	if [[ -z "${INCLUDE_RC:-}" ]]; then
+		golang_tags=$(echo "${golang_tags}" | grep -v "rc.*")
+	fi
+	if [[ -n "${LATEST_MINOR:-}" ]]; then
+		golang_tags=$(echo "${golang_tags}" | grep "${LATEST_MINOR}.*")
+	fi
+	latest_golang_tag=$(echo "${golang_tags}" | tail -n1)
+	latest_golang_digest=$(crane digest "google-go.pkg.dev/golang:${latest_golang_tag}")
+	latest_golang_image="google-go.pkg.dev/golang:${latest_golang_tag}@${latest_golang_digest}"
+	echo "🔄  Ensuring ${latest_golang_image}..."
+	if gsed -i -E "s#google-go\.pkg\.dev/golang:([0-9]+\.[0-9]+\.[0-9+][^@ ]*)?(@sha256:[0-9a-f]+)?#${latest_golang_image}#g" "${DOCKERFILE}"; then
+		echo "✅  Done!"
+		exit 0
+	else
+		echo "❌  sed didn't replace?"
+		exit 1
+	fi
+fi
+echo "❌  Nothing to do, no google-go.pkg.dev/golang image referenced in the ${DOCKERFILE}"

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,0 +1,14 @@
+module github.com/GoogleCloudPlatform/promethue-engine/hack
+
+go 1.24.0
+
+require (
+	github.com/Masterminds/semver/v3 v3.3.1
+	github.com/stretchr/testify v1.10.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/hack/go.sum
+++ b/hack/go.sum
@@ -1,0 +1,12 @@
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${DEBUG_MODE:-}" ]]; then
+	set -o xtrace
+fi
+
+SCRIPT_DIR="$(
+	cd -- "$(dirname "$0")" >/dev/null 2>&1
+	pwd -P
+)"
+
+# Extended regular expressions (ERE) regex matching paths to exclude from the fork commit.
+# NOTE: # ^\..+ means all hidden files (e.g. changes to .golangci.yaml .gitignore or CI).
+# TODO(bwplotka): Consider moving to globs with dotglob and extglob settings.. or Go (:
+export RELEASE_LIB_EXCLUDE_RE="^\..+
+^README\.md
+^CHANGELOG\.md
+^MAINTAINERS\.md
+^CONTRIBUTING\.md
+^RELEASE\.md
+^Dockerfile
+^docs/.*
+^documentation/.*
+^google/.*
+^.*go\..*
+^.*\.gitignore
+^.*package.json
+^.*package-lock.json
+^Makefile.*
+^.*vendor/.*
+^VERSION
+^.*node_modules/.*"
+
+# Extended regular expressions (ERE) regex matching paths from EXCLUDE_RE that should be included.
+# This is needed as it's simpler than implementing RE negative matchers.
+# NOTE: For Prometheus the two specific documentation files are imported in Google Managed Prometheus docs, so keep those.
+export RELEASE_LIB_DOCUMENTATION_INCLUDE_RE="^documentation/examples/prometheus-agent\.y.?ml
+^documentation/examples/prometheus\.y.?ml"
+
+release-lib::confirm() {
+	local prompt_message="${1:-Are you sure?}"
+
+	# -p: Display the prompt string.
+	# -r: Prevents backslash interpretation.
+	# -n 1: Read only one character.
+	read -p "$prompt_message [y/n/CTR+C]: " -r -n 1 response
+	echo # Ensures the cursor moves to the next line after input.
+	case "$response" in
+	[yY])
+		return 0
+		;;
+	[nN])
+		echo "❌  The action has been cancelled as requested."
+		return 1
+		;;
+	*)
+		echo "Invalid input. Exiting script." >&2
+		exit 1
+		;;
+	esac
+}
+
+# clone clones the $REMOTE_URL to $clone_dir at $source_branch version, then
+# creates $target_branch from it, if set.
+#
+# Idempotence: If the $clone_dir exists, skip cloning and check if
+# the $clone_dir is a git repo on the desired branch.
+# TODO: Cloning takes time, consider resetting repo if present.
+release-lib::idemp::clone() {
+	local clone_dir="${1}"
+	if [[ -z "${clone_dir}" ]]; then
+		echo "❌  clone_dir arg is not set." >&2
+		return 1
+	fi
+	local source_branch="${2}" # Branch to fetch when cloning, base for $target_branch
+	if [[ -z "${source_branch}" ]]; then
+		echo "❌  source_branch arg is not set." >&2
+		return 1
+	fi
+	local target_branch="${3}" # Branch to create from source_branch,
+	if [[ -z "${target_branch}" ]]; then
+		target_branch="${source_branch}"
+	fi
+
+	if [[ -z "${REMOTE_URL}" ]]; then
+		echo "❌  REMOTE_URL environment variable is not set." >&2
+		return 1
+	fi
+
+	if [[ ! -d "${clone_dir}" ]]; then
+		git clone -b "${source_branch}" "${REMOTE_URL}" "${clone_dir}"
+		if [[ "${source_branch}" != "${target_branch}" ]]; then
+			pushd "${clone_dir}"
+			git checkout -b "${target_branch}"
+			popd
+		fi
+	else
+		if ! release-lib::confirm "The repository clone on ${clone_dir} exists. Do you want to reuse this directory? 'n' will attempt a hard reset on the repo (quicker then re-clone)."; then
+			git checkout "${source_branch}"
+			git reset --hard "origin/${source_branch}"
+			git branch --merged | grep -v "\*|${source_branch}" | xargs git branch -D
+			# TODO: Remove tags?
+		fi
+	fi
+
+	pushd "${clone_dir}"
+	if [[ "$(git symbolic-ref --short HEAD)" != "${target_branch}" ]]; then
+		echo "❌  Malformed ${DIR}; expected ${target_branch} got $(git symbolic-ref --short HEAD); remove or fix manually the ${clone_dir} and rerun." >&2
+		return 1
+	fi
+	popd
+}
+
+release-lib::remote_url_from_branch() {
+	local branch=$1
+	# Check if the BRANCH environment variable is set.
+	if [[ -z "${branch}" ]]; then
+		echo "❌  branch is required." >&2
+		return 1
+	fi
+
+	if [[ "${branch}" =~ release-(2|3)\.[0-9]+\.[0-9]+-gmp$ ]]; then
+		echo "git@github.com:GoogleCloudPlatform/prometheus.git"
+	elif [[ "${branch}" =~ release-0\.[0-9]+\.[0-9]+-gmp$ ]]; then
+		echo "git@github.com:GoogleCloudPlatform/alertmanager.git"
+	elif [[ "${branch}" =~ release/0\.[0-9]+$ ]]; then
+		echo "git@github.com:GoogleCloudPlatform/prometheus-engine.git"
+	else
+		echo "❌  No matching remote URL found for branch=${branch}" >&2
+		return 1
+	fi
+}
+
+release-lib::upstream_remote_url() {
+	local project=$1
+	if [[ -z "${project}" ]]; then
+		echo "❌  project is required." >&2
+		return 1
+	fi
+
+	if [[ "${project}" == "prometheus" ]]; then
+		echo "git@github.com:prometheus/prometheus.git"
+	elif [[ "${project}" == "alertmanager" ]]; then
+		echo "git@github.com:prometheus/alertmanager.git"
+	else
+		echo "❌  No matching remote URL found for project='${project}'" >&2
+		return 1
+	fi
+}
+
+release-lib::idemp::vulnlist() {
+	local dir="${1}"
+	if [[ -z "${dir}" ]]; then
+		echo "❌  dir arg is required." >&2
+		return 1
+	fi
+	local vuln_file="${2}"
+	if [[ -z "${vuln_file}" ]]; then
+		echo "❌  vuln_file arg is required." >&2
+		return 1
+	fi
+	if [[ "${vuln_file}" != /* ]]; then
+		echo "❌  vuln_file arg must point to an absolute file path." >&2
+		return 1
+	fi
+
+	if [[ ! -f "${vuln_file}" || -z $(cat "${vuln_file}") ]]; then
+		release-lib::vulnlist "${dir}" "${vuln_file}"
+	else
+		echo "⚠️ Using existing ${vuln_file}"
+	fi
+}
+
+release-lib::vulnlist() {
+	local dir="${1}"
+	if [[ -z "${dir}" ]]; then
+		echo "❌  dir arg is required." >&2
+		return 1
+	fi
+	local vuln_file="${2}"
+	if [[ -z "${vuln_file}" ]]; then
+		echo "❌  vuln_file arg is required." >&2
+		return 1
+	fi
+	if [[ "${vuln_file}" != /* ]]; then
+		echo "❌  vuln_file arg must point to an absolute file path." >&2
+		return 1
+	fi
+
+	echo "🔄 Detecting Go vulnerabilities to fix..."
+	# TODO(bwplotka): Capture correct Go version.
+	# TODO(bwplotka): api.text is useful, document how to obtain it.
+	pushd "${SCRIPT_DIR}/vulnupdatelist/"
+	go run "./..." \
+		-go-version=1.23.4 \
+		-only-fixed \
+		-dir="${dir}" \
+		-nvd-api-key="$(cat "./api.text")" | tee "${vuln_file}"
+	if [[ -z $(cat "${vuln_file}") ]]; then
+		# Print this, otherwise error on the above might keep this file mistakenly empty.
+		echo "no vulnerabilities" >"${vuln_file}"
+	fi
+	popd
+}
+
+release-lib::gomod_vulnfix() {
+	local dir=${1}
+	if [[ -z "${dir}" ]]; then
+		echo "❌  dir arg is required." >&2
+		return 1
+	fi
+
+	local vuln_file="${2}"
+	if [[ -z "${vuln_file}" ]]; then
+		echo "❌  vuln_file arg is required." >&2
+		return 1
+	fi
+	if [[ ! -f "${vuln_file}" ]]; then
+		echo "❌  no ${vuln_file} file found" >&2
+		return 1
+	fi
+
+	if [[ "no vulnerabilities" == $(cat "${vuln_file}") ]]; then
+		echo "❌  ${vuln_file} shows no vulnerabilities" >&2
+		return 1
+	fi
+
+	# Read the vulnerability file line by line.
+	# The `|| [[ -n "$line" ]]` part handles the case where the last line doesn't have a newline.
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		# Skip any empty lines in the input file.
+		if [ -z "$line" ]; then
+			continue
+		fi
+
+		mod=$(echo "$line" | awk '{print $2}')
+		mod_path=$(echo "${mod}" | cut -d'@' -f1)
+		desired_version=$(echo "${mod}" | cut -d'@' -f2)
+
+		if [[ -z "${mod_path}" ]] || [[ -z "${desired_version}" ]]; then
+			echo "⚠️ Skipping malformed line: $line"
+			continue
+		fi
+
+		echo "🔄 Updating module '${mod_path}' to version '${desired_version}'..."
+		gsed -i.bak "s|\(	${mod_path} \).*|\1${desired_version}|" "${dir}/go.mod"
+	done <"${vuln_file}"
+	echo "🔄 Resolving ${dir}/go.mod..."
+	pushd "${dir}"
+	go mod tidy
+	popd
+}
+
+release-lib::idemp::git_commit_amend_match() {
+	# Anything staged?
+	if ! git diff-index --quiet --cached HEAD; then
+		release-lib::git_commit_amend_match "${1}"
+	fi
+}
+
+release-lib::git_commit_amend_match() {
+	local message="${1}"
+	if [[ -z "${message}" ]]; then
+		echo "❌  message is required." >&2
+		return 1
+	fi
+	if [[ "$(git log -1 --pretty=%s)" == "${message}" ]]; then
+		git commit -s --amend -m "${message}"
+	else
+		git commit -sm "${message}"
+	fi
+}
+
+release-lib::needs_push() {
+	local branch_to_push="${1}"
+	if [[ -z "${branch_to_push}" ]]; then
+		echo "❌  branch_to_push environment variable is not set." >&2
+		return 1
+	fi
+	local base_branch_to_diff="${2}"
+	if [[ -z "${base_branch_to_diff}" ]]; then
+		echo "❌  base_branch_to_diff environment variable is not set." >&2
+		return 1
+	fi
+	git checkout "${branch_to_push}"
+
+	# TODO: Fix edge case - deleting branch remotely does not delete it locally (origin ref).
+	if upstream_head=$(git fetch && git rev-parse "origin/${branch_to_push}"); then
+		if [[ "$(git rev-parse HEAD)" == "${upstream_head}" ]]; then
+			echo "⚠️ Nothing to push; origin/${branch_to_push} is all up to date"
+			return 1
+		fi
+		git --no-pager log --oneline "${upstream_head}"...HEAD
+		return 0
+	fi
+	# Likely "origin/${branch_to_push}" does not exists yet, so definitely something to
+	# push (full $branch_to_push). Assuming the $branch_to_push will be proposed to be merged to
+	# $base_branch_to_diff, so showing a full diff vs $base_branch_to_diff.
+	if upstream_base_head=$(git fetch && git rev-parse "origin/${base_branch_to_diff}"); then
+		if [[ "$(git rev-parse HEAD)" == "${upstream_base_head}" ]]; then
+			echo "⚠️ Nothing to push, even the base origin/${base_branch_to_diff} is up to date; did you expect that?"
+			return 1
+		fi
+		git --no-pager log --oneline "${upstream_base_head}"...HEAD
+		return 0
+	fi
+}
+
+release-lib::exclude_changes_from_last_commit() {
+	local exclude_regexes=$1
+	if [[ -z "${exclude_regexes}" ]]; then
+		echo "❌  exclude_regexes is required." >&2
+		return 1
+	fi
+	local include_regexes=$2
+	if [[ -z "${include_regexes}" ]]; then
+		echo "❌  include_regexes is required." >&2
+		return 1
+	fi
+	local commit_title=$3
+	if [[ -z "${commit_title}" ]]; then
+		echo "❌  commit_title is required." >&2
+		return 1
+	fi
+
+	# Get all files touched by a git commit, delimited by space.
+	changed_files=$(git show --pretty="" --name-only "$(git rev-parse --verify HEAD)")
+	if [ -z "${changed_files}" ]; then
+		echo "❌  suspicious HEAD commit, no files changed." >&2
+		return 1
+	fi
+
+	# Change to \n delimit (needed for grep to work) and exclude/include lines.
+	tmp_to_exclude=$(echo "${changed_files}" | tr ' ' '\n' | grep -E "${exclude_regexes}" | grep -v -E "${include_regexes}")
+
+	# Group node_module and vendor changes, we know we want to get rid of full directories here -- too many of those files slowing things down and obscuring the summary in git commit -- git restore supports globs.
+	to_exclude=$(echo "${tmp_to_exclude}" | gsed -e 's|vendor/.*$|vendor/*|' -e 's|node_modules/.*$|node_modules/*|' | sort -u | tr ' ' '\n')
+	if [ -z "${to_exclude}" ]; then
+		# Nothing to exclude.
+		return 0
+	fi
+
+	echo "🔄 Excluding the following files from the fork squash commit: ${to_exclude}; appending this information to the git commit message"
+	curr_msg=$(git log --format=%B -n1)
+
+	# Get all changes to be in stage area.
+	git reset --soft HEAD~1
+	while IFS= read -r exclude_path; do
+		git restore -S "${exclude_path}"
+	done <<<"${to_exclude}"
+	# Commit after unstaging exclusions.
+	# TODO(bwplotka): Handle nothing to commit after exclusion case.
+	git commit -m "${commit_title}" -m "${curr_msg}" -m "Excluded files:
+${to_exclude}
+"
+	git restore .
+	git clean -fd
+}

--- a/hack/lib_test.sh
+++ b/hack/lib_test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${DEBUG_MODE:-}" ]]; then
+	set -o xtrace
+fi
+
+SCRIPT_DIR="$(
+	cd -- "$(dirname "$0")" >/dev/null 2>&1
+	pwd -P
+)"
+source "${SCRIPT_DIR}/test-lib.sh"
+source "${SCRIPT_DIR}/lib.sh"
+
+TEST_FAILED=0
+cleanup() {
+	if ((TEST_FAILED)); then
+		echo "${line_break}"
+		echo "$test_name: FAILED"
+		echo "${line_break}"
+		# Print out the directories.
+		echo "CHECKOUT_DIR=${CHECKOUT_DIR}"
+	else
+		rm -rf \
+			"${CHECKOUT_DIR:-}"
+	fi
+}
+
+exit_on_error() {
+	if [ $? -ne 0 ]; then
+		echo "Error!" >&2
+		exit 1
+	fi
+}
+
+setup() {
+	CHECKOUT_DIR=$(mktemp --tmpdir -d tmpcheckout.XXXXX)
+	export CHECKOUT_DIR
+}
+
+create_file() {
+	mkdir -p "$(dirname $1)"
+	echo "change" >$1
+}
+test_exclude_changes_from_last_commit() {
+	setup
+
+	# Add a fake state and branches to fake repo.
+	git init "${CHECKOUT_DIR}"
+	pushd "${CHECKOUT_DIR}"
+
+	git commit --allow-empty -m "COMMIT 1: initial commit"
+
+	create_file cmd/prometheus/main.go
+	create_file config/config.go
+	create_file documentation/examples/prometheus-agent.yml
+	create_file documentation/examples/prometheus.yml
+	create_file tsdb/some.go
+
+	# Files expected to be excluded.
+	create_file .github/workflows/some-ci.yaml
+	create_file README.md
+	create_file VERSION.md
+	create_file docs/command-line/prometheus.md
+	create_file documentation/examples/remote_storage/vendor/abc/d.go
+	create_file documentation/examples/remote_storage/vendor/abc2/a.ini
+	create_file go.mod
+	create_file go.sum
+	create_file vendor/abc2/a.ini
+	create_file web/ui/node_modules/webpack/whatever.js
+
+	git add --all
+	git commit -m "some commit"
+
+	release-lib::exclude_changes_from_last_commit "${RELEASE_LIB_EXCLUDE_RE}" "${RELEASE_LIB_DOCUMENTATION_INCLUDE_RE}" "COMMIT 2: my commit"
+	exit_on_error
+
+	got="$(git -C "${CHECKOUT_DIR}" log --format=%B --no-decorate)"
+	expected=$(
+		cat <<EOF
+COMMIT 2: my commit
+
+some commit
+
+Excluded files:
+.github/workflows/some-ci.yaml
+README.md
+VERSION.md
+docs/command-line/prometheus.md
+documentation/examples/remote_storage/vendor/*
+go.mod
+go.sum
+vendor/*
+web/ui/node_modules/*
+
+COMMIT 1: initial commit
+EOF
+	)
+	assert_equal "${got}" "${expected}"
+}
+
+run_all_tests() {
+	run test_exclude_changes_from_last_commit
+}
+
+run() {
+	local test_name=$1
+	local line_break="========================================"
+	echo "${line_break}"
+	echo "=== Running $test_name"
+	echo "${line_break}"
+	# Assume test failure. The only way for the test to succeed if *all
+	# statements* execute without errors and without exiting early due to some
+	# other failure. If instead we assume that the test will pass and wait until
+	# it fully returns to set TEST_FAILED=1 in an else clause, then that else
+	# clause might never execute because the `trap ...` will be loaded onto the
+	# stack first.
+	TEST_FAILED=1
+	# TODO(bwplotka): Bash gods are not happy; it seems this is a bit broken
+	# as set +e is not applied to the sub function call. Either fix it or move to Go...
+	if $test_name; then
+		echo "${line_break}"
+		echo "$test_name: OK"
+		echo "${line_break}"
+		echo
+		TEST_FAILED=0
+	fi
+	cleanup
+}
+# Ensure the cleanup happens.
+trap cleanup EXIT INT TERM
+# Run tests.
+run_all_tests
+echo "ALL TESTS PASSED"

--- a/hack/prepare_rc/tag.go
+++ b/hack/prepare_rc/tag.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+var (
+	rcRe = regexp.MustCompile(`^rc.(\d+)$`)
+)
+
+// Tag is a helper for the tag operations.
+type Tag struct {
+	semver.Version
+	rc int
+}
+
+// NewTag constructs a valid tag.
+func NewTag(tag string) (Tag, error) {
+	v, err := semver.NewVersion(tag)
+	if err != nil {
+		return Tag{}, err
+	}
+	rcNum := -1
+	if rc := v.Prerelease(); rc != "" {
+		// We expect only -rc.X suffixes, nothing else.
+		matches := rcRe.FindStringSubmatch(rc)
+		if len(matches) < 2 {
+			return Tag{}, fmt.Errorf(`tag suffix has to be empty or match <tag>-rc.(\d+)$ regex; got %v`, rc)
+		}
+		rcNum, err = strconv.Atoi(matches[1])
+		if err != nil {
+			panic(fmt.Errorf("regexp suppose to validate it's a number, but we can't parse it %v; %w", matches[1], err))
+		}
+	}
+	return Tag{Version: *v, rc: rcNum}, nil
+}
+
+func (t Tag) String() string {
+	return "v" + t.Version.String()
+}
+
+func (t Tag) RC() int {
+	return t.rc
+}
+
+// NextRC returns the next RC tag to release, bases on the current one.
+// If the current one is not an RC, new patch RC.0 will be returned.
+func (t Tag) NextRC() Tag {
+	version := t.Version
+	if t.rc == -1 {
+		// Current tag is not a RC, we need to bump patch version to cut a new RC.
+		version = t.Version.IncPatch()
+	}
+	rcNum := t.rc + 1
+	var err error
+	version, err = version.SetPrerelease(fmt.Sprintf("rc.%v", rcNum))
+	if err != nil {
+		panic(err)
+	}
+	return Tag{Version: version, rc: rcNum}
+}

--- a/hack/prepare_rc/tag_test.go
+++ b/hack/prepare_rc/tag_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextRC(t *testing.T) {
+	tag, err := NewTag("v0.15.3-rc.5")
+	require.NoError(t, err)
+	require.Equal(t, "v0.15.3-rc.6", tag.NextRC().String())
+
+	tag, err = NewTag("v0.15.3")
+	require.NoError(t, err)
+	require.Equal(t, "v0.15.4-rc.0", tag.NextRC().String())
+
+	_, err = NewTag("v0.15.3-rc.5-magicsuffix")
+	require.Error(t, err)
+}

--- a/hack/release-forksync.sh
+++ b/hack/release-forksync.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${DEBUG_MODE:-}" ]]; then
+	set -o xtrace
+fi
+
+FORK_COMMIT_FILE=".git/fork-commit-sha.txt"
+
+# TODO(bwplotka): Clean err on missing deps e.g. gsed.
+
+SCRIPT_DIR="$(
+	cd -- "$(dirname "$0")" >/dev/null 2>&1
+	pwd -P
+)"
+source "${SCRIPT_DIR}/lib.sh"
+
+usage() {
+	local me
+	me="${BASH_SOURCE[0]}"
+	cat <<_EOM
+usage: ${me}
+
+Create a new release of fork against an upstream version (tag) while carrying the patches from the
+previous fork version. The process involves an "semantic fork git rebase -i" flow, similar to the normal git rebase -i (see semantic_fork_rebase for details).
+
+NOTE: The script is idempotent; to force it to recreate local artifacts (e.g. local clones, remote branches it created), remove the artifact you want to recreate.
+
+Example use:
+* SOURCE_BRANCH=release-2.45.3-gmp UPSTREAM_TAG=v2.53.5 CHECKOUT_DIR=~/Repos/tmp-release bash ${me}
+
+Variables:
+* CHECKOUT_DIR (required) - Local working directory e.g. for local clones.
+* SOURCE_BRANCH (required) - Fork branch considered as a source for the forked changes. This branch will be semantically rebased on UPSTREAM_TAG.
+* UPSTREAM_TAG (required) - Upstream tag to synchronize (rebase) to; this also controls the name of the eventual branch to use for the sync (release-$UPSTREAM_TAG-gmp).
+* PR_BRANCH (default: $USER/cut-release-$UPSTREAM_TAG-gmp) - Upstream branch to push to.
+_EOM
+}
+
+if (($# > 0)); then
+	case $1 in
+	help)
+		usage
+		exit 1
+		;;
+	esac
+fi
+
+if [[ -z "${CHECKOUT_DIR}" ]]; then
+	echo "❌  CHECKOUT_DIR environment variable is not set." >&2
+	usage
+	exit 1
+fi
+if [[ -z "${SOURCE_BRANCH}" ]]; then
+	echo "❌  SOURCE_BRANCH environment variable is not set." >&2
+	usage
+	exit 1
+fi
+if [[ -z "${UPSTREAM_TAG}" ]]; then
+	echo "❌  UPSTREAM_TAG environment variable is not set." >&2
+	usage
+	exit 1
+fi
+
+idemp::create_fork_commit() {
+	if [[ ! -f "${FORK_COMMIT_FILE}" || -z $(cat "${FORK_COMMIT_FILE}") ]]; then
+		create_fork_commit
+	else
+		echo "⚠️ Using existing ${FORK_COMMIT_FILE}"
+	fi
+}
+
+# create_fork_commit prepare a squashed commit with the core fork changes to cherry-pick.
+# It writes the SHA of that commit into the ${FORK_COMMIT_FILE}
+#
+# This commit excludes all files that are:
+# * no longer needed (documentation)
+# * can be easily recreated (e.g. by checking out the latest state or the automation like go mod vendor).
+#
+# Exclusion significantly simplifies the fork sync procedure.
+create_fork_commit() {
+	# Create ephemeral branch from the source of the forked code.
+	git checkout "${SOURCE_BRANCH}"
+	git checkout --detach
+
+	# Get the exact upstream tag we base our fork on.
+	source_tag="${SOURCE_BRANCH#release-}"
+	source_tag="v${source_tag%-gmp}"
+
+	# Reset it to clean vanilla version.
+	git reset --hard "${source_tag}"
+
+	# Squash all forked changes into a single commit.
+	# HEAD@{1} is where the branch was just before the previous command.
+	# TODO(bwplotka): Handle no change here.
+	git merge --squash "HEAD@{1}" && git commit --no-edit
+
+	# We could take it as-is but there are trivial changes we know we have to recreate, exclude them.
+	release-lib::exclude_changes_from_last_commit "${RELEASE_LIB_EXCLUDE_RE}" "${RELEASE_LIB_DOCUMENTATION_INCLUDE_RE}" "google-patch[logic]: required upstream code modifications"
+	git rev-parse --verify HEAD >"${FORK_COMMIT_FILE}"
+	git checkout "${PR_BRANCH}"
+}
+
+force_clean_git_local_changes() {
+	git restore -S .
+	git restore .
+	git clean -fd
+}
+
+idemp::recreate_fork_base_files() {
+	pushd "${DIR}"
+	if [[ "$(git rev-parse --verify HEAD)" != "$(git rev-list -n 1 "${UPSTREAM_TAG}")" ]]; then
+		# There are some commits already, check if this step was done ~correctly.
+		# Get 2 first commits from the upstream tag to HEAD.
+		commits_state=$(git log --oneline --no-decorate "${UPSTREAM_TAG}"..HEAD | cut -d' ' -f2- | tail -2)
+		expected="google-patch[libs]: add google fork packages (export and secret)
+google-patch[setup]: initial setup"
+		if [[ "${PROJECT}" != "prometheus" ]]; then
+			expected="google-patch[setup]: initial setup"
+			commits_state=$(echo "${commits_state}" | tail -1)
+		fi
+		if ! state_diff=$(diff <(echo "${commits_state}") <(echo "${expected}")); then
+			echo "❌  Unexpected commit state on $(pwd); expected first commits to match
+${expected}
+
+diff:
+${state_diff}
+
+Remove those commits or remove the dir to recreate and rerun."
+			exit 1
+		fi
+		echo "⚠️ Using existing commit state; looks clean:
+${commits_state}"
+		return 0
+	fi
+	if [ -n "$(git status --porcelain)" ]; then
+		echo "❌  Unclean git state on $(pwd); clean it (e.g. git clean -fd) or remove the dir to recreate; and rerun."
+		exit 1
+	fi
+	recreate_fork_base_files
+}
+
+# recreate_fork_base_files creates a few base commits:
+# * setup (e.g. removal unnecessary files, documentation, gitignore, CI files, Dockerfile)
+# * libs (e.g. any libs with non-conflicting code that we maintain on forks e.g. export pkg).
+#
+# NOTE: This is interconnected with $RELEASE_LIB_EXCLUDE_RE variable that excludes some of those files
+# from cherry-pick to recreate it here.
+recreate_fork_base_files() {
+	echo "🔄 Creating 'google-patch[setup]' on top of the ${UPSTREAM_TAG} state..."
+
+	# Remove unnecessary files, especially documentation - we want ppl to use GCP or upstream Prometheus docs.
+	rm "MAINTAINERS.md"
+	rm "CHANGELOG.md"
+	rm "RELEASE.md"
+	rm -r ".circleci/"
+	rm -r ".github/"
+	rm -r "docs/"
+	# Remove all but important linked files.
+	find "documentation" -type f | grep -v -E "${RELEASE_LIB_DOCUMENTATION_INCLUDE_RE}" | xargs rm --
+	find "documentation" -type d -empty -delete
+
+	git checkout "${SOURCE_BRANCH}" -- "README.md"
+	git checkout "${SOURCE_BRANCH}" -- "CONTRIBUTING.md"
+	git checkout "${SOURCE_BRANCH}" -- ".gcloudignore"
+
+	# Apply our simplified CI.
+	git checkout "${SOURCE_BRANCH}" -- ".github/"
+
+	# Add our own build pipeline.
+	# TODO(bwplotka): We could consider Dockerfile.google and removal of vanilla Dockerfile
+	# This needs fix on Louhi side, so has to be carefully done.
+	git checkout "${SOURCE_BRANCH}" -- "Dockerfile"
+
+	git add --all
+	git commit -s -m "google-patch[setup]: initial setup
+
+Changes:
+* Removal of unnecessary files (e.g. documentation) to avoid confusion.
+* Replacing README and CONTRIBUTING doc files with our wording.
+* Replacing CI scripts with our own.
+* Replacing Dockerfile with our own for Google assured build.
+* Adding .gcloudignore
+"
+	if [ -n "$(git status --porcelain)" ]; then
+		echo "❌  Unclean git state on $(pwd); clean it (e.g. git clean -fd) or remove the dir to recreate; and rerun."
+		exit 1
+	fi
+	if [[ "${PROJECT}" == "prometheus" ]]; then
+		# After unfork this will change, but currently we have a separate package to maintain on Prometheus fork for:
+		# * secrets
+		# * lease
+		# * GCM export
+		# Recreate that instead of cherry-picking little commits.
+		echo "🔄 Creating 'google-patch[libs]' on top of the 'google-patch[setup]' commit..."
+		if ! git checkout "${SOURCE_BRANCH}" -- "google/"; then
+			echo "❌  Expected google lib is missing on ${SOURCE_BRANCH}; Perhaps source branch is missing that (too old) or we are in progress of the unforking; double check and update script or fetch it manuall and commit with the 'google-patch[libs]:' prefix"
+			exit 1
+		fi
+
+		git add --all
+		git commit -s -m "google-patch[libs]: add google fork packages (export and secret)
+
+  Changes:
+  * Add google directory with export and secret code.
+  "
+	fi
+	# All done, nothing to do.
+}
+
+REMOTE_URL=$(release-lib::remote_url_from_branch "${SOURCE_BRANCH}")
+PROJECT=$(
+	tmp=${REMOTE_URL##*/}
+	echo "${tmp%.git}"
+)
+UPSTREAM_REMOTE_URL=$(release-lib::upstream_remote_url "${PROJECT}")
+RELEASE_BRANCH="release-${UPSTREAM_TAG#v}-gmp"
+PR_BRANCH=${PR_BRANCH:-"${USER}/cut-${RELEASE_BRANCH}"}
+
+echo "🔄 Assuming ${PROJECT} with remotes {internal: ${REMOTE_URL}, upstream: ${UPSTREAM_REMOTE_URL}}; syncing ${UPSTREAM_TAG} into ${RELEASE_BRANCH} with the internal patches synced to ${PR_BRANCH} from ${SOURCE_BRANCH}"
+
+DIR="${CHECKOUT_DIR}/${PROJECT}"
+release-lib::idemp::clone "${DIR}" "${SOURCE_BRANCH}" "${PR_BRANCH}"
+
+pushd "${DIR}"
+
+if ! url=$(git remote get-url upstream 2>/dev/null) || [[ "${url}" != "${UPSTREAM_REMOTE_URL}" ]]; then
+	git remote add upstream "${UPSTREAM_REMOTE_URL}"
+fi
+
+# Is cherry pick in progress?
+if git rev-parse -q --verify CHERRY_PICK_HEAD; then
+	echo "❌ Cherry pick is in progress on ${DIR}; cd there and fix conflicts manually, then --continue and rerun the script" >&2
+	exit 1
+fi
+
+# Step 1: Prepare ${RELEASE_BRANCH} and ${PR_BRANCH}, both targeting vanilla ${UPSTREAM_TAG} for now. This will be used as a base for a PR with rebased forked functionality.
+if ! git fetch upstream "refs/tags/${UPSTREAM_TAG}:refs/tags/${UPSTREAM_TAG}"; then
+	echo "❌  Failed to fetch ${UPSTREAM_TAG} from the upstream ${UPSTREAM_REMOTE_URL}" >&2
+	exit 1
+fi
+
+if git fetch origin && git rev-parse -q "origin/${RELEASE_BRANCH}" >/dev/null; then
+	echo "❌  The internal 'origin/${RELEASE_BRANCH}' branch already exists. This means that this script was already run sucessfully or the release branch is live; aborting.
+
+   Remove that remote branch and ${DIR} if you wish to recreate this branch." >&2
+	exit 1
+fi
+
+if git rev-parse -q "${RELEASE_BRANCH}" >/dev/null; then
+	release_branch_head=$(git rev-parse -q "${RELEASE_BRANCH}")
+	if [[ "${release_branch_head}" != "$(git rev-list -n 1 "${UPSTREAM_TAG}")" ]]; then
+		echo "❌  Internal '${RELEASE_BRANCH}' branch already exists and it's not pointing to the upstream ${UPSTREAM_TAG}; aborting. Remove that branch if you wish to resume this script." >&2
+		exit 1
+	fi
+else
+	git checkout "${UPSTREAM_TAG}" --detach
+	git checkout -b "${RELEASE_BRANCH}"
+
+	# Switch back to PR_BRANCH and reset it to RELEASE_BRANCH.
+	git checkout "${PR_BRANCH}"
+	git reset --hard "${RELEASE_BRANCH}"
+fi
+
+# Step 2: Prepare a squashed commit for core fork changes to cherry-pick. Exclude
+# all files that are either no longer needed (documentation) or can be easily recreated
+# (e.g. by checking out the latest state or the automation). This significantly simplifies
+# the fork sync procedure.
+if ! idemp::create_fork_commit "${DIR}"; then
+	force_clean_git_local_changes
+	git checkout "${PR_BRANCH}" # Ensure clean state.
+	exit 1
+fi
+
+# Step 3: Recreate base fork commits like setup, build and vendor.
+git checkout "${PR_BRANCH}"
+idemp::recreate_fork_base_files
+
+# Step 4: Cherry-pick the squashed fork commit -- this will likely conflict and manual intervention and review is needed.
+
+if [[ "$(git log --oneline --no-decorate -n1 | cut -d' ' -f2- | cut -d':' -f1)" != "google-patch[logic]" ]]; then
+	echo "🔄 Cherry picking prepared commit from the ${FORK_COMMIT_FILE}..."
+	if ! git cherry-pick "$(cat "${FORK_COMMIT_FILE}")"; then
+		echo "❌ Cherry pick found some conflicts (generally expected for this commit). Go to the directory, fix the issues and run 'git cherry-pick --continue', don't change the commit message (!); then rerun the script.  Dir:
+  cd ${DIR}
+
+  NOTE: You can run 'make test' to run all tests. After cherry-pick --continue, you can also do git rebase -i ${UPSTREAM_TAG} and arrange/change commits as you need." >&2
+		exit 1
+	fi
+else
+	echo "⚠️ google-patch[logic]* is present; assuming cherry-pick was done successfully; proceeding."
+fi
+
+if release-lib::needs_push "${PR_BRANCH}" "${RELEASE_BRANCH}"; then
+	git --no-pager log --oneline "${RELEASE_BRANCH}"...HEAD
+
+	if release-lib::confirm "About to git push state from ${DIR} to origin/${PR_BRANCH}; also pushing ${RELEASE_BRANCH} with the upstream state; are you sure?"; then
+		git push origin "${PR_BRANCH}"
+		git push origin "${RELEASE_BRANCH}"
+
+		# TODO(bwplotka): Use gh to creat this
+		echo "✅  Sync changes has been pushed on origin/${PR_BRANCH}; the vanilla upstream was pushed to ${RELEASE_BRANCH}; create a PR with origin/${PR_BRANCH} -> ${RELEASE_BRANCH}, ensure CI is passing and get the changes reviewed (especially  the cherry-picked 'google-patch[logic]:' commit!)."
+		echo "ℹ️  After PR is merged, consider running:
+* Vulnerability check/fix:
+BRANCH=${RELEASE_BRANCH} CHECKOUT_DIR=${CHECKOUT_DIR} bash ${SCRIPT_DIR}/release-vulnfix.sh
+* RC release creation:
+BRANCH=${RELEASE_BRANCH} TAG=${UPSTREAM_TAG}-gmp.0-rc.0 CHECKOUT_DIR=${CHECKOUT_DIR} bash ${SCRIPT_DIR}/release-rc.sh"
+	fi
+else
+	exit 1
+fi

--- a/hack/release-rc.sh
+++ b/hack/release-rc.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${DEBUG_MODE:-}" ]]; then
+	set -o xtrace
+fi
+
+# TODO(bwplotka): Clean err on missing deps e.g. gsed.
+
+SCRIPT_DIR="$(
+	cd -- "$(dirname "$0")" >/dev/null 2>&1
+	pwd -P
+)"
+source "${SCRIPT_DIR}/lib.sh"
+
+usage() {
+	local me
+	me="${BASH_SOURCE[0]}"
+	cat <<_EOM
+usage: ${me}
+
+Release the RC.
+
+NOTE: The script is idempotent; to force it to recreate local artifacts (e.g. local clones, remote branches it created), remove the artifact you want to recreate.
+
+Example use:
+ * BRANCH=release/0.15 TAG=v0.15.4-rc.0 CHECKOUT_DIR=~/Repos/tmp-release ${me}
+ * BRANCH=release-2.45.3-gmp TAG=v2.45.3-gmp.13-rc.0 CHECKOUT_DIR=~/Repos/tmp-release ${me}
+ * BRANCH=release-0.27.0-gmp TAG=v0.27.0-gmp.4-rc.0 CHECKOUT_DIR=~/Repos/tmp-release ${me}
+
+Variables:
+* BRANCH (required) - Release branch to work on; Project is auto-detected from this.
+* TAG (required) - Tag to release.
+* CHECKOUT_DIR (required) - Local working directory e.g. for local clones.
+_EOM
+}
+
+if (($# > 0)); then
+	case $1 in
+	help)
+		usage
+		exit 0
+		;;
+	esac
+fi
+
+# Check if the BRANCH environment variable is set.
+if [[ -z "${BRANCH}" ]]; then
+	echo "❌  BRANCH environment variable is not set." >&2
+	usage
+	exit 1
+fi
+
+REMOTE_URL=$(release-lib::remote_url_from_branch "${BRANCH}")
+PROJECT=$(
+	tmp=${REMOTE_URL##*/}
+	echo ${tmp%.git}
+)
+PR_BRANCH=${BRANCH} # Same as branch because we push directly, without PR as per our process.
+
+echo "🔄 Assuming ${PROJECT} with remote ${REMOTE_URL}; changes will be pushed directly to ${PR_BRANCH}"
+
+# Check if the BRANCH environment variable is set.
+if [[ -z "${CHECKOUT_DIR}" ]]; then
+	echo "❌  CHECKOUT_DIR environment variable is not set." >&2
+	usage
+	exit 1
+fi
+
+# TODO(bwplotka): Auto-detect this.
+if [[ -z "${TAG}" ]]; then
+	echo "❌  TAG environment variable is not set." >&2
+	usage
+	exit 1
+fi
+
+DIR="${CHECKOUT_DIR}/${PROJECT}"
+release-lib::idemp::clone "${DIR}" "${BRANCH}" "${PR_BRANCH}"
+
+pushd "${DIR}"
+
+if [[ "${PROJECT}" == "prometheus-engine" ]]; then
+	pushd "${SCRIPT_DIR}"
+	go run "./prepare_rc" -dir "${DIR}" -tag "${TAG}"
+	popd
+	"${DIR}/hack/presubmit.sh" manifests
+	git add --all
+else
+	# Prometheus and Alertmanager fork needs just a correct version in the VERSION file,
+	# so the binary build (go_build_info) metrics and flags are correct.
+	temp=${TAG#v} # Remove v and then -rc.* suffix.
+	echo "${temp%-rc.*}" >VERSION
+	git add VERSION
+fi
+
+# Commit if anything is staged.
+release-lib::idemp::git_commit_amend_match "chore: prepare for ${TAG} release"
+
+# Check if tag exists.
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+	# Tag exists, but is it tagged for the current HEAD?
+	if [[ "$(git rev-parse HEAD)" != "$(git rev-list -n 1 "${TAG}")" ]]; then
+		echo "❌  Tag ${TAG} exists already locally, not pointing to the HEAD; consider 'git tag -d' to remove it and rerun." >&2
+		exit 1
+	fi
+else
+	echo "🔄 Creating a signed tag ${TAG}..."
+	# explicit TTY is often needed on Macs.
+	# TODO(bwplotka): Consider adding v0.x second tag for Prometheus fork (similar to how v0.300 Prometheus releases are structured).
+	# This is to have a little bit cleaner prometheus-engine go.mod version against the fork.
+	GPG_TTY=$(tty) git tag -s "${TAG}" -m "${TAG}"
+fi
+
+if release-lib::needs_push "${PR_BRANCH}" "${BRANCH}" || ! git ls-remote --tags --exit-code origin "refs/tags/${TAG}" >/dev/null; then
+	if release-lib::confirm "About to git push state from ${DIR} to origin/${PR_BRANCH}; then ${TAG}; are you sure?"; then
+		git push origin "${PR_BRANCH}"
+		git push origin "${TAG}"
+	fi
+else
+	exit 1
+fi

--- a/hack/release-vulnfix.sh
+++ b/hack/release-vulnfix.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${DEBUG_MODE:-}" ]]; then
+	set -o xtrace
+fi
+
+# TODO(bwplotka): Clean err on missing deps e.g. gsed.
+# TODO(bwplotka): Consider automation for npm and docker images (Go, debian, similar to bump-go.sh)
+
+SCRIPT_DIR="$(
+	cd -- "$(dirname "$0")" >/dev/null 2>&1
+	pwd -P
+)"
+source "${SCRIPT_DIR}/lib.sh"
+
+usage() {
+	local me
+	me="${BASH_SOURCE[0]}"
+	cat <<_EOM
+usage: ${me}
+
+Attempt a minimal dependency upgrade to solve fixable vulnerabilities.
+
+NOTE: The script is idempotent; to force it to recreate local artifacts (e.g. local clones, remote branches it created), remove the artifact you want to recreate.
+
+Example use:
+ * BRANCH=release/0.15 CHECKOUT_DIR=~/Repos/tmp-release ${me}
+ * BRANCH=release-2.45.3-gmp CHECKOUT_DIR=~/Repos/tmp-release ${me}
+ * BRANCH=release-0.27.0-gmp CHECKOUT_DIR=~/Repos/tmp-release ${me}
+
+Variables:
+* BRANCH (required) - Release branch to work on; Project is auto-detected from this.
+* CHECKOUT_DIR (required) - Local working directory e.g. for local clones.
+* PR_BRANCH (default: USER/BRANCH-vulnfix) - Upstream branch to push to (user-confirmed first).
+_EOM
+}
+
+if (($# > 0)); then
+	case $1 in
+	help)
+		usage
+		exit 0
+		;;
+	esac
+fi
+
+# Check if the BRANCH environment variable is set.
+if [[ -z "${BRANCH}" ]]; then
+	echo "❌  BRANCH environment variable is not set." >&2
+	usage
+	return 1
+fi
+
+REMOTE_URL=$(release-lib::remote_url_from_branch "${BRANCH}")
+PROJECT=$(
+	tmp=${REMOTE_URL##*/}
+	echo ${tmp%.git}
+)
+PR_BRANCH=${PR_BRANCH:-"${USER}/${BRANCH}-vulnfix"}
+
+echo "🔄 Assuming ${PROJECT} with remote ${REMOTE_URL}; changes will be pushed to ${PR_BRANCH}"
+
+# Check if the BRANCH environment variable is set.
+if [[ -z "${CHECKOUT_DIR}" ]]; then
+	echo "❌  CHECKOUT_DIR environment variable is not set." >&2
+	usage
+	return 1
+fi
+
+DIR="${CHECKOUT_DIR}/${PROJECT}"
+release-lib::idemp::clone "${DIR}" "${BRANCH}" "${PR_BRANCH}"
+
+vuln_file="${DIR}/.git/vulnlist.txt"
+pushd "${DIR}"
+
+release-lib::idemp::vulnlist "${DIR}" "${vuln_file}"
+
+if [[ "no vulnerabilities" != $(cat "${vuln_file}") ]]; then
+	# Attempt to update + go mod tidy.
+	release-lib::gomod_vulnfix "${DIR}" "${vuln_file}"
+	git add go.mod go.sum
+
+	# Check if that helped.
+	echo "⚠️ This will fail on older branches with vendoring; in this case, simply go to ${DIR}, run 'go mod vendor' and rerun."
+	release-lib::vulnlist "${DIR}" "${vuln_file}"
+	if [[ "no vulnerabilities" != $(cat "${vuln_file}") ]]; then
+		echo "❌  After go mod update some vulnerabilities are still found; go to ${DIR} and resolve it manually and remove the ./vulnlist.txt file and rerun." >&2
+		exit 1
+	fi
+fi
+
+# TODO: Warn of unstaged files at this point.
+
+# Commit if anything is staged.
+msg="google patch[deps]: fix Go ${BRANCH} vulnerabilities"
+if [[ "${PROJECT}" == "prometheus-engine" ]]; then
+	msg="fix: fix ${BRANCH} vulnerabilities"
+fi
+release-lib::idemp::git_commit_amend_match "${msg}"
+
+if release-lib::needs_push "${PR_BRANCH}" "${BRANCH}"; then
+	if release-lib::confirm "About to FORCE git push from ${DIR} to origin/${PR_BRANCH}; are you sure?"; then
+		git push --force origin "${PR_BRANCH}"
+	fi
+else
+	exit 1
+fi

--- a/hack/test-lib.sh
+++ b/hack/test-lib.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${DEBUG_MODE:-}" ]]; then
+	set -o xtrace
+fi
+
+_assert_equal() {
+	got="${1}"
+	expected="${2}"
+
+	if [[ "${got}" == "${expected}" ]]; then
+		return
+	fi
+
+	echo "assertion failure:"
+	cat <<EOF
+<<<<<<< GOT
+${got}
+=======
+${expected}
+>>>>>>> EXPECTED
+EOF
+
+	return 1
+}
+
+_assert_pass() {
+	if eval "$1"; then
+		return
+	fi
+
+	return 1
+}
+
+_assert_fail() {
+	if ! eval "$1"; then
+		return
+	fi
+
+	return 1
+}
+
+# Sanity check on pass/fail helpers.
+_assert_pass true || exit 1
+_assert_fail false || exit 1
+
+_assert_fail "_assert_pass false" || exit 1
+_assert_fail "_assert_fail true" || exit 1
+
+_assert_pass "_assert_equal 1 1" || exit 1
+echo "NOTE: Expected failure output below on _assert_fail (exit code 0 though)"
+_assert_fail "_assert_equal 1 2" || exit 1
+
+# Stronger assertion helpers that exit the program on assertion failure.
+assert_pass() { _assert_pass "$@" || exit 1; }
+assert_fail() { _assert_fail "$@" || exit 1; }
+assert_equal() { _assert_equal "$@" || exit 1; }

--- a/hack/vulnupdatelist/main.go
+++ b/hack/vulnupdatelist/main.go
@@ -1,0 +1,140 @@
+// package main implements vulnupdatelist script.
+//
+// Run this script to list all the vulnerable Go modules to upgrade.
+// Compared to govulncheck binary, it also checks severity and groups the results
+// into clear table per module to upgrade.
+//
+// Example use:
+//
+//	go run ./... \
+//		-go-version=1.23.0 \
+//		-only-fixed \
+//		-dir=../../../prometheus \
+//		-nvd-api-key="$(cat ./api.text)" | tee vuln.txt
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+var (
+	goVersion = flag.String("go-version", "", "Go version to test vulnerabilities in (stdlib). Otherwise the `go env GOVERSION` is used")
+	dir       = flag.String("dir", ".", "Where to run the script from")
+	nvdAPIKey = flag.String("nvd-api-key", "", "API Key for avoiding rate-limiting on severity checks; see https://nvd.nist.gov/developers/request-an-api-key")
+	onlyFixed = flag.Bool("only-fixed", false, "Don't print vulnerable modules without fixed version; note: fixed version often means sometimes that a new major version contains a fix.")
+)
+
+// UpdateList presents the minimum version to upgrade to solve all CVEs with
+// a fixed version. The CVE refers to the important CVE.
+// For example critical CVE 1 is fixed in v0.5.1 and low is fixed in v0.10.1.
+// TODO(bwplotka): Logically, there might be cases where low contains heavy breaking changes that we can't fix easily; add option to print those too.
+type UpdateList struct {
+	CVE            CVE // If CVE has +<number> suffix, it means the top CVE.
+	AdditionalCVEs int // Lower priority CVEs included in the "fixed" version.
+	Module         string
+	FixedVersion   *semver.Version
+	Version        string
+}
+
+func (u UpdateList) String() string {
+	fixedVersion := "???"
+	if u.FixedVersion != nil {
+		fixedVersion = "v" + u.FixedVersion.String()
+	}
+	if u.AdditionalCVEs > 0 {
+		return fmt.Sprintf("%s %s@%s %s(+%d more) now@%s", u.CVE.Severity, u.Module, fixedVersion, u.CVE.ID, u.AdditionalCVEs, u.Version)
+	}
+	return fmt.Sprintf("%s %s@%s %s now@%s", u.CVE.Severity, u.Module, fixedVersion, u.CVE.ID, u.Version)
+}
+
+func main() {
+	flag.Parse()
+
+	workDir, err := filepath.Abs(*dir)
+	if err != nil {
+		log.Fatalf("Failed to resolve work dir: %v", err)
+	}
+	slog.Info("Running vulnupdatelist", "dir", workDir)
+
+	if err := ensureGovulncheck(workDir); err != nil {
+		log.Fatalf("Failed to ensure govulncheck is installed: %v", err)
+	}
+
+	slog.Info("Running govulncheck... ")
+	vulnJSON, err := runGovulncheck(workDir, *goVersion)
+	if err != nil {
+		log.Fatalf("Error running govulncheck: %v", err)
+	}
+
+	if len(vulnJSON) == 0 {
+		slog.Info("govulncheck produced no output; no vulnerabilities found.")
+		os.Exit(0)
+	}
+
+	slog.Info("Parsing vulnerabilities and finding updates...")
+	updates, err := compileUpdateList(bytes.NewReader(vulnJSON), *onlyFixed)
+	if err != nil {
+		log.Fatalf("Error parsing govulncheck output: %v", err)
+	}
+	if len(updates) == 0 {
+		slog.Info("No actionable vulnerabilities with fixed versions found.")
+		os.Exit(0)
+	}
+	for _, up := range updates {
+		fmt.Println(up.String())
+	}
+}
+
+// ensureGovulncheck checks if govulncheck is in the PATH, and installs it if not.
+func ensureGovulncheck(dir string) error {
+	_, err := exec.LookPath("govulncheck")
+	if err == nil {
+		slog.Info("govulncheck is already installed")
+		return nil
+	}
+
+	slog.Info("govulncheck not found. Installing...")
+	cmd := exec.Command("go", "install", "golang.org/x/vuln/cmd/govulncheck@latest")
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run 'go install': %w", err)
+	}
+	slog.Info("govulncheck installed successfully.")
+	return nil
+}
+
+// runGovulncheck executes `govulncheck -json ./...` and returns the output.
+func runGovulncheck(dir string, goVersion string) ([]byte, error) {
+	cmd := exec.Command("govulncheck", "--format=json", "./...")
+	if goVersion != "" {
+		cmd.Env = append(os.Environ(), "GOVERSION="+goVersion)
+	}
+
+	cmd.Dir = dir
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	// govulncheck exits with a non-zero status code if vulns are found.
+	// We ignore the exit code and check stderr instead. If stderr is empty,
+	// it's a successful run (even with vulnerabilities).
+	_ = cmd.Run()
+
+	if stderr.Len() > 0 {
+		// Only return an error if stderr is not empty, as this indicates a real execution problem.
+		return nil, fmt.Errorf("govulncheck execution error: %s", stderr.String())
+	}
+	return out.Bytes(), nil
+}

--- a/hack/vulnupdatelist/nvdapi.go
+++ b/hack/vulnupdatelist/nvdapi.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// NVDResponse is the top-level object for the NVD CVE API.
+type NVDResponse struct {
+	Vulnerabilities []struct {
+		CVE struct {
+			ID      string `json:"id"`
+			Metrics struct {
+				CVSSMetricV31 []struct {
+					CVSSData struct {
+						BaseSeverity string `json:"baseSeverity"`
+					} `json:"cvssData"`
+				} `json:"cvssMetricV31"`
+			} `json:"metrics"`
+		} `json:"cve"`
+	} `json:"vulnerabilities"`
+}
+
+// getCVSSSeverity fetches vulnerability details from the NVD API and returns the CVSS V3 severity.
+func getCVSSSeverity(apiKey string, cveID string) (string, error) {
+	// https://nvd.nist.gov/developers/vulnerabilities
+	apiURL := fmt.Sprintf("https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=%s", cveID)
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	if apiKey != "" {
+		req.Header.Set("apiKey", apiKey)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to make request to NVD API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("NVD API returned non-200 status: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var nvdResponse NVDResponse
+	if err := json.Unmarshal(body, &nvdResponse); err != nil {
+		return "", fmt.Errorf("failed to parse JSON from NVD API: %w", err)
+	}
+
+	if len(nvdResponse.Vulnerabilities) > 0 {
+		metrics := nvdResponse.Vulnerabilities[0].CVE.Metrics
+		if len(metrics.CVSSMetricV31) > 0 {
+			return metrics.CVSSMetricV31[0].CVSSData.BaseSeverity, nil
+		}
+	}
+
+	return "UNKNOWN", nil
+}
+
+type CVE struct {
+	ID       string
+	Severity string
+}
+
+func (a CVE) LessThan(b CVE) bool {
+	order := map[string]int{
+		"CRITICAL": 0,
+		"HIGH":     1,
+		"MEDIUM":   2,
+		"UNKNOWN":  3,
+		"":         3,
+	}
+	return order[a.Severity] < order[b.Severity]
+}
+
+func getCVEDetails(apiKey string, osv OSV) CVE {
+	cveID := CVE{Severity: "UNKNOWN"}
+	// Assume ID is GO-... ID and use it as a fallback.
+	for _, a := range osv.Aliases {
+		if strings.HasPrefix(a, "CVE") {
+			cveID.ID = a
+			break
+		}
+	}
+	if cveID.ID == "" {
+		return CVE{ID: osv.ID, Severity: "UNKNOWN"} // Fallback to GO ID.
+	}
+	sev, err := getCVSSSeverity(apiKey, cveID.ID)
+	if err != nil {
+		slog.Error("failed to find severity", "cve", cveID, "err", err)
+	} else {
+		cveID.Severity = sev
+	}
+	return cveID
+}

--- a/hack/vulnupdatelist/nvdapi_test.go
+++ b/hack/vulnupdatelist/nvdapi_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCVEDetails(t *testing.T) {
+	t.Skip("depends on NVDE API")
+
+	c := getCVEDetails("", OSV{
+		ID:      "GO-2021-0065",
+		Aliases: []string{"GHSA-jmrx-5g74-6v2f", "CVE-2019-11250"},
+	})
+	require.Equal(t, "CVE-2019-11250", c.ID)
+	require.Equal(t, "MEDIUM", c.Severity)
+}

--- a/hack/vulnupdatelist/vuln.go
+++ b/hack/vulnupdatelist/vuln.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// Vuln represents the top-level structure of a single vulnerability report item.
+type Vuln struct {
+	OSV     *OSV     `json:"osv"`
+	Finding *Finding `json:"finding"`
+}
+
+// OSV contains the details of the Open Source Vulnerability.
+type OSV struct {
+	ID       string     `json:"id"`
+	Aliases  []string   `json:"aliases"`
+	Summary  string     `json:"summary"`
+	Details  string     `json:"details"`
+	Affected []Affected `json:"affected"`
+}
+
+func (o OSV) CVEs() string {
+	return strings.Join(append([]string{o.ID}, o.Aliases...), ", ")
+}
+
+// Affected describes a package that is affected by the vulnerability.
+type Affected struct {
+	Package Package `json:"package"`
+	Ranges  []Range `json:"ranges"`
+}
+
+// Package holds the name and ecosystem of the vulnerable package.
+type Package struct {
+	Name      string `json:"name"`
+	Ecosystem string `json:"ecosystem"`
+}
+
+// Range specifies the version ranges affected by the vulnerability.
+type Range struct {
+	Type   string  `json:"type"`
+	Events []Event `json:"events"`
+}
+
+// Event marks the introduction or fixing of a vulnerability in the version history.
+type Event struct {
+	Introduced string `json:"introduced,omitempty"`
+	Fixed      string `json:"fixed,omitempty"`
+}
+
+type Finding struct {
+	OSVID        string `json:"osv"`
+	FixedVersion string `json:"fixed_version"`
+	Trace        []FindingTrace
+}
+
+type FindingTrace struct {
+	Module  string `json:"module"`
+	Version string `json:"version"`
+}
+
+// compileUpdateList decodes the JSON stream from govulncheck and extracts
+// a list of modules that need to be updated to a fixed version.
+func compileUpdateList(jsonData io.Reader, onlyFixed bool) ([]UpdateList, error) {
+	updates := make(map[string]UpdateList)
+	osvs := make(map[string]*OSV)
+	decoder := json.NewDecoder(jsonData)
+
+	for {
+		var v Vuln
+		if err := decoder.Decode(&v); err == io.EOF {
+			break // End of JSON stream
+		} else if err != nil {
+			// It might not be a JSON error, could be other text in the stream.
+			// We continue to try and find valid JSON objects.
+			continue
+		}
+
+		if v.OSV == nil && v.Finding == nil {
+			continue
+		}
+		if v.OSV != nil {
+			osvs[v.OSV.ID] = v.OSV
+			continue
+		}
+
+		// Parse finding.
+		// We assume OSVs are printed first.
+		osv := osvs[v.Finding.OSVID]
+		cve := CVE{}
+		allCVEs := v.Finding.OSVID
+		if osv != nil {
+			cve = getCVEDetails(*nvdAPIKey, *osv)
+			allCVEs = osv.CVEs()
+		} else {
+			slog.Error("Malformed govulncheck input; a finding without a OSV entry; assuming unkown severity.", "finding.osv", v.Finding.OSVID)
+			cve.ID = v.Finding.OSVID // Fallback to GO ID
+			cve.Severity = "UNKNOWN"
+		}
+		if len(v.Finding.Trace) == 0 {
+			slog.Error("Malformed govulncheck input; a finding with empty trace; ignoring.", "finding.osv", v.Finding.OSVID)
+			continue
+		}
+
+		module := v.Finding.Trace[0].Module
+
+		var fixVersion *semver.Version
+		if v.Finding.FixedVersion != "" {
+			var err error
+			fixVersion, err = semver.NewVersion(v.Finding.FixedVersion)
+			if err != nil {
+				slog.Warn("Found Go vulnerability with a fix that is not a correct semver version; assuming no fix version", "mod", module, "osv", cve, "fixedVersion", v.Finding.FixedVersion, "err", err)
+			}
+		}
+
+		if onlyFixed && fixVersion == nil {
+			slog.Warn("IMPORTANT: Found Go vulnerability without a fixed version. Ignoring this module, given the -only-fixed flag...", "mod", module, "osv", cve)
+			continue
+		}
+
+		up, ok := updates[module]
+		if !ok {
+			slog.Info("Found Go vulnerability with a fix; queuing...", "mod", module, "CVEs", allCVEs)
+			updates[module] = UpdateList{
+				CVE:          cve,
+				Module:       module,
+				FixedVersion: fixVersion,
+				Version:      v.Finding.Trace[0].Version,
+			}
+			continue
+		}
+
+		// Check if there are more CVE IDs corresponding to the vulnerability, which can give more context.
+		slog.Debug("Found Go vulnerability with a fix, the module was already queued; resolving version...", "mod", module, "CVEs", allCVEs)
+		up.AdditionalCVEs++
+		if fixVersion != nil {
+			if up.FixedVersion == nil || fixVersion.GreaterThan(up.FixedVersion) {
+				up.FixedVersion = fixVersion
+			}
+		}
+		if !cve.LessThan(up.CVE) {
+			up.CVE = cve
+		}
+		updates[module] = up
+	}
+
+	updateList := slices.Collect(maps.Values(updates))
+	sort.Slice(updateList, func(i, j int) bool {
+		return updateList[i].CVE.LessThan(updateList[j].CVE)
+	})
+	return updateList, nil
+}


### PR DESCRIPTION
See gmp:toil-automation for motivation.

* listing Go vulns + severity
* create a security vuln fix commit
* create a new fork release that syncs with certain upstream tag (see go/gmp:fork-toil)
* cut RC

TODO:
* [ ] Clean them up and potentially separate into small PRs if needed
* [ ] (separate PR) basic tests, CI testing it, ensuring license, shellcheck lint, cleaning other scripts we have in hack
I didn't have time to clean them up or separate into smaller PRs

