### PR TITLE
Add OperatorConfig validation tests

### DIFF
--- a/e2e/crd_validation_test.go
+++ b/e2e/crd_validation_test.go
@@ -23,6 +23,7 @@ import (
 
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
 	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -575,6 +576,209 @@ func TestCRDValidation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "config",
 						Namespace: "invalid-namespace",
+					},
+				},
+				wantErr: true,
+			},
+			"bad scrape interval": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-bad-scrape-interval",
+						Namespace: "gmp-public",
+					},
+					Collection: monitoringv1.CollectionSpec{
+						KubeletScraping: &monitoringv1.KubeletScraping{
+							Interval: "xyz",
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"missing collection credentials secret key": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-missing-collection-credentials",
+						Namespace: "gmp-public",
+					},
+					Collection: monitoringv1.CollectionSpec{
+						Credentials: &v1.SecretKeySelector{},
+					},
+				},
+				wantErr: true,
+			},
+			"bad generator URL": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-bad-generator-url",
+						Namespace: "gmp-public",
+					},
+					Rules: monitoringv1.RuleEvaluatorSpec{
+						GeneratorURL: "~:://example.com",
+					},
+				},
+				wantErr: true,
+			},
+			"missing rule manager credentials secret key": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-missing-rule-manager-credentials",
+						Namespace: "gmp-public",
+					},
+					Rules: monitoringv1.RuleEvaluatorSpec{
+						Credentials: &v1.SecretKeySelector{},
+					},
+				},
+				wantErr: true,
+			},
+			"missing managed alert manager config secret key": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-missing-alert-manager-secret",
+						Namespace: "gmp-public",
+					},
+					ManagedAlertmanager: &monitoringv1.ManagedAlertmanagerSpec{
+						ConfigSecret: &v1.SecretKeySelector{},
+					},
+				},
+				wantErr: true,
+			},
+			"rule manager authorization credentials secret key missing": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-missing-rule-auth-secret",
+						Namespace: "gmp-public",
+					},
+					Rules: monitoringv1.RuleEvaluatorSpec{
+						Alerting: monitoringv1.AlertingSpec{
+							Alertmanagers: []monitoringv1.AlertmanagerEndpoints{{
+								Name: "bar",
+								TLS:  &monitoringv1.TLSConfig{},
+								Authorization: &monitoringv1.Authorization{
+									Credentials: &v1.SecretKeySelector{},
+								},
+							}},
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"rule manager TLS secret key missing": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-missing-tls-secret-key",
+						Namespace: "gmp-public",
+					},
+					Rules: monitoringv1.RuleEvaluatorSpec{
+						Alerting: monitoringv1.AlertingSpec{
+							Alertmanagers: []monitoringv1.AlertmanagerEndpoints{{
+								Name: "bar",
+								TLS: &monitoringv1.TLSConfig{
+									KeySecret: &v1.SecretKeySelector{},
+								},
+							}},
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"rule manager TLS CA mutually exclusive": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-tls-ca-mutually-exclusive",
+						Namespace: "gmp-public",
+					},
+					Rules: monitoringv1.RuleEvaluatorSpec{
+						Alerting: monitoringv1.AlertingSpec{
+							Alertmanagers: []monitoringv1.AlertmanagerEndpoints{{
+								Name: "bar",
+								TLS: &monitoringv1.TLSConfig{
+									CA: &monitoringv1.SecretOrConfigMap{
+										Secret: &v1.SecretKeySelector{
+											LocalObjectReference: v1.LocalObjectReference{
+												Name: "baz",
+											},
+										},
+										ConfigMap: &v1.ConfigMapKeySelector{
+											LocalObjectReference: v1.LocalObjectReference{
+												Name: "qux",
+											},
+										},
+									},
+								},
+							}},
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"rule manager TLS CA secret key missing": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-tls-ca-secret-key-missing",
+						Namespace: "gmp-public",
+					},
+					Rules: monitoringv1.RuleEvaluatorSpec{
+						Alerting: monitoringv1.AlertingSpec{
+							Alertmanagers: []monitoringv1.AlertmanagerEndpoints{{
+								Name: "bar",
+								TLS: &monitoringv1.TLSConfig{
+									CA: &monitoringv1.SecretOrConfigMap{
+										Secret: &v1.SecretKeySelector{},
+									},
+								},
+							}},
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"rule manager TLS Cert mutually exclusive": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-tls-cert-mutually-exclusive",
+						Namespace: "gmp-public",
+					},
+					Rules: monitoringv1.RuleEvaluatorSpec{
+						Alerting: monitoringv1.AlertingSpec{
+							Alertmanagers: []monitoringv1.AlertmanagerEndpoints{{
+								Name: "bar",
+								TLS: &monitoringv1.TLSConfig{
+									Cert: &monitoringv1.SecretOrConfigMap{
+										Secret: &v1.SecretKeySelector{
+											LocalObjectReference: v1.LocalObjectReference{
+												Name: "baz",
+											},
+										},
+										ConfigMap: &v1.ConfigMapKeySelector{
+											LocalObjectReference: v1.LocalObjectReference{
+												Name: "qux",
+											},
+										},
+									},
+								},
+							}},
+						},
+					},
+				},
+				wantErr: true,
+			},
+			"rule manager TLS Cert secret key missing": {
+				obj: &monitoringv1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-tls-cert-secret-key-missing",
+						Namespace: "gmp-public",
+					},
+					Rules: monitoringv1.RuleEvaluatorSpec{
+						Alerting: monitoringv1.AlertingSpec{
+							Alertmanagers: []monitoringv1.AlertmanagerEndpoints{{
+								Name: "bar",
+								TLS: &monitoringv1.TLSConfig{
+									Cert: &monitoringv1.SecretOrConfigMap{
+										Secret: &v1.SecretKeySelector{},
+									},
+								},
+							}},
+						},
 					},
 				},
 				wantErr: true,

--- a/pkg/operator/apis/monitoring/v1/operator_types_test.go
+++ b/pkg/operator/apis/monitoring/v1/operator_types_test.go
@@ -278,6 +278,68 @@ func TestOperatorConfigValidate(t *testing.T) {
 			err: "invalid rules config: invalid alert manager endpoint `bar` (index 0): invalid TLS CA: missing secret key selector name",
 		},
 		{
+			desc: "rule manager TLS CA mutually exclusive",
+			oc: &OperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "config",
+				},
+				Rules: RuleEvaluatorSpec{
+					Alerting: AlertingSpec{
+						Alertmanagers: []AlertmanagerEndpoints{{
+							Name: "bar",
+							TLS: &TLSConfig{
+								CA: &SecretOrConfigMap{
+									Secret: &v1.SecretKeySelector{
+										LocalObjectReference: v1.LocalObjectReference{
+											Name: "baz",
+										},
+									},
+									ConfigMap: &v1.ConfigMapKeySelector{
+										LocalObjectReference: v1.LocalObjectReference{
+											Name: "qux",
+										},
+									},
+								},
+							},
+						}},
+					},
+				},
+			},
+			err: "invalid rules config: invalid alert manager endpoint `bar` (index 0): invalid TLS CA: SecretOrConfigMap fields are mutually exclusive",
+		},
+		{
+			desc: "rule manager TLS Cert mutually exclusive",
+			oc: &OperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "config",
+				},
+				Rules: RuleEvaluatorSpec{
+					Alerting: AlertingSpec{
+						Alertmanagers: []AlertmanagerEndpoints{{
+							Name: "bar",
+							TLS: &TLSConfig{
+								Cert: &SecretOrConfigMap{
+									Secret: &v1.SecretKeySelector{
+										LocalObjectReference: v1.LocalObjectReference{
+											Name: "baz",
+										},
+									},
+									ConfigMap: &v1.ConfigMapKeySelector{
+										LocalObjectReference: v1.LocalObjectReference{
+											Name: "qux",
+										},
+									},
+								},
+							},
+						}},
+					},
+				},
+			},
+			err: "invalid rules config: invalid alert manager endpoint `bar` (index 0): invalid TLS Cert: SecretOrConfigMap fields are mutually exclusive",
+		},
+		{
 			desc: "rule manager TLS CA secret key",
 			oc: &OperatorConfig{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Added tests for OperatorConfig validation including mutual exclusivity and edge cases in interval and URL configurations, in response to the user request.

---
*PR created automatically by Jules for task [4736691683968907047](https://jules.google.com/task/4736691683968907047) started by @bernot-dev*