### PR TITLE
Split the config maps based on size while being created. So that many config maps are created with max size of 950KB and rule evaluator loads all configmaps to file for rules generator

### DIFF
--- a/charts/rule-evaluator/templates/deployment.yaml
+++ b/charts/rule-evaluator/templates/deployment.yaml
@@ -111,8 +111,21 @@ spec:
       - name: config-out
         emptyDir: {}
       - name: rules
-        configMap:
-          name: rules
+        # Mount exactly one ConfigMap per rule type (3 total)
+        # - rules: namespace-scoped Rules
+        # - clusterrules: cluster-scoped ClusterRules
+        # - globalrules: GlobalRules
+        projected:
+          sources:
+          - configMap:
+              name: rules
+              optional: true
+          - configMap:
+              name: clusterrules
+              optional: true
+          - configMap:
+              name: globalrules
+              optional: true
       - name: rules-out
         emptyDir: {}
       affinity:

--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -24,8 +24,6 @@ COPY go.sum go.sum
 COPY vendor* vendor
 COPY cmd cmd
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 # Install yq tool.
-
 ENV GOEXPERIMENT=boringcrypto
 ENV CGO_ENABLED=1
 ENV GOFIPS140=off
@@ -37,10 +35,11 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
         gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
+    VERSION=$(awk -F': ' '/^version:/ {print $2}' charts/values.global.yaml) && \
+    BUILD_DATE=$(date --iso-8601=seconds) && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CC=${CC} \
       go build \
-        -ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | yq '.version' ) \
-        -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
+        -ldflags="-X github.com/prometheus/common/version.Version=${VERSION} -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE}" \
 	-o config-reloader \
 	cmd/config-reloader/*.go
 

--- a/cmd/datasource-syncer/Dockerfile
+++ b/cmd/datasource-syncer/Dockerfile
@@ -24,8 +24,6 @@ COPY go.sum go.sum
 COPY vendor* vendor
 COPY cmd cmd
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 # Install yq tool.
-
 ENV GOEXPERIMENT=boringcrypto
 ENV CGO_ENABLED=1
 ENV GOFIPS140=off
@@ -37,10 +35,11 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
         gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
+    VERSION=$(awk -F': ' '/^version:/ {print $2}' charts/values.global.yaml) && \
+    BUILD_DATE=$(date --iso-8601=seconds) && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CC=${CC} \
       go build \
-        -ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | yq '.version' ) \
-        -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
+        -ldflags="-X github.com/prometheus/common/version.Version=${VERSION} -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE}" \
 	-o datasource-syncer \
 	cmd/datasource-syncer/*.go
 

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -37,8 +37,6 @@ WORKDIR /app
 COPY charts/values.global.yaml charts/values.global.yaml
 COPY --from=assets /app ./
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 # Install yq tool.
-
 ENV GOEXPERIMENT=boringcrypto
 ENV CGO_ENABLED=1
 ENV GOFIPS140=off
@@ -50,10 +48,11 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
         gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
+    VERSION=$(awk -F': ' '/^version:/ {print $2}' charts/values.global.yaml) && \
+    BUILD_DATE=$(date --iso-8601=seconds) && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CC=${CC} \
       go build \
-        -ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | yq ".version" ) \
-        -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
+        -ldflags="-X github.com/prometheus/common/version.Version=${VERSION} -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE}" \
 	-o frontend \
 	cmd/frontend/*.go
 

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -25,8 +25,6 @@ COPY vendor* vendor
 COPY cmd cmd
 COPY pkg pkg
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 # Install yq tool.
-
 ENV GOEXPERIMENT=boringcrypto
 ENV CGO_ENABLED=1
 ENV GOFIPS140=off
@@ -38,10 +36,11 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
         gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
+    VERSION=$(awk -F': ' '/^version:/ {print $2}' charts/values.global.yaml) && \
+    BUILD_DATE=$(date --iso-8601=seconds) && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CC=${CC} \
       go build \
-        -ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | yq '.version' ) \
-        -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
+        -ldflags="-X github.com/prometheus/common/version.Version=${VERSION} -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE}" \
 	-o operator \
 	cmd/operator/*.go
 

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -26,8 +26,6 @@ COPY cmd cmd
 COPY pkg pkg
 COPY internal internal
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3 # Install yq tool.
-
 ENV GOEXPERIMENT=boringcrypto
 ENV CGO_ENABLED=1
 ENV GOFIPS140=off
@@ -39,10 +37,11 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
         gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
+    VERSION=$(awk -F': ' '/^version:/ {print $2}' charts/values.global.yaml) && \
+    BUILD_DATE=$(date --iso-8601=seconds) && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CC=${CC} \
       go build \
-        -ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | yq '.version' ) \
-        -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
+        -ldflags="-X github.com/prometheus/common/version.Version=${VERSION} -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE}" \
 	-o rule-evaluator \
 	cmd/rule-evaluator/*.go
 

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -213,8 +213,18 @@ spec:
       - name: config-out
         emptyDir: {}
       - name: rules
-        configMap:
-          name: rules
+        # Mount exactly one ConfigMap per rule type (3 total)
+        projected:
+          sources:
+          - configMap:
+              name: rules
+              optional: true
+          - configMap:
+              name: clusterrules
+              optional: true
+          - configMap:
+              name: globalrules
+              optional: true
       - name: rules-out
         emptyDir: {}
       affinity:

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -214,6 +214,9 @@ spec:
         emptyDir: {}
       - name: rules
         # Mount exactly one ConfigMap per rule type (3 total)
+        # - rules: namespace-scoped Rules
+        # - clusterrules: cluster-scoped ClusterRules
+        # - globalrules: GlobalRules
         projected:
           sources:
           - configMap:

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -229,7 +229,7 @@ type RulesConfigUpdateStatus struct {
 
 func retryOperation(op func() error, maxRetries int, delay time.Duration) error {
 	var lastErr error
-	for i := 0; i < maxRetries; i++ {
+	for range maxRetries {
 		if err := op(); err != nil {
 			lastErr = err
 			time.Sleep(delay)
@@ -342,7 +342,7 @@ func (r *rulesReconciler) ensureRuleConfigs(ctx context.Context, projectID, loca
 	return anyErr
 }
 
-// createOrUpdateConfigMap creates or updates a single ConfigMap for a rule type
+// createOrUpdateConfigMap creates or updates a single ConfigMap for a rule type.
 func (r *rulesReconciler) createOrUpdateConfigMap(
 	ctx context.Context,
 	name string,
@@ -380,7 +380,7 @@ func (r *rulesReconciler) createOrUpdateConfigMap(
 	return updateStatus.ConfigMapResults[name]
 }
 
-// Helper to compress or not compress rule file content
+// Helper to compress or not compress rule file content.
 func setConfigMapDataRaw(buf *strings.Builder, compression monitoringv1.CompressionType, data string) error {
 	if compression == monitoringv1.CompressionGzip {
 		return errors.New("gzip compression not implemented in setConfigMapDataRaw")

--- a/pkg/operator/rules_test.go
+++ b/pkg/operator/rules_test.go
@@ -632,7 +632,7 @@ func applyScale(obj client.Object, scale *autoscalingv1.Scale) error {
 	return nil
 }
 
-// flakyClient simulates a client that fails the first update/create, then succeeds
+// flakyClient simulates a client that fails the first update/create, then succeeds.
 type flakyClient struct {
 	client.Client
 	failOnce map[string]bool
@@ -690,13 +690,13 @@ func TestEnsureRuleConfigs_SplitConfigMaps(t *testing.T) {
 		client: c,
 		opts:   Options{OperatorNamespace: "gmp-system"},
 	}
-	err := reconciler.ensureRuleConfigs(context.Background(), "proj", "loc", "cluster", monitoringv1.CompressionNone)
+	err := reconciler.ensureRuleConfigs(t.Context(), "proj", "loc", "cluster", monitoringv1.CompressionNone)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	var cmList corev1.ConfigMapList
-	if err := c.List(context.Background(), &cmList); err != nil {
+	if err := c.List(t.Context(), &cmList); err != nil {
 		t.Fatalf("listing configmaps: %v", err)
 	}
 
@@ -758,13 +758,13 @@ func TestEnsureRuleConfigs_InterruptionRecovery(t *testing.T) {
 	}
 
 	// First call: will fail once per ConfigMap, but retry and succeed
-	err := reconciler.ensureRuleConfigs(context.Background(), "proj", "loc", "cluster", monitoringv1.CompressionNone)
+	err := reconciler.ensureRuleConfigs(t.Context(), "proj", "loc", "cluster", monitoringv1.CompressionNone)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	var cmList corev1.ConfigMapList
-	if err := fc.List(context.Background(), &cmList); err != nil {
+	if err := fc.List(t.Context(), &cmList); err != nil {
 		t.Fatalf("listing configmaps: %v", err)
 	}
 	// Should have 3 ConfigMaps: rules, clusterrules, globalrules


### PR DESCRIPTION
**Why:**
Since the k8s configmaps have hard limit of 1MB, when there is a need of creating more GlobalRules, ClusterRules or Rules, all are going into one ConfigMap by rule-generator and from there it is being mounted as volume to rule-evaluator. Which brings the hard limit of alert definitions in one GKE cluster which is enabled the GMP can not go beyond 1 MB size.

This change will overcome that hard limit.