### PR TITLE
refactor: reorder containers in rule-evaluator

### DIFF
--- a/charts/rule-evaluator/templates/deployment.yaml
+++ b/charts/rule-evaluator/templates/deployment.yaml
@@ -38,39 +38,6 @@ spec:
         - name: config-out
           mountPath: /prometheus/config_out
       containers:
-      - name: config-reloader
-        image: {{.Values.images.configReloader.image}}:{{.Values.images.configReloader.tag}}
-        args:
-        - --config-file=/prometheus/config/config.yaml
-        - --config-file-output=/prometheus/config_out/config.yaml
-        - --config-dir=/etc/rules
-        - --config-dir-output=/prometheus/rules_out
-        - --reload-url=http://127.0.0.1:9092/-/reload
-        - --ready-url=http://127.0.0.1:9092/-/ready
-        - --listen-address=:9093
-        ports:
-        - name: cfg-rel-metrics
-          protocol: TCP
-          containerPort: 9093
-        resources: {{- toYaml $.Values.resources.configReloader | nindent 10}}
-        volumeMounts:
-        - name: config
-          readOnly: true
-          mountPath: /prometheus/config
-        - name: config-out
-          mountPath: /prometheus/config_out
-        - name: rules
-          readOnly: true
-          mountPath: /etc/rules
-        - name: rules-out
-          mountPath: /prometheus/rules_out
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - all
-          privileged: false
-          readOnlyRootFilesystem: true
       - name: evaluator
         image: {{.Values.images.ruleEvaluator.image}}:{{.Values.images.ruleEvaluator.tag}}
         args:
@@ -97,6 +64,39 @@ spec:
             path: /-/ready
           # Readiness attempts a query round-trip so we need a more generous timeout.
           timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
+          readOnlyRootFilesystem: true
+      - name: config-reloader
+        image: {{.Values.images.configReloader.image}}:{{.Values.images.configReloader.tag}}
+        args:
+        - --config-file=/prometheus/config/config.yaml
+        - --config-file-output=/prometheus/config_out/config.yaml
+        - --config-dir=/etc/rules
+        - --config-dir-output=/prometheus/rules_out
+        - --reload-url=http://127.0.0.1:9092/-/reload
+        - --ready-url=http://127.0.0.1:9092/-/ready
+        - --listen-address=:9093
+        ports:
+        - name: cfg-rel-metrics
+          protocol: TCP
+          containerPort: 9093
+        resources: {{- toYaml $.Values.resources.configReloader | nindent 10}}
+        volumeMounts:
+        - name: config
+          readOnly: true
+          mountPath: /prometheus/config
+        - name: config-out
+          mountPath: /prometheus/config_out
+        - name: rules
+          readOnly: true
+          mountPath: /etc/rules
+        - name: rules-out
+          mountPath: /prometheus/rules_out
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -130,44 +130,6 @@ spec:
         - name: config-out
           mountPath: /prometheus/config_out
       containers:
-      - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.4-gke.0
-        args:
-        - --config-file=/prometheus/config/config.yaml
-        - --config-file-output=/prometheus/config_out/config.yaml
-        - --config-dir=/etc/rules
-        - --config-dir-output=/prometheus/rules_out
-        - --reload-url=http://127.0.0.1:9092/-/reload
-        - --ready-url=http://127.0.0.1:9092/-/ready
-        - --listen-address=:9093
-        ports:
-        - name: cfg-rel-metrics
-          protocol: TCP
-          containerPort: 9093
-        resources:
-          limits:
-            memory: 32M
-          requests:
-            cpu: 1m
-            memory: 4M
-        volumeMounts:
-        - name: config
-          readOnly: true
-          mountPath: /prometheus/config
-        - name: config-out
-          mountPath: /prometheus/config_out
-        - name: rules
-          readOnly: true
-          mountPath: /etc/rules
-        - name: rules-out
-          mountPath: /prometheus/rules_out
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - all
-          privileged: false
-          readOnlyRootFilesystem: true
       - name: evaluator
         image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.15.4-gke.0
         args:
@@ -199,6 +161,44 @@ spec:
             path: /-/ready
           # Readiness attempts a query round-trip so we need a more generous timeout.
           timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
+          readOnlyRootFilesystem: true
+      - name: config-reloader
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.15.4-gke.0
+        args:
+        - --config-file=/prometheus/config/config.yaml
+        - --config-file-output=/prometheus/config_out/config.yaml
+        - --config-dir=/etc/rules
+        - --config-dir-output=/prometheus/rules_out
+        - --reload-url=http://127.0.0.1:9092/-/reload
+        - --ready-url=http://127.0.0.1:9092/-/ready
+        - --listen-address=:9093
+        ports:
+        - name: cfg-rel-metrics
+          protocol: TCP
+          containerPort: 9093
+        resources:
+          limits:
+            memory: 32M
+          requests:
+            cpu: 1m
+            memory: 4M
+        volumeMounts:
+        - name: config
+          readOnly: true
+          mountPath: /prometheus/config
+        - name: config-out
+          mountPath: /prometheus/config_out
+        - name: rules
+          readOnly: true
+          mountPath: /etc/rules
+        - name: rules-out
+          mountPath: /prometheus/rules_out
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
Due to Kustomize/JSON Patch limitations, it solves problems for us if the rule-evaluator container is first in the manifest. This allows us to reuse the same patch for P4SA.

Same as #1765, but for release/0.15 branch.