### PR TITLE
fix: prevent panic of rule-evaluator on shutdown

### DIFF
--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -1050,6 +1050,7 @@ func (e *ruleEvaluator) Stop() {
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
 	e.rulesManager.Stop()
+	e.rulesManager = nil
 }
 
 func newQueryFunc(logger log.Logger, v1api v1.API) rules.QueryFunc {


### PR DESCRIPTION
The rule-evaluator contained a bug where it would attempt to restart the rule evalutor manager during shutdown, and would reuse a done channel that had already been closed, resulting in a panic. This change signals the manager when an interrupt is received, and does not attempt to restart it.