### PR TITLE
refactor: placeholder for p4sa modifications

### DIFF
--- a/charts/operator/templates/rule-evaluator.yaml
+++ b/charts/operator/templates/rule-evaluator.yaml
@@ -65,6 +65,8 @@ spec:
         ports:
         - name: r-eval-metrics
           containerPort: 19092
+        env:
+        - name: _GOOGLE_APPLICATION_CREDENTIALS # Placeholder for P4SA
         resources: {{- toYaml $.Values.resources.ruleEvaluator | nindent 10 }}
         volumeMounts:
         - name: config-out

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -678,6 +678,8 @@ spec:
         ports:
         - name: r-eval-metrics
           containerPort: 19092
+        env:
+        - name: _GOOGLE_APPLICATION_CREDENTIALS # Placeholder for P4SA
         resources:
           limits:
             memory: 1G


### PR DESCRIPTION
Kustomize cannot create paths that don't exist, so this change creates an empty env list that can be modififed by Kustomize later to add the P4SA token.