### PR TITLE
chore: bump GMP version to the latest prod

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -33,6 +33,11 @@ updates:
     docker:
       patterns:
         - "*"
+      exclude-patterns:
+        # To change those we need to do make regen. Still
+        # allow dependabot to bump it to let us know it's possible, just not
+        # in a single group.
+        - "gke.gcr.io/prometheus-engine/*"
 - package-ecosystem: gomod
   directory: /
   ignore:

--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -16,7 +16,7 @@ commonLabels: false
 namespace:
   public: gmp-public
   system: gmp-system
-version: 0.15.3
+version: 0.15.4
 images:
   # NOTE: All tags have to be quoted otherwise they might be treated as a number.
   bash:
@@ -30,16 +30,16 @@ images:
     tag: "v2.53.4-gmp.0-gke.1"
   configReloader:
     image: gke.gcr.io/prometheus-engine/config-reloader
-    tag: "v0.15.3-gke.0"
+    tag: "v0.15.4-gke.0"
   operator:
     image: gke.gcr.io/prometheus-engine/operator
-    tag: "v0.15.3-gke.0"
+    tag: "v0.15.4-gke.0"
   ruleEvaluator:
     image: gke.gcr.io/prometheus-engine/rule-evaluator
-    tag: "v0.15.3-gke.0"
+    tag: "v0.15.4-gke.0"
   datasourceSyncer:
     image: gke.gcr.io/prometheus-engine/datasource-syncer
-    tag: "v0.15.3-gke.0"
+    tag: "v0.15.4-gke.0"
 resources:
   alertManager:
     limits:

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -41,7 +41,7 @@ spec:
                 - linux
       containers:
       - name: datasource-syncer-init
-        image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.15.4-gke.0
         args:
         - "--datasource-uids=$DATASOURCE_UIDS"
         - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
@@ -79,7 +79,7 @@ spec:
                     - linux
           containers:
           - name: datasource-syncer
-            image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.15.3-gke.0
+            image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.15.4-gke.0
             args:
             - "--datasource-uids=$DATASOURCE_UIDS"
             - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -347,7 +347,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.15.3
+        app.kubernetes.io/version: 0.15.4
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -373,7 +373,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.4-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -545,14 +545,14 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.15.3
+        app.kubernetes.io/version: 0.15.4
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/operator:v0.15.4-gke.0
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"
@@ -648,7 +648,7 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
         app: managed-prometheus-rule-evaluator
-        app.kubernetes.io/version: 0.15.3
+        app.kubernetes.io/version: 0.15.4
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -674,7 +674,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.4-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -715,7 +715,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.4-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
@@ -823,7 +823,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.15.3
+        app.kubernetes.io/version: 0.15.4
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
@@ -882,7 +882,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.4-gke.0
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -118,7 +118,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.15.3
+        app.kubernetes.io/version: 0.15.4
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
@@ -131,7 +131,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.4-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -169,7 +169,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.3-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.4-gke.0
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"


### PR DESCRIPTION
Also adjusted dependabot as funnny enough, it nicely notified us about this
https://github.com/GoogleCloudPlatform/prometheus-engine/actions/runs/17222882290/job/48861825066?pr=1733