### PR TITLE
fix(config,operator): allow regex in ScrapeEndpoint.Port in 0.17

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -406,7 +406,6 @@ spec:
                         because port numbers are not unique across containers.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$
                       x-kubernetes-int-or-string: true
                       x-kubernetes-validations:
                       - message: Port is required

--- a/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -406,7 +406,6 @@ spec:
                         because port numbers are not unique across containers.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$
                       x-kubernetes-int-or-string: true
                       x-kubernetes-validations:
                       - message: Port is required

--- a/e2e/crd_validation_test.go
+++ b/e2e/crd_validation_test.go
@@ -118,7 +118,6 @@ func TestCRDDefaulting(t *testing.T) {
 					client.ObjectKeyFromObject(tc.obj),
 					tc.obj,
 				)
-
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)
 				}
@@ -146,7 +145,6 @@ func TestCRDDefaulting(t *testing.T) {
 					client.ObjectKeyFromObject(tc.obj),
 					tc.obj,
 				)
-
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)
 				}
@@ -533,6 +531,24 @@ func TestCRDValidation(t *testing.T) {
 					},
 				},
 				wantErr: true,
+			},
+			// Regression case for b/464455553.
+			"port using regex": {
+				obj: &monitoringv1.PodMonitoring{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "port-using-regex",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Interval: "1m",
+								Port:     intstr.FromString("metrics|maybe|apply-to_this(.*)|and-maybe(s?)"),
+							},
+						},
+					},
+				},
+				wantErr: false,
 			},
 			"duplicate port": {
 				obj: &monitoringv1.PodMonitoring{

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -648,7 +648,6 @@ spec:
                           because port numbers are not unique across containers.
                         maxLength: 253
                         minLength: 1
-                        pattern: ^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                           - message: Port is required
@@ -3005,7 +3004,6 @@ spec:
                           because port numbers are not unique across containers.
                         maxLength: 253
                         minLength: 1
-                        pattern: ^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                           - message: Port is required

--- a/pkg/operator/apis/monitoring/v1/pod_types.go
+++ b/pkg/operator/apis/monitoring/v1/pod_types.go
@@ -211,7 +211,6 @@ type ScrapeEndpoint struct {
 	// +kubebuilder:validation:XIntOrString
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern="^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$"
 	// +kubebuilder:validation:XValidation:rule="self != 0",message="Port is required"
 	// +required
 	Port intstr.IntOrString `json:"port,omitempty"`


### PR DESCRIPTION
Fix for b/464455553

Essentially, RE2 chars are allowed and make sense on port names as per [`__address__` logic](https://training.promlabs.com/training/relabeling/introduction-to-relabeling/hidden-labels-and-metadata/) we use in https://github.com/GoogleCloudPlatform/prometheus-engine/blob/release/0.17/pkg/operator/apis/monitoring/v1/pod_config.go#L348-L357 (in case of a string based port).