### PR TITLE
docs: correct spelling of Kubernetes

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_clusterpodmonitorings.yaml
@@ -1035,7 +1035,7 @@ spec:
                         onto a Prometheus target.
                       properties:
                         from:
-                          description: Kubenetes resource label to remap.
+                          description: Kubernetes resource label to remap.
                           type: string
                         to:
                           description: |-

--- a/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_podmonitorings.yaml
@@ -1053,7 +1053,7 @@ spec:
                         onto a Prometheus target.
                       properties:
                         from:
-                          description: Kubenetes resource label to remap.
+                          description: Kubernetes resource label to remap.
                           type: string
                         to:
                           description: |-

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -1241,7 +1241,7 @@ spec:
                           onto a Prometheus target.
                         properties:
                           from:
-                            description: Kubenetes resource label to remap.
+                            description: Kubernetes resource label to remap.
                             type: string
                           to:
                             description: |-
@@ -3641,7 +3641,7 @@ spec:
                           onto a Prometheus target.
                         properties:
                           from:
-                            description: Kubenetes resource label to remap.
+                            description: Kubernetes resource label to remap.
                             type: string
                           to:
                             description: |-

--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -291,7 +291,7 @@ type TargetLabels struct {
 // LabelMapping specifies how to transfer a label from a Kubernetes resource
 // onto a Prometheus target.
 type LabelMapping struct {
-	// Kubenetes resource label to remap.
+	// Kubernetes resource label to remap.
 	From string `json:"from"`
 	// Remapped Prometheus target label.
 	// Defaults to the same name as `From`.


### PR DESCRIPTION
Hey team, sorry for the spellcheck PR. This got caught by my linter and I thought I would contribute back. Docs change only, does not impact v1alpha1 api functionality.