### PR TITLE
chore: use 2.53.5-gmp.0-gke.6 (rc.6) version

### DIFF
--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -16,30 +16,30 @@ commonLabels: false
 namespace:
   public: gmp-public
   system: gmp-system
-version: 0.15.3
+version: 0.15.4
 images:
   # NOTE: All tags have to be quoted otherwise they might be treated as a number.
   bash:
     image: gke.gcr.io/gke-distroless/bash
-    tag: "gke_distroless_20250407.00_p0"
+    tag: "gke_distroless_20250807.00_p0"
   alertmanager:
     image: gke.gcr.io/prometheus-engine/alertmanager
     tag: "v0.27.0-gmp.3-gke.0"
   prometheus:
     image: gke.gcr.io/prometheus-engine/prometheus
-    tag: "v2.53.4-gmp.0-gke.1"
+    tag: "v2.53.5-gmp.0-gke.6"
   configReloader:
     image: gke.gcr.io/prometheus-engine/config-reloader
-    tag: "v0.15.3-gke.0"
+    tag: "v0.15.4-gke.0"
   operator:
     image: gke.gcr.io/prometheus-engine/operator
-    tag: "v0.15.3-gke.0"
+    tag: "v0.15.4-gke.0"
   ruleEvaluator:
     image: gke.gcr.io/prometheus-engine/rule-evaluator
-    tag: "v0.15.3-gke.0"
+    tag: "v0.15.4-gke.0"
   datasourceSyncer:
     image: gke.gcr.io/prometheus-engine/datasource-syncer
-    tag: "v0.15.3-gke.0"
+    tag: "v0.15.4-gke.0"
 resources:
   alertManager:
     limits:

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -41,7 +41,7 @@ spec:
                 - linux
       containers:
       - name: datasource-syncer-init
-        image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.15.4-gke.0
         args:
         - "--datasource-uids=$DATASOURCE_UIDS"
         - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
@@ -79,7 +79,7 @@ spec:
                     - linux
           containers:
           - name: datasource-syncer
-            image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.15.3-gke.0
+            image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.15.4-gke.0
             args:
             - "--datasource-uids=$DATASOURCE_UIDS"
             - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"

--- a/go.mod
+++ b/go.mod
@@ -344,7 +344,8 @@ replace (
 	// Remove once this version moves to newer Prometheus.
 	github.com/prometheus/common => github.com/prometheus/common v0.61.0
 	// See go/gmp:fork-toil for rationales of this entry.
-	github.com/prometheus/prometheus => github.com/GoogleCloudPlatform/prometheus v0.0.0-20250808093343-c957fe3dccf2 // v2.53.5-gmp.0-rc.0
+	github.com/prometheus/prometheus => github.com/GoogleCloudPlatform/prometheus v0.0.0-20250822124349-98e3120b1750
+// v2.53.5-gmp.0-gke.6
 )
 
 tool (

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rW
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.1 h1:Sz1JIXEcSfhz7fUi7xHnhpIE0thVASYjvosApmHuD2k=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.1/go.mod h1:n/LSCXNuIYqVfBlVXyHfMQkZDdp1/mmxfSjADd3z1Zg=
-github.com/GoogleCloudPlatform/prometheus v0.0.0-20250808093343-c957fe3dccf2 h1:RTA2FVsAFDv9JuaE7LNioRsgdRDtD/1MjiWwCLi0TbI=
-github.com/GoogleCloudPlatform/prometheus v0.0.0-20250808093343-c957fe3dccf2/go.mod h1:+WdwyasqiCKs6mMSlln5EzgyFrk4g1mfh/RnOxeXQzA=
+github.com/GoogleCloudPlatform/prometheus v0.0.0-20250822124349-98e3120b1750 h1:xuD+UwWYcwPqUvHVoyowUEy49UnW+n+0DCDpwhUL548=
+github.com/GoogleCloudPlatform/prometheus v0.0.0-20250822124349-98e3120b1750/go.mod h1:KJY4lbAwOWwFJ9qgAPDYo3KVfXKokl7gU9WsMrNIdNk=
 github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -172,8 +172,8 @@ github.com/docker/cli v27.5.0+incompatible h1:aMphQkcGtpHixwwhAXJT1rrK/detk2JIvD
 github.com/docker/cli v27.5.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v27.5.0+incompatible h1:um++2NcQtGRTz5eEgO6aJimo6/JxrTXC941hd05JO6U=
-github.com/docker/docker v27.5.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.0.0+incompatible h1:Olh0KS820sJ7nPsBKChVhk5pzqcwDR15fumfAd/p9hM=
+github.com/docker/docker v28.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -347,7 +347,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.15.3
+        app.kubernetes.io/version: 0.15.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -359,7 +359,7 @@ spec:
       priorityClassName: gmp-critical
       initContainers:
       - name: config-init
-        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20250407.00_p0
+        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20250807.00_p0
         command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
         volumeMounts:
         - name: config-out
@@ -373,7 +373,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.4-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -409,7 +409,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: prometheus
-        image: gke.gcr.io/prometheus-engine/prometheus:v2.53.4-gmp.0-gke.1
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.53.5-gmp.0-gke.6
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --enable-feature=exemplar-storage
@@ -545,14 +545,14 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.15.3
+        app.kubernetes.io/version: 0.15.0
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/operator:v0.15.4-gke.0
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"
@@ -648,7 +648,7 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
         app: managed-prometheus-rule-evaluator
-        app.kubernetes.io/version: 0.15.3
+        app.kubernetes.io/version: 0.15.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -660,7 +660,7 @@ spec:
       priorityClassName: gmp-critical
       initContainers:
       - name: config-init
-        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20250407.00_p0
+        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20250807.00_p0
         command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
         volumeMounts:
         - name: config-out
@@ -674,7 +674,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.4-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -715,7 +715,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.4-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
@@ -823,7 +823,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.15.3
+        app.kubernetes.io/version: 0.15.0
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
@@ -832,7 +832,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
       - name: config-init
-        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20250407.00_p0
+        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20250807.00_p0
         command: ['/bin/bash', '-c', 'touch /alertmanager/config_out/config.yaml && echo -e "receivers:\n  - name: noop\nroute:\n  receiver: noop" > alertmanager/config_out/config.yaml']
         volumeMounts:
         - name: alertmanager-config
@@ -882,7 +882,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.4-gke.0
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -118,20 +118,20 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.15.3
+        app.kubernetes.io/version: 0.15.0
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
       initContainers:
       - name: config-init
-        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20250407.00_p0
+        image: gke.gcr.io/gke-distroless/bash:gke_distroless_20250807.00_p0
         command: ['/bin/bash', '-c', 'touch /prometheus/config_out/config.yaml']
         volumeMounts:
         - name: config-out
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.4-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -169,7 +169,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.4-gke.0
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"


### PR DESCRIPTION
To test 2.53.5 with PE before 0.17.0 release.