### PR TITLE
build(frontend): make embedded assets the default behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ bin-go:
 	@echo ">> building binaries"
 ifeq ($(NO_DOCKER), 1)
 	if [ "$(BIN_GO_NAME)" = "frontend" ]; then pkg/ui/build.sh; fi
-	CGO_ENABLED=0 go build -tags builtinassets -o ./build/bin/$(BIN_GO_NAME) ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/*.go
+	CGO_ENABLED=0 go build -o ./build/bin/$(BIN_GO_NAME) ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/*.go
 # If pushing, build and tag native arch image to GCR.
 else ifeq ($(DOCKER_PUSH), 1)
 	$(call docker_build, --tag gmp/$(BIN_GO_NAME) -f ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/Dockerfile .)

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -50,13 +50,11 @@ ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
 RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
       apt install -y --no-install-recommends \
-        -tags builtinassets \
         gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
       CC=aarch64-linux-gnu-gcc; \
     fi && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CC=${CC} \
       go build \
-        -tags builtinassets \
         -ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | go tool yq ".version" ) \
         -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
 	-o frontend \

--- a/pkg/ui/.gitignore
+++ b/pkg/ui/.gitignore
@@ -1,3 +1,2 @@
 /build
 /static
-/embed.go

--- a/pkg/ui/assets_embed.go
+++ b/pkg/ui/assets_embed.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build builtinassets
-// +build builtinassets
+//go:build !localassets
+// +build !localassets
 
 package ui
 

--- a/pkg/ui/assets_local.go
+++ b/pkg/ui/assets_local.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !builtinassets
+//go:build localassets
+// +build localassets
 
 package ui
 

--- a/pkg/ui/embed.go
+++ b/pkg/ui/embed.go
@@ -11,10 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build builtinassets
-// +build builtinassets
+//go:build !localassets
+// +build !localassets
 
 package ui
 
 import "embed"
 
+// Following line replaced by compress_assets.sh
+//{{go:embed}}
+
+var EmbedFS embed.FS

--- a/third_party/prometheus_ui/base/scripts/compress_assets.sh
+++ b/third_party/prometheus_ui/base/scripts/compress_assets.sh
@@ -5,12 +5,12 @@
 set -euo pipefail
 
 cd web/ui
-cp embed.go.tmpl embed.go
 
 GZIP_OPTS="-fk"
 # gzip option '-k' may not always exist in the latest gzip available on different distros.
 if ! gzip -k -h &>/dev/null; then GZIP_OPTS="-f"; fi
 
 find static -type f -name '*.gz' -delete
-find static -type f -exec gzip $GZIP_OPTS '{}' \; -print0 | xargs -0 -I % echo %.gz | xargs echo //go:embed >> embed.go
-echo var EmbedFS embed.FS >> embed.go
+find static -type f -exec gzip $GZIP_OPTS '{}' \;
+FILES=$(find static -name "*.gz" -type f | tr '\n' ' ')
+sed -i "s|// {{go:embed}}|//go:embed $FILES|" embed.go

--- a/third_party/prometheus_ui/base/web/ui/README.md
+++ b/third_party/prometheus_ui/base/web/ui/README.md
@@ -5,9 +5,7 @@ into the Prometheus binary using the embed package.
 
 During development it is more convenient to always use the files on disk to 
 directly see changes without recompiling.
-To make this work, remove the `builtinassets` build tag in the `flags` entry
-in `.promu.yml`, and then `make build` (or build Prometheus using
-`go build ./cmd/prometheus`).
+To make this work, add the `localassets` build tag in the `go build` command in `make` that builds the frontend (add `-tags localassets`) and then `make build` as usual.
 
 This will serve all files from your local filesystem. This is for development purposes only.
 


### PR DESCRIPTION
Inverts the build tag logic to ensure that standard `go build` commands produce self-contained binaries with embedded assets. The dev workflow allowing for live updates must be explicitly specified now.