### PR TITLE
feat: enable against GCM tests for e2e

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -86,5 +86,8 @@ jobs:
         testrun: ${{fromJson(needs.e2e-testruns.outputs.testrun)}}
     steps:
       - uses: actions/checkout@v4
-      - name: Run e2e
+      - name: Run e2e (with GCM)
+        env:
+          # This enables GCM tests (--skip-gcm=false).
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GCM_SECRET }}
         run: TEST_RUN=${{matrix.testrun}} make e2e


### PR DESCRIPTION
We plan to add more tests around this path, so checking if it's safe to enable or we need to do bit more work to make it per CI.

We already have secret for other GCM e2e tests.