### PR TITLE
build: relax linter config for maintenance mode in release/0.12

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,66 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# The release/0.12 linter is set to a minimal maintnance mode.
+# Code style & non-critical issues should be resolved in
+# main to prevent accidental breakage.
+
 linters:
-  enable-all: true
-  disable:
-    - containedctx
-    - contextcheck
-    - cyclop
-    - deadcode # Deprecated
-    - depguard
-    - errorlint
-    - exhaustive
-    - exhaustivestruct
-    - exhaustruct # Deprecated
-    - exportloopref
-    - forbidigo
-    - forcetypeassert
-    - funlen
-    - gci
-    - gochecknoglobals
-    - gocognit
-    - goconst
-    - gocritic
-    - gocyclo
-    - godox
-    - goerr113
-    - gofumpt
-    - golint # Deprecated
-    - gomnd
-    - gomoddirectives
-    - gosec
-    - ifshort # Deprecated
-    - inamedparam
-    - interfacer # Deprecated
-    - ireturn
-    - lll
-    - maintidx
-    - maligned # Deprecated
-    - nestif
-    - nilnil
-    - nlreturn
-    - noctx
-    - nonamedreturns
-    - nosnakecase # Deprecated
-    - nosprintfhostport
-    - paralleltest
-    - perfsprint
-    - prealloc
-    - protogetter
-    - scopelint # Deprecated
-    - structcheck # Deprecated
-    - stylecheck
-    - tagliatelle
-    - testpackage
-    - thelper
-    - tparallel
-    - unparam
-    - varcheck # Deprecated
-    - varnamelen
-    - wastedassign
-    - wrapcheck
-    - wsl
+  disable-all: true
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - typecheck
+    - unused
+    - gosimple
+    - ineffassign
+
 linters-settings:
   importas:
     no-unaliased: true
@@ -84,151 +40,15 @@ linters-settings:
       alias: apierrors
     - pkg: "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
       alias: monitoringv1
-  revive:
-    enable-all-rules: true
-    rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
-      - name: add-constant
-        severity: warning
-        disabled: true
-        arguments:
-          - maxLitCount: "3"
-            allowStrs: '""'
-            allowInts: "0,1,2"
-            allowFloats: "0.0,0.,1.0,1.,2.0,2."
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bare-return
-      - name: bare-return
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cognitive-complexity
-      - name: cognitive-complexity
-        severity: warning
-        disabled: true
-        arguments: [7]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comment-spacings
-      - name: comment-spacings
-        severity: warning
-        disabled: true
-        arguments:
-          - mypragma
-          - otherpragma
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-naming
-      - name: confusing-naming
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cyclomatic
-      - name: cyclomatic
-        severity: warning
-        disabled: true
-        arguments: [3]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#defer
-      - name: defer
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
-      - name: duplicated-imports
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
-      - name: exported
-        severity: warning
-        disabled: true
-        arguments:
-          - "checkPrivateReceivers"
-          - "disableStutteringCheck"
-          - "sayRepetitiveInsteadOfStutters"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#flag-parameter
-      - name: flag-parameter
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-length
-      - name: function-length
-        severity: warning
-        disabled: true
-        arguments: [10, 0]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-result-limit
-      - name: function-result-limit
-        severity: warning
-        disabled: true
-        arguments: [2]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
-      - name: if-return
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-alias-naming
-      - name: import-alias-naming
-        severity: warning
-        disabled: true
-        arguments:
-          - "^[a-z][a-z0-9]{0,}$"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-shadowing
-      - name: import-shadowing
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#line-length-limit
-      - name: line-length-limit
-        severity: warning
-        disabled: true
-        arguments: [80]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-public-structs
-      - name: max-public-structs
-        severity: warning
-        disabled: true
-        arguments: [3]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#package-comments
-      - name: package-comments
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-address
-      - name: range-val-address
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-import-alias
-      - name: redundant-import-alias
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
-      - name: struct-tag
-        arguments:
-          - "json,inline"
-          - "bson,outline,gnu"
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-equal
-      - name: time-equal
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unchecked-type-assertion
-      - name: unchecked-type-assertion
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
-      - name: unhandled-error
-        severity: warning
-        disabled: true
-        arguments:
-          - "fmt.Printf"
-          - "myFunction"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
-      - name: unused-receiver
-        severity: warning
-        disabled: true
-        arguments:
-          - allowRegex: "^_"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#use-any
-      - name: use-any
-        severity: warning
-        disabled: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
-      - name: useless-break
-        severity: warning
-        disabled: true
 issues:
   exclude-use-default: false
   exclude:
     # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
-    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
-  exclude-rules:
-  - path: _test\.go
-    linters:
-    - dupl
+    # Allow ignore errors on stdout/stderr/printing
+    - 'Error return value of .((os\.)?std(out|err)\..*|.*printf?). is not checked'
+    # Allow ignore errors on Close/Flush
+    - 'Error return value of .*Close. is not checked'
+    - 'Error return value of .*Flush. is not checked'
+    # Allow ignore errors on Remove/Setenv
+    - 'Error return value of os\.Remove(All)?. is not checked'
+    - 'Error return value of os\.(Un)?Setenv. is not checked'


### PR DESCRIPTION
Switch golangci-lint from `enable-all: true` strategy to an allowlist one. The release/0.12 branch is strictly for dependency updates & vulnerability fixes.

The previous configuration caused unrelated build failures whenever golangci-lint added new linters (e.g., `usetesting`) or updated style rules (e.g., `revive`).