### PR TITLE
build: revert Go native certified FIPS 140-3 cryptography on main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ bin-go:
 	@echo ">> building binaries"
 ifeq ($(NO_DOCKER), 1)
 	if [ "$(BIN_GO_NAME)" = "frontend" ]; then pkg/ui/build.sh; fi
-	CGO_ENABLED=0 GOEXPERIMENT=noboringcrypto GOFIPS140=certified go build -tags builtinassets -o ./build/bin/$(BIN_GO_NAME) ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/*.go
+	CGO_ENABLED=0 go build -tags builtinassets -o ./build/bin/$(BIN_GO_NAME) ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/*.go
 # If pushing, build and tag native arch image to GCR.
 else ifeq ($(DOCKER_PUSH), 1)
 	$(call docker_build, --tag gmp/$(BIN_GO_NAME) -f ./$(BIN_GO_DIR)/$(BIN_GO_NAME)/Dockerfile .)

--- a/cmd/config-reloader/Dockerfile
+++ b/cmd/config-reloader/Dockerfile
@@ -15,6 +15,7 @@
 FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.26.4@sha256:3444149d0a7e3f7cfb9c2db65f0f75676fe6ad04de3ce72674efb120c08dd1c1 AS buildbase
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILDARCH
 WORKDIR /app
 COPY charts/values.global.yaml charts/values.global.yaml
 COPY go.mod go.mod
@@ -25,19 +26,29 @@ COPY tools tools
 COPY vendor* vendor
 COPY cmd cmd
 
-ENV GOEXPERIMENT=noboringcrypto
-ENV CGO_ENABLED=0
-ENV GOFIPS140=certified
+ENV GOEXPERIMENT=boringcrypto
+ENV CGO_ENABLED=1
+ENV GOFIPS140=off
 ENV GOTOOLCHAIN=local
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
-RUN go build \
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
+	export CC=aarch64-linux-gnu-gcc; \
+	elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-x86-64-linux-gnu libc6-dev-amd64-cross; \
+	export CC=x86_64-linux-gnu-gcc; \
+	fi && \
+	GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+	go build \
 	-ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | go tool -modfile="tools/go.mod" yq '.version' ) \
 	-X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
 	-o config-reloader \
 	cmd/config-reloader/*.go
 
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
+FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20260307.00_p0@sha256:d5c073079125b887158bb1dd0ee4da49b39a08203c3c96124ee310962dd5aae2
 COPY --from=buildbase /app/config-reloader /bin/config-reloader
 ENTRYPOINT ["/bin/config-reloader"]

--- a/cmd/config-reloader/boring.go
+++ b/cmd/config-reloader/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build experiment.boringcrypto
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)

--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"crypto/fips140"
 	"flag"
 	"net/http"
 	"net/url"
@@ -61,11 +60,6 @@ func main() {
 	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
-
-	if !fips140.Enabled() {
-		_ = level.Error(logger).Log("msg", "FIPS mode is required by security policy but could not be initialized")
-		os.Exit(1)
-	}
 
 	if *configDirOutput != "" && *configDir == "" {
 		//nolint:errcheck

--- a/cmd/datasource-syncer/Dockerfile
+++ b/cmd/datasource-syncer/Dockerfile
@@ -15,6 +15,7 @@
 FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.26.4@sha256:3444149d0a7e3f7cfb9c2db65f0f75676fe6ad04de3ce72674efb120c08dd1c1 AS buildbase
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILDARCH
 WORKDIR /app
 COPY charts/values.global.yaml charts/values.global.yaml
 COPY go.mod go.mod
@@ -25,20 +26,30 @@ COPY tools tools
 COPY vendor* vendor
 COPY cmd cmd
 
-ENV GOEXPERIMENT=noboringcrypto
-ENV CGO_ENABLED=0
-ENV GOFIPS140=certified
+ENV GOEXPERIMENT=boringcrypto
+ENV CGO_ENABLED=1
+ENV GOFIPS140=off
 ENV GOTOOLCHAIN=local
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
-RUN go build \
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
+	export CC=aarch64-linux-gnu-gcc; \
+	elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-x86-64-linux-gnu libc6-dev-amd64-cross; \
+	export CC=x86_64-linux-gnu-gcc; \
+	fi && \
+	GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+	go build \
 	-ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | go tool -modfile="tools/go.mod" yq '.version' ) \
 	-X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
 	-o datasource-syncer \
 	cmd/datasource-syncer/*.go
 
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
+FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20260307.00_p0@sha256:d5c073079125b887158bb1dd0ee4da49b39a08203c3c96124ee310962dd5aae2
 COPY --from=buildbase /app/datasource-syncer /bin/datasource-syncer
 ENTRYPOINT ["/bin/datasource-syncer"]
 

--- a/cmd/datasource-syncer/boring.go
+++ b/cmd/datasource-syncer/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build experiment.boringcrypto
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)

--- a/cmd/datasource-syncer/main.go
+++ b/cmd/datasource-syncer/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"crypto/fips140"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -66,11 +65,6 @@ func main() {
 	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
-
-	if !fips140.Enabled() {
-		_ = level.Error(logger).Log("msg", "FIPS mode is required by security policy but could not be initialized")
-		os.Exit(1)
-	}
 
 	if len(*datasourceUIDList) == 0 {
 		//nolint:errcheck

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -40,17 +40,28 @@ COPY --from=assets /app/pkg/ui/static pkg/ui/static
 FROM buildbase AS appbase
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILDARCH
 WORKDIR /app
 COPY charts/values.global.yaml charts/values.global.yaml
 COPY --from=assets /app ./
 
-ENV GOEXPERIMENT=noboringcrypto
-ENV CGO_ENABLED=0
-ENV GOFIPS140=certified
+ENV GOEXPERIMENT=boringcrypto
+ENV CGO_ENABLED=1
+ENV GOFIPS140=off
 ENV GOTOOLCHAIN=local
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
-RUN go build \
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
+	export CC=aarch64-linux-gnu-gcc; \
+	elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-x86-64-linux-gnu libc6-dev-amd64-cross; \
+	export CC=x86_64-linux-gnu-gcc; \
+	fi && \
+	GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+	go build \
 	-tags builtinassets \
 	-ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | go tool -modfile="tools/go.mod" yq ".version" ) \
 	-X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
@@ -58,6 +69,6 @@ RUN go build \
 	cmd/frontend/*.go
 
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
+FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20260307.00_p0@sha256:d5c073079125b887158bb1dd0ee4da49b39a08203c3c96124ee310962dd5aae2
 COPY --from=appbase /app/frontend /bin/frontend
 ENTRYPOINT ["/bin/frontend"]

--- a/cmd/frontend/boring.go
+++ b/cmd/frontend/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build experiment.boringcrypto
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"context"
-	"crypto/fips140"
 	"errors"
 	"flag"
 	"fmt"
@@ -85,11 +84,6 @@ func main() {
 	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
-
-	if !fips140.Enabled() {
-		_ = level.Error(logger).Log("msg", "FIPS mode is required by security policy but could not be initialized")
-		os.Exit(1)
-	}
 
 	switch strings.ToLower(*logLevel) {
 	case "debug":

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -15,6 +15,7 @@
 FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.26.4@sha256:3444149d0a7e3f7cfb9c2db65f0f75676fe6ad04de3ce72674efb120c08dd1c1 AS buildbase
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILDARCH
 WORKDIR /app
 COPY charts/values.global.yaml charts/values.global.yaml
 COPY go.mod go.mod
@@ -26,19 +27,29 @@ COPY vendor* vendor
 COPY cmd cmd
 COPY pkg pkg
 
-ENV GOEXPERIMENT=noboringcrypto
-ENV CGO_ENABLED=0
-ENV GOFIPS140=certified
+ENV GOEXPERIMENT=boringcrypto
+ENV CGO_ENABLED=1
+ENV GOFIPS140=off
 ENV GOTOOLCHAIN=local
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
-RUN go build \
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
+	export CC=aarch64-linux-gnu-gcc; \
+	elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-x86-64-linux-gnu libc6-dev-amd64-cross; \
+	export CC=x86_64-linux-gnu-gcc; \
+	fi && \
+	GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+	go build \
 	-ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | go tool -modfile="tools/go.mod" yq '.version' ) \
 	-X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
 	-o operator \
 	cmd/operator/*.go
 
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
+FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20260307.00_p0@sha256:d5c073079125b887158bb1dd0ee4da49b39a08203c3c96124ee310962dd5aae2
 COPY --from=buildbase /app/operator /bin/operator
 ENTRYPOINT ["/bin/operator"]

--- a/cmd/operator/boring.go
+++ b/cmd/operator/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build experiment.boringcrypto
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"crypto/fips140"
 	"errors"
 	"flag"
 	"net/http"
@@ -93,11 +92,6 @@ func main() {
 	ctrl.SetLogger(logger)
 	if err := errors.Join(errList...); err != nil {
 		logger.Error(err, "unable to fetch Google Cloud metadata")
-	}
-
-	if !fips140.Enabled() {
-		logger.Error(errors.New("FIPS mode required"), "FIPS mode is required by security policy but could not be initialized")
-		os.Exit(1)
 	}
 
 	cfg, err := ctrl.GetConfig()

--- a/cmd/rule-evaluator/Dockerfile
+++ b/cmd/rule-evaluator/Dockerfile
@@ -15,6 +15,7 @@
 FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.26.4@sha256:3444149d0a7e3f7cfb9c2db65f0f75676fe6ad04de3ce72674efb120c08dd1c1 AS buildbase
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILDARCH
 WORKDIR /app
 COPY charts/values.global.yaml charts/values.global.yaml
 COPY go.mod go.mod
@@ -27,19 +28,29 @@ COPY cmd cmd
 COPY pkg pkg
 COPY internal internal
 
-ENV GOEXPERIMENT=noboringcrypto
-ENV CGO_ENABLED=0
-ENV GOFIPS140=certified
+ENV GOEXPERIMENT=boringcrypto
+ENV CGO_ENABLED=1
+ENV GOFIPS140=off
 ENV GOTOOLCHAIN=local
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
-RUN go build \
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
+	export CC=aarch64-linux-gnu-gcc; \
+	elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-x86-64-linux-gnu libc6-dev-amd64-cross; \
+	export CC=x86_64-linux-gnu-gcc; \
+	fi && \
+	GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+	go build \
 	-ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | go tool -modfile="tools/go.mod" yq '.version' ) \
 	-X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
 	-o rule-evaluator \
 	cmd/rule-evaluator/*.go
 
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
+FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20260307.00_p0@sha256:d5c073079125b887158bb1dd0ee4da49b39a08203c3c96124ee310962dd5aae2
 COPY --from=buildbase /app/rule-evaluator /bin/rule-evaluator
 ENTRYPOINT ["/bin/rule-evaluator"]

--- a/cmd/rule-evaluator/boring.go
+++ b/cmd/rule-evaluator/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build experiment.boringcrypto
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"crypto/fips140"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -106,11 +105,6 @@ func main() {
 	logger := log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
-
-	if !fips140.Enabled() {
-		_ = level.Error(logger).Log("msg", "FIPS mode is required by security policy but could not be initialized")
-		os.Exit(1)
-	}
 
 	a := kingpin.New("rule", "The Prometheus Rule Evaluator")
 	logLevel := a.Flag("log.level",

--- a/examples/instrumentation/go-synthetic/Dockerfile
+++ b/examples/instrumentation/go-synthetic/Dockerfile
@@ -13,20 +13,31 @@
 # limitations under the License.
 
 FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.26.4@sha256:3444149d0a7e3f7cfb9c2db65f0f75676fe6ad04de3ce72674efb120c08dd1c1 AS buildbase
-ARG TARGETOS
-ARG TARGETARCH
 WORKDIR /app
 COPY . ./
 
 FROM buildbase AS appbase
+ARG TARGETOS
+ARG TARGETARCH
+ARG BUILDARCH
 
-ENV GOEXPERIMENT=noboringcrypto
-ENV CGO_ENABLED=0
-ENV GOFIPS140=certified
+ENV GOEXPERIMENT=boringcrypto
+ENV CGO_ENABLED=1
+ENV GOFIPS140=off
 ENV GOOS=${TARGETOS}
 ENV GOARCH=${TARGETARCH}
-RUN go build -o go-synthetic ./examples/instrumentation/go-synthetic
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
+	export CC=aarch64-linux-gnu-gcc; \
+	elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-x86-64-linux-gnu libc6-dev-amd64-cross; \
+	export CC=x86_64-linux-gnu-gcc; \
+	fi && \
+	GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+	go build -o go-synthetic ./examples/instrumentation/go-synthetic
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
+FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20260307.00_p0@sha256:d5c073079125b887158bb1dd0ee4da49b39a08203c3c96124ee310962dd5aae2
 COPY --from=appbase /app/go-synthetic /bin/go-synthetic
 ENTRYPOINT ["/bin/go-synthetic"]

--- a/hack/format_help.sh
+++ b/hack/format_help.sh
@@ -26,4 +26,4 @@ BIN_PATH=$1
 # Print the command --help, but remove the full path (which is in tmp dir when
 # build through go run) and potential debug logs because as GCE_METADATA_HOST is
 # broken for purpose for consistent defaults.
-GCE_METADATA_HOST="disabled" GOEXPERIMENT=noboringcrypto GOFIPS140=certified go run "${REPO_ROOT}/cmd/${BIN_PATH}" --help 2>&1 >/dev/null | sed 's/^Usage of \/.*\//Usage of /' | sed '/.*http:\/\/disabled\/.*/d'
+GCE_METADATA_HOST="disabled" go run "${REPO_ROOT}/cmd/${BIN_PATH}" --help 2>&1 >/dev/null | sed 's/^Usage of \/.*\//Usage of /' | sed '/.*http:\/\/disabled\/.*/d'


### PR DESCRIPTION
This replicates the approach from PR #1952 onto the main branch, reverting the adoption of Go 1.26 native FIPS mode (`crypto/fips140`, `GOFIPS140=certified`) and restoring dynamic linking with `BoringCrypto` (`gke-distroless/libc`, `GOEXPERIMENT=boringcrypto`, `CGO_ENABLED=1`), without altering `golangci-lint` configuration.