### PR TITLE
PO to GMP Migration Tool: Orchestrator & CLI Boilerplate

### DIFF
--- a/cmd/gmp-migrate/Dockerfile
+++ b/cmd/gmp-migrate/Dockerfile
@@ -1,0 +1,55 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.26.4@sha256:3444149d0a7e3f7cfb9c2db65f0f75676fe6ad04de3ce72674efb120c08dd1c1 AS buildbase
+ARG TARGETOS
+ARG TARGETARCH
+ARG BUILDARCH
+WORKDIR /app
+COPY charts/values.global.yaml charts/values.global.yaml
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY tools tools
+# Copy the Go vendor directory only if it exists. Vendor folder will automatically
+# cause 'go build' to use -mod=vendor flag (otherwise -mod=mod is used).
+COPY vendor* vendor
+COPY cmd cmd
+COPY pkg pkg
+
+ENV GOEXPERIMENT=boringcrypto
+ENV CGO_ENABLED=1
+ENV GOFIPS140=off
+ENV GOTOOLCHAIN=local
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
+	export CC=aarch64-linux-gnu-gcc; \
+	elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
+	apt-get update && apt-get install -y --no-install-recommends \
+	gcc-x86-64-linux-gnu libc6-dev-amd64-cross; \
+	export CC=x86_64-linux-gnu-gcc; \
+	fi && \
+	GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+	go build \
+	-ldflags="-X github.com/prometheus/common/version.Version=$(cat charts/values.global.yaml | go tool -modfile="tools/go.mod" yq '.version' ) \
+	-X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
+	-o gmp-migrate \
+	cmd/gmp-migrate/*.go
+
+
+FROM gke.gcr.io/gke-distroless/libc:gke_distroless_20260307.00_p0@sha256:d5c073079125b887158bb1dd0ee4da49b39a08203c3c96124ee310962dd5aae2
+COPY --from=buildbase /app/gmp-migrate /bin/gmp-migrate
+ENTRYPOINT ["/bin/gmp-migrate"]

--- a/cmd/gmp-migrate/README.md
+++ b/cmd/gmp-migrate/README.md
@@ -1,0 +1,6 @@
+# gmp-migrate
+
+`gmp-migrate` is a tool designed to migrate Prometheus Operator resources to Google Cloud Managed Service for Prometheus (GMP) resources.
+
+> [!WARNING]
+> This tool is currently **experimental** and a **work-in-progress (WIP)**. It is not ready for use.

--- a/cmd/gmp-migrate/main.go
+++ b/cmd/gmp-migrate/main.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/gmp-migrate/main.go
+++ b/cmd/gmp-migrate/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/migrate"
+	"github.com/alecthomas/kingpin/v2"
+)
+
+var (
+	// Flags.
+	inputFile = kingpin.Flag("file", "Input source (YAML file, directory, or '-' for stdin)").Short('f').Required().String()
+)
+
+func main() {
+	kingpin.CommandLine.Help = "Migrate Prometheus Operator configurations to Google Managed Prometheus (GMP)."
+	kingpin.Parse()
+
+	migrator := migrate.NewMigrator()
+	_, err := migrator.Run(*inputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[ERROR] Migration failed: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/gmp-migrate/main.go
+++ b/cmd/gmp-migrate/main.go
@@ -83,6 +83,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Print the standardized summary to Stderr using the migrator's stream
+	migrator.PrintSummary(report)
+
 	// If any resource failed to migrate, exit with a non-zero code.
 	if report.FailedCount > 0 {
 		slog.Error("Migration completed with failures", slog.Int("failures", report.FailedCount))

--- a/cmd/gmp-migrate/main.go
+++ b/cmd/gmp-migrate/main.go
@@ -62,7 +62,10 @@ func main() {
 			slog.Any("arguments", flag.Args()),
 		)
 		fmt.Fprintln(os.Stderr, "\nAll input files and directories must be explicitly passed using the -f or --file flags. For example:")
-		fmt.Fprintf(os.Stderr, "  %s -f %s -f %s\n\n", os.Args[0], inputFiles.String(), strings.Join(flag.Args(), " -f "))
+		var allInputs []string
+		allInputs = append(allInputs, inputFiles...)
+		allInputs = append(allInputs, flag.Args()...)
+		fmt.Fprintf(os.Stderr, "  %s -f %s\n\n", os.Args[0], strings.Join(allInputs, " -f "))
 		flag.Usage()
 		os.Exit(1)
 	}

--- a/cmd/gmp-migrate/main.go
+++ b/cmd/gmp-migrate/main.go
@@ -15,26 +15,41 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/migrate"
-	"github.com/alecthomas/kingpin/v2"
-)
-
-var (
-	// Flags.
-	inputFile = kingpin.Flag("file", "Input source (YAML file, directory, or '-' for stdin)").Short('f').Required().String()
 )
 
 func main() {
-	kingpin.CommandLine.Help = "Migrate Prometheus Operator configurations to Google Managed Prometheus (GMP)."
-	kingpin.Parse()
+	var inputFile string
+	flag.StringVar(&inputFile, "file", "", "Input source (YAML file, directory, or '-' for stdin) (Required)")
+	flag.StringVar(&inputFile, "f", "", "Input source (YAML file, directory, or '-' for stdin) (Required)")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		fmt.Fprint(os.Stderr, "Migrate Prometheus Operator configurations to Google Managed Prometheus (GMP).\n\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if inputFile == "" {
+		fmt.Fprintln(os.Stderr, "[ERROR] Flag -f / --file is required.")
+		flag.Usage()
+		os.Exit(1)
+	}
 
 	migrator := migrate.NewMigrator()
-	_, err := migrator.Run(*inputFile)
+	report, err := migrator.Run(inputFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[ERROR] Migration failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// If any resource failed to migrate, exit with a non-zero code.
+	if report.FailedCount > 0 {
+		fmt.Fprintf(os.Stderr, "\n[ERROR] Migration completed with %d failures.\n", report.FailedCount)
 		os.Exit(1)
 	}
 }

--- a/cmd/gmp-migrate/main.go
+++ b/cmd/gmp-migrate/main.go
@@ -83,18 +83,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Write the convertedGMP manifests using the migrator's Stdout stream
+	// If any resource failed to convert in-memory, we print summary and abort
+	if report.FailedCount > 0 {
+		migrator.PrintSummary(report) // Still print the diagnostic summary to Stderr
+		slog.Error("Migration aborted: resources failed conversion. Zero manifests were written to Stdout.",
+			slog.Int("failures", report.FailedCount),
+		)
+		os.Exit(1)
+	}
+
+	// Write the converted GMP manifests using the migrator's Stdout stream
 	if err := migrator.WriteOutputs(report.Outputs); err != nil {
 		slog.Error("Failed to write outputs", slog.Any("error", err))
 		os.Exit(1)
 	}
 
-	// Print the standardized summary to Stderr using the migrator's stream
+	// Print the successful complete summary to Stderr
 	migrator.PrintSummary(report)
-
-	// If any resource failed to migrate, exit with a non-zero code.
-	if report.FailedCount > 0 {
-		slog.Error("Migration completed with failures", slog.Int("failures", report.FailedCount))
-		os.Exit(1)
-	}
 }

--- a/cmd/gmp-migrate/main.go
+++ b/cmd/gmp-migrate/main.go
@@ -19,16 +19,35 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/migrate"
 )
 
+// commaStringSlice implements the flag.Value interface to support
+// repeated and/or comma-separated string flags.
+type commaStringSlice []string
+
+func (s *commaStringSlice) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *commaStringSlice) Set(value string) error {
+	for p := range strings.SplitSeq(value, ",") {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			*s = append(*s, trimmed)
+		}
+	}
+	return nil
+}
+
 func main() {
 	slog.SetDefault(slog.New(migrate.NewConsoleHandler(os.Stderr)))
 
-	var inputFile string
-	flag.StringVar(&inputFile, "file", "", "Input source (YAML file, directory, or '-' for stdin) (Required)")
-	flag.StringVar(&inputFile, "f", "", "Input source (YAML file, directory, or '-' for stdin) (Required)")
+	var inputFiles commaStringSlice
+	flag.Var(&inputFiles, "file", "Input source (YAML file, directory, or '-' for stdin) (Required)")
+	flag.Var(&inputFiles, "f", "Input source (YAML file, directory, or '-' for stdin) (Required)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
@@ -37,14 +56,25 @@ func main() {
 	}
 	flag.Parse()
 
-	if inputFile == "" {
+	// Reject unexpected positional arguments to prevent silent typos (like forgetting -f)
+	if flag.NArg() > 0 {
+		slog.Error("Unexpected positional arguments.",
+			slog.Any("arguments", flag.Args()),
+		)
+		fmt.Fprintln(os.Stderr, "\nAll input files and directories must be explicitly passed using the -f or --file flags. For example:")
+		fmt.Fprintf(os.Stderr, "  %s -f %s -f %s\n\n", os.Args[0], inputFiles.String(), strings.Join(flag.Args(), " -f "))
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if len(inputFiles) == 0 {
 		slog.Error("Flag -f / --file is required.")
 		flag.Usage()
 		os.Exit(1)
 	}
 
 	migrator := migrate.NewMigrator()
-	report, err := migrator.Run(inputFile)
+	report, err := migrator.Run(inputFiles...)
 	if err != nil {
 		slog.Error("Migration failed", slog.Any("error", err))
 		os.Exit(1)

--- a/cmd/gmp-migrate/main.go
+++ b/cmd/gmp-migrate/main.go
@@ -17,12 +17,15 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/GoogleCloudPlatform/prometheus-engine/pkg/migrate"
 )
 
 func main() {
+	slog.SetDefault(slog.New(migrate.NewConsoleHandler(os.Stderr)))
+
 	var inputFile string
 	flag.StringVar(&inputFile, "file", "", "Input source (YAML file, directory, or '-' for stdin) (Required)")
 	flag.StringVar(&inputFile, "f", "", "Input source (YAML file, directory, or '-' for stdin) (Required)")
@@ -35,7 +38,7 @@ func main() {
 	flag.Parse()
 
 	if inputFile == "" {
-		fmt.Fprintln(os.Stderr, "[ERROR] Flag -f / --file is required.")
+		slog.Error("Flag -f / --file is required.")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -43,13 +46,13 @@ func main() {
 	migrator := migrate.NewMigrator()
 	report, err := migrator.Run(inputFile)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[ERROR] Migration failed: %v\n", err)
+		slog.Error("Migration failed", slog.Any("error", err))
 		os.Exit(1)
 	}
 
 	// If any resource failed to migrate, exit with a non-zero code.
 	if report.FailedCount > 0 {
-		fmt.Fprintf(os.Stderr, "\n[ERROR] Migration completed with %d failures.\n", report.FailedCount)
+		slog.Error("Migration completed with failures", slog.Int("failures", report.FailedCount))
 		os.Exit(1)
 	}
 }

--- a/cmd/gmp-migrate/main.go
+++ b/cmd/gmp-migrate/main.go
@@ -83,6 +83,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Write the convertedGMP manifests using the migrator's Stdout stream
+	if err := migrator.WriteOutputs(report.Outputs); err != nil {
+		slog.Error("Failed to write outputs", slog.Any("error", err))
+		os.Exit(1)
+	}
+
 	// Print the standardized summary to Stderr using the migrator's stream
 	migrator.PrintSummary(report)
 

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,10 @@ require (
 	sigs.k8s.io/controller-runtime v0.18.7
 )
 
-require github.com/efficientgo/e2e v0.14.1-0.20230710114240-c316eb95ae5b
+require (
+	github.com/efficientgo/e2e v0.14.1-0.20230710114240-c316eb95ae5b
+	sigs.k8s.io/yaml v1.6.0
+)
 
 require (
 	cloud.google.com/go/auth v0.16.5 // indirect
@@ -83,7 +86,7 @@ require (
 	github.com/edsrzf/mmap-go v1.2.0 // indirect
 	github.com/efficientgo/core v1.0.0-rc.3 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
-	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb // indirect
 	github.com/fatih/color v1.18.0 // indirect
@@ -114,7 +117,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
-	github.com/imdario/mergo v0.3.6 // indirect
+	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
@@ -176,7 +179,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3re
 github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
 github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
-github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
-github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
+github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb h1:IT4JYU7k4ikYg1SCxNI1/Tieq/NFvh6dzLdgi7eu0tM=
@@ -249,8 +249,8 @@ github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
 github.com/hetznercloud/hcloud-go/v2 v2.9.0 h1:s0N6R7Zoi2DPfMtUF5o9VeUBzTtHVY6MIkHOQnfu/AY=
 github.com/hetznercloud/hcloud-go/v2 v2.9.0/go.mod h1:qtW/TuU7Bs16ibXl/ktJarWqU2LwHr7eGlwoilHxtgg=
-github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
-github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
+github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/ionos-cloud/sdk-go/v6 v6.1.11 h1:J/uRN4UWO3wCyGOeDdMKv8LWRzKu6UIkLEaes38Kzh8=
 github.com/ionos-cloud/sdk-go/v6 v6.1.11/go.mod h1:EzEgRIDxBELvfoa/uBN0kOQaqovLjUWEB7iW4/Q+t4k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -68,18 +68,19 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 
 	// Helper to process and categorize attributes
 	processAttr := func(a slog.Attr) {
+		val := a.Value.Resolve()
 		switch a.Key {
 		case "kind":
-			kind = a.Value.String()
+			kind = val.String()
 		case "namespace":
-			namespace = a.Value.String()
+			namespace = val.String()
 		case "name":
-			name = a.Value.String()
+			name = val.String()
 		case "file":
-			file = a.Value.String()
+			file = val.String()
 		default:
 			// Collect all other attributes to print at the end of the line
-			extraAttrs = append(extraAttrs, fmt.Sprintf("%s=%v", a.Key, a.Value.Any()))
+			extraAttrs = append(extraAttrs, fmt.Sprintf("%s=%v", a.Key, val.Any()))
 		}
 	}
 

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// LevelSuccess defines a custom slog.Level for Success (standard Info is 0, Warn is 4).
+const LevelSuccess slog.Level = slog.LevelInfo + 1 // Level 1
+
+// ConsoleHandler is a thread-safe slog.Handler that formats logs for the console (Stderr)
+// and tracks the highest log level seen per resource (for statistics).
+type ConsoleHandler struct {
+	mu             sync.Mutex
+	out            io.Writer
+	resourceLevels map[string]slog.Level
+	attrs          []slog.Attr
+}
+
+// NewConsoleHandler creates a new ConsoleHandler.
+func NewConsoleHandler(out io.Writer) *ConsoleHandler {
+	return &ConsoleHandler{
+		out:            out,
+		resourceLevels: make(map[string]slog.Level),
+	}
+}
+
+func (h *ConsoleHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true // Log everything
+}
+
+func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	var kind, namespace, name, file string
+	var extraAttrs []string
+
+	// Helper to process and categorize attributes
+	processAttr := func(a slog.Attr) {
+		switch a.Key {
+		case "kind":
+			kind = a.Value.String()
+		case "namespace":
+			namespace = a.Value.String()
+		case "name":
+			name = a.Value.String()
+		case "file":
+			file = a.Value.String()
+		default:
+			// Collect all other attributes to print at the end of the line
+			extraAttrs = append(extraAttrs, fmt.Sprintf("%s=%v", a.Key, a.Value.Any()))
+		}
+	}
+
+	// Extract attributes bound to the logger instance
+	for _, a := range h.attrs {
+		processAttr(a)
+	}
+
+	// Extract attributes passed in the individual log call
+	r.Attrs(func(a slog.Attr) bool {
+		processAttr(a)
+		return true
+	})
+
+	// Map slog.Level to string for console output.
+	var levelStr string
+	switch r.Level {
+	case slog.LevelDebug:
+		levelStr = "DEBUG"
+	case slog.LevelInfo:
+		levelStr = "INFO"
+	case LevelSuccess:
+		levelStr = "SUCCESS"
+	case slog.LevelWarn:
+		levelStr = "WARNING"
+	case slog.LevelError:
+		levelStr = "ERROR"
+	default:
+		levelStr = r.Level.String()
+	}
+
+	// Format prefix cleanly
+	var prefix string
+	if file != "" {
+		prefix = fmt.Sprintf("[%s] ", file)
+	} else if kind != "" && name != "" {
+		prefix = fmt.Sprintf("[%s:%s/%s] ", kind, namespace, name)
+	}
+
+	// 1. Write formatted log to Stderr (console), appending extra attributes if any.
+	var suffix string
+	if len(extraAttrs) > 0 {
+		suffix = " " + strings.Join(extraAttrs, " ")
+	}
+	consoleLine := fmt.Sprintf("[%s] %s%s%s\n", levelStr, prefix, r.Message, suffix)
+	if _, err := io.WriteString(h.out, consoleLine); err != nil {
+		return err
+	}
+
+	// 2. Track the highest log level seen for this resource (for final report)
+	if kind != "" && name != "" {
+		key := fmt.Sprintf("%s/%s/%s", kind, namespace, name)
+		if r.Level > h.resourceLevels[key] {
+			h.resourceLevels[key] = r.Level
+		}
+	} else if file != "" {
+		// Track file-level log severity under the file path key
+		if r.Level > h.resourceLevels[file] {
+			h.resourceLevels[file] = r.Level
+		}
+	}
+
+	return nil
+}
+
+func (h *ConsoleHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	newAttrs := append(h.attrs, attrs...)
+	return &ConsoleHandler{
+		out:            h.out,
+		resourceLevels: h.resourceLevels,
+		attrs:          newAttrs,
+	}
+}
+
+func (h *ConsoleHandler) WithGroup(_ string) slog.Handler {
+	return h
+}

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -25,13 +25,36 @@ import (
 	"sync"
 )
 
-// LevelSuccess defines a custom slog.Level for Success (standard Info is 0, Warn is 4).
-const LevelSuccess slog.Level = slog.LevelInfo + 1 // Level 1
+// Custom slog.Levels for status logging.
+const (
+	LevelSuccess slog.Level = slog.LevelInfo - 1 // Level -1 (Standard Info is 0)
+	LevelSkipped slog.Level = slog.LevelInfo + 1 // Level 1
+)
+
+// ResourceStatus defines the final migration state of an ingested resource.
+type ResourceStatus int
+
+const (
+	StatusSuccess ResourceStatus = iota // 0 (Migrated Successfully)
+	StatusSkipped                       // 1 (Skipped / Unsupported)
+	StatusWarning                       // 2 (Migrated with Warnings)
+	StatusFailed                        // 3 (Failed)
+)
+
+// statusLevels maps slog.Levels to their corresponding ResourceStatus.
+// Levels omitted from this map (like slog.LevelInfo) represent progress logs
+// and are ignored for status tracking.
+var statusLevels = map[slog.Level]ResourceStatus{
+	LevelSuccess:    StatusSuccess,
+	LevelSkipped:    StatusSkipped,
+	slog.LevelWarn:  StatusWarning,
+	slog.LevelError: StatusFailed,
+}
 
 // loggerState encapsulates the shared, thread-safe state across all handler clones.
 type loggerState struct {
-	mu             sync.Mutex
-	resourceLevels map[string]slog.Level
+	mu               sync.Mutex
+	resourceStatuses map[string]ResourceStatus
 }
 
 // ConsoleHandler is a thread-safe slog.Handler that formats logs for the console (Stderr)
@@ -50,7 +73,7 @@ func NewConsoleHandler(out io.Writer) *ConsoleHandler {
 	return &ConsoleHandler{
 		out: out,
 		state: &loggerState{
-			resourceLevels: make(map[string]slog.Level),
+			resourceStatuses: make(map[string]ResourceStatus),
 		},
 	}
 }
@@ -104,6 +127,8 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 		levelStr = "INFO"
 	case LevelSuccess:
 		levelStr = "SUCCESS"
+	case LevelSkipped:
+		levelStr = "SKIPPED"
 	case slog.LevelWarn:
 		levelStr = "WARNING"
 	case slog.LevelError:
@@ -134,21 +159,24 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 		return err
 	}
 
-	// 2. Track the highest log level seen for this resource (for final report)
-	if kind != "" && name != "" {
-		var key string
-		if namespace == "" {
-			key = fmt.Sprintf("%s/%s", kind, name)
-		} else {
-			key = fmt.Sprintf("%s/%s/%s", kind, namespace, name)
-		}
-		if val, exists := h.state.resourceLevels[key]; !exists || r.Level > val {
-			h.state.resourceLevels[key] = r.Level
-		}
-	} else if file != "" {
-		// Track file-level log severity under the file path key
-		if val, exists := h.state.resourceLevels[file]; !exists || r.Level > val {
-			h.state.resourceLevels[file] = r.Level
+	// 2. Track the migration status of the resource (for final report)
+	// Only update the map if the log level represents an actual status milestone.
+	if status, ok := statusLevels[r.Level]; ok {
+		if kind != "" && name != "" {
+			var key string
+			if namespace == "" {
+				key = fmt.Sprintf("%s/%s", kind, name)
+			} else {
+				key = fmt.Sprintf("%s/%s/%s", kind, namespace, name)
+			}
+			if val, exists := h.state.resourceStatuses[key]; !exists || status > val {
+				h.state.resourceStatuses[key] = status
+			}
+		} else if file != "" {
+			// Track file-level log status under the file path key
+			if val, exists := h.state.resourceStatuses[file]; !exists || status > val {
+				h.state.resourceStatuses[file] = status
+			}
 		}
 	}
 
@@ -175,10 +203,10 @@ func (h *ConsoleHandler) WithGroup(_ string) slog.Handler {
 	return h
 }
 
-// ResourceLevels returns a thread-safe copy of the tracked resource log levels.
-func (h *ConsoleHandler) ResourceLevels() map[string]slog.Level {
+// ResourceStatuses returns a thread-safe copy of the tracked resource statuses.
+func (h *ConsoleHandler) ResourceStatuses() map[string]ResourceStatus {
 	h.state.mu.Lock()
 	defer h.state.mu.Unlock()
 
-	return maps.Clone(h.state.resourceLevels)
+	return maps.Clone(h.state.resourceStatuses)
 }

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -127,12 +127,12 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 	// 2. Track the highest log level seen for this resource (for final report)
 	if kind != "" && name != "" {
 		key := fmt.Sprintf("%s/%s/%s", kind, namespace, name)
-		if r.Level > h.state.resourceLevels[key] {
+		if val, exists := h.state.resourceLevels[key]; !exists || r.Level > val {
 			h.state.resourceLevels[key] = r.Level
 		}
 	} else if file != "" {
 		// Track file-level log severity under the file path key
-		if r.Level > h.state.resourceLevels[file] {
+		if val, exists := h.state.resourceLevels[file]; !exists || r.Level > val {
 			h.state.resourceLevels[file] = r.Level
 		}
 	}

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -184,14 +184,12 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 }
 
 func (h *ConsoleHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	// 1. Allocate a brand-new, independent underlying array of exact size
-	newAttrs := make([]slog.Attr, len(h.attrs)+len(attrs))
-
-	// 2. Copy the parent's attributes to the beginning of the new array
-	copy(newAttrs, h.attrs)
-
-	// 3. Copy the new attributes to the remaining space, starting at the offset
-	copy(newAttrs[len(h.attrs):], attrs)
+	if len(attrs) == 0 {
+		return h
+	}
+	newAttrs := make([]slog.Attr, 0, len(h.attrs)+len(attrs))
+	newAttrs = append(newAttrs, h.attrs...)
+	newAttrs = append(newAttrs, attrs...)
 	return &ConsoleHandler{
 		out:   h.out,
 		state: h.state,

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"os"
 	"strings"
 	"sync"
 )
@@ -43,6 +44,9 @@ type ConsoleHandler struct {
 
 // NewConsoleHandler creates a new ConsoleHandler.
 func NewConsoleHandler(out io.Writer) *ConsoleHandler {
+	if out == nil {
+		out = os.Stderr
+	}
 	return &ConsoleHandler{
 		out: out,
 		state: &loggerState{
@@ -112,7 +116,11 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 	if file != "" {
 		prefix = fmt.Sprintf("[%s] ", file)
 	} else if kind != "" && name != "" {
-		prefix = fmt.Sprintf("[%s:%s/%s] ", kind, namespace, name)
+		if namespace == "" {
+			prefix = fmt.Sprintf("[%s:%s] ", kind, name) // Clean omission
+		} else {
+			prefix = fmt.Sprintf("[%s:%s/%s] ", kind, namespace, name)
+		}
 	}
 
 	// 1. Write formatted log to Stderr (console), appending extra attributes if any.
@@ -127,7 +135,12 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 
 	// 2. Track the highest log level seen for this resource (for final report)
 	if kind != "" && name != "" {
-		key := fmt.Sprintf("%s/%s/%s", kind, namespace, name)
+		var key string
+		if namespace == "" {
+			key = fmt.Sprintf("%s/%s", kind, name) // Clean omission, no double-slash!
+		} else {
+			key = fmt.Sprintf("%s/%s/%s", kind, namespace, name)
+		}
 		if val, exists := h.state.resourceLevels[key]; !exists || r.Level > val {
 			h.state.resourceLevels[key] = r.Level
 		}

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -141,10 +141,18 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 }
 
 func (h *ConsoleHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	// 1. Allocate a brand-new, independent underlying array of exact size
+	newAttrs := make([]slog.Attr, len(h.attrs)+len(attrs))
+
+	// 2. Copy the parent's attributes to the beginning of the new array
+	copy(newAttrs, h.attrs)
+
+	// 3. Copy the new attributes to the remaining space, starting at the offset
+	copy(newAttrs[len(h.attrs):], attrs)
 	return &ConsoleHandler{
 		out:   h.out,
 		state: h.state,
-		attrs: append(h.attrs, attrs...),
+		attrs: newAttrs,
 	}
 }
 

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -25,12 +25,6 @@ import (
 	"sync"
 )
 
-// Custom slog.Levels for status logging.
-const (
-	LevelSuccess slog.Level = slog.LevelInfo - 1 // Level -1 (Standard Info is 0)
-	LevelSkipped slog.Level = slog.LevelInfo + 1 // Level 1
-)
-
 // ResourceStatus defines the final migration state of an ingested resource.
 type ResourceStatus int
 
@@ -45,10 +39,16 @@ const (
 // Levels omitted from this map (like slog.LevelInfo) represent progress logs
 // and are ignored for status tracking.
 var statusLevels = map[slog.Level]ResourceStatus{
-	LevelSuccess:    StatusSuccess,
-	LevelSkipped:    StatusSkipped,
+	slog.LevelDebug: StatusSuccess,
 	slog.LevelWarn:  StatusWarning,
 	slog.LevelError: StatusFailed,
+}
+
+// trackStatus updates the tracked status for a key if the new status is more severe.
+func (h *ConsoleHandler) trackStatus(key string, status ResourceStatus) {
+	if val, exists := h.state.resourceStatuses[key]; !exists || status > val {
+		h.state.resourceStatuses[key] = status
+	}
 }
 
 // loggerState encapsulates the shared, thread-safe state across all handler clones.
@@ -86,7 +86,7 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 	h.state.mu.Lock()
 	defer h.state.mu.Unlock()
 
-	var kind, namespace, name, file string
+	var kind, namespace, name, file, migrationStatus string
 	var extraAttrs []string
 
 	// Helper to process and categorize attributes
@@ -101,6 +101,8 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 			name = val.String()
 		case "file":
 			file = val.String()
+		case "migration_status":
+			migrationStatus = val.String()
 		default:
 			// Collect all other attributes to print at the end of the line
 			extraAttrs = append(extraAttrs, fmt.Sprintf("%s=%v", a.Key, val.Any()))
@@ -122,13 +124,12 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 	var levelStr string
 	switch r.Level {
 	case slog.LevelDebug:
-		levelStr = "DEBUG"
+		levelStr = "SUCCESS"
 	case slog.LevelInfo:
 		levelStr = "INFO"
-	case LevelSuccess:
-		levelStr = "SUCCESS"
-	case LevelSkipped:
-		levelStr = "SKIPPED"
+		if migrationStatus == "skipped" {
+			levelStr = "SKIPPED"
+		}
 	case slog.LevelWarn:
 		levelStr = "WARNING"
 	case slog.LevelError:
@@ -160,23 +161,22 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 	}
 
 	// 2. Track the migration status of the resource (for final report)
-	// Only update the map if the log level represents an actual status milestone.
-	if status, ok := statusLevels[r.Level]; ok {
-		if kind != "" && name != "" {
-			var key string
-			if namespace == "" {
-				key = fmt.Sprintf("%s/%s", kind, name)
-			} else {
-				key = fmt.Sprintf("%s/%s/%s", kind, namespace, name)
-			}
-			if val, exists := h.state.resourceStatuses[key]; !exists || status > val {
-				h.state.resourceStatuses[key] = status
-			}
-		} else if file != "" {
-			// Track file-level log status under the file path key
-			if val, exists := h.state.resourceStatuses[file]; !exists || status > val {
-				h.state.resourceStatuses[file] = status
-			}
+	var key string
+	if kind != "" && name != "" {
+		if namespace == "" {
+			key = fmt.Sprintf("%s/%s", kind, name)
+		} else {
+			key = fmt.Sprintf("%s/%s/%s", kind, namespace, name)
+		}
+	} else if file != "" {
+		key = file
+	}
+
+	if key != "" {
+		if r.Level == slog.LevelInfo && migrationStatus == "skipped" {
+			h.trackStatus(key, StatusSkipped)
+		} else if status, ok := statusLevels[r.Level]; ok {
+			h.trackStatus(key, status)
 		}
 	}
 

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -44,13 +44,6 @@ var statusLevels = map[slog.Level]ResourceStatus{
 	slog.LevelError: StatusFailed,
 }
 
-// trackStatus updates the tracked status for a key if the new status is more severe.
-func (h *ConsoleHandler) trackStatus(key string, status ResourceStatus) {
-	if val, exists := h.state.resourceStatuses[key]; !exists || status > val {
-		h.state.resourceStatuses[key] = status
-	}
-}
-
 // loggerState encapsulates the shared, thread-safe state across all handler clones.
 type loggerState struct {
 	mu               sync.Mutex
@@ -207,4 +200,11 @@ func (h *ConsoleHandler) ResourceStatuses() map[string]ResourceStatus {
 	defer h.state.mu.Unlock()
 
 	return maps.Clone(h.state.resourceStatuses)
+}
+
+// trackStatus updates the tracked status for a key if the new status is more severe.
+func (h *ConsoleHandler) trackStatus(key string, status ResourceStatus) {
+	if val, exists := h.state.resourceStatuses[key]; !exists || status > val {
+		h.state.resourceStatuses[key] = status
+	}
 }

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"strings"
 	"sync"
 )
@@ -158,4 +159,12 @@ func (h *ConsoleHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 
 func (h *ConsoleHandler) WithGroup(_ string) slog.Handler {
 	return h
+}
+
+// ResourceLevels returns a thread-safe copy of the tracked resource log levels.
+func (h *ConsoleHandler) ResourceLevels() map[string]slog.Level {
+	h.state.mu.Lock()
+	defer h.state.mu.Unlock()
+
+	return maps.Clone(h.state.resourceLevels)
 }

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -117,7 +117,7 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 		prefix = fmt.Sprintf("[%s] ", file)
 	} else if kind != "" && name != "" {
 		if namespace == "" {
-			prefix = fmt.Sprintf("[%s:%s] ", kind, name) // Clean omission
+			prefix = fmt.Sprintf("[%s:%s] ", kind, name)
 		} else {
 			prefix = fmt.Sprintf("[%s:%s/%s] ", kind, namespace, name)
 		}
@@ -137,7 +137,7 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 	if kind != "" && name != "" {
 		var key string
 		if namespace == "" {
-			key = fmt.Sprintf("%s/%s", kind, name) // Clean omission, no double-slash!
+			key = fmt.Sprintf("%s/%s", kind, name)
 		} else {
 			key = fmt.Sprintf("%s/%s/%s", kind, namespace, name)
 		}

--- a/pkg/migrate/logger.go
+++ b/pkg/migrate/logger.go
@@ -26,20 +26,27 @@ import (
 // LevelSuccess defines a custom slog.Level for Success (standard Info is 0, Warn is 4).
 const LevelSuccess slog.Level = slog.LevelInfo + 1 // Level 1
 
+// loggerState encapsulates the shared, thread-safe state across all handler clones.
+type loggerState struct {
+	mu             sync.Mutex
+	resourceLevels map[string]slog.Level
+}
+
 // ConsoleHandler is a thread-safe slog.Handler that formats logs for the console (Stderr)
 // and tracks the highest log level seen per resource (for statistics).
 type ConsoleHandler struct {
-	mu             sync.Mutex
-	out            io.Writer
-	resourceLevels map[string]slog.Level
-	attrs          []slog.Attr
+	out   io.Writer
+	state *loggerState
+	attrs []slog.Attr
 }
 
 // NewConsoleHandler creates a new ConsoleHandler.
 func NewConsoleHandler(out io.Writer) *ConsoleHandler {
 	return &ConsoleHandler{
-		out:            out,
-		resourceLevels: make(map[string]slog.Level),
+		out: out,
+		state: &loggerState{
+			resourceLevels: make(map[string]slog.Level),
+		},
 	}
 }
 
@@ -48,8 +55,8 @@ func (h *ConsoleHandler) Enabled(_ context.Context, _ slog.Level) bool {
 }
 
 func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	h.state.mu.Lock()
+	defer h.state.mu.Unlock()
 
 	var kind, namespace, name, file string
 	var extraAttrs []string
@@ -120,13 +127,13 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 	// 2. Track the highest log level seen for this resource (for final report)
 	if kind != "" && name != "" {
 		key := fmt.Sprintf("%s/%s/%s", kind, namespace, name)
-		if r.Level > h.resourceLevels[key] {
-			h.resourceLevels[key] = r.Level
+		if r.Level > h.state.resourceLevels[key] {
+			h.state.resourceLevels[key] = r.Level
 		}
 	} else if file != "" {
 		// Track file-level log severity under the file path key
-		if r.Level > h.resourceLevels[file] {
-			h.resourceLevels[file] = r.Level
+		if r.Level > h.state.resourceLevels[file] {
+			h.state.resourceLevels[file] = r.Level
 		}
 	}
 
@@ -134,11 +141,10 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 }
 
 func (h *ConsoleHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	newAttrs := append(h.attrs, attrs...)
 	return &ConsoleHandler{
-		out:            h.out,
-		resourceLevels: h.resourceLevels,
-		attrs:          newAttrs,
+		out:   h.out,
+		state: h.state,
+		attrs: append(h.attrs, attrs...),
 	}
 }
 

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -237,6 +237,10 @@ func (m *Migrator) convertResources() []*unstructured.Unstructured {
 
 func (m *Migrator) writeOutputs(outputs []*unstructured.Unstructured) error {
 	for i, out := range outputs {
+		if out == nil || out.Object == nil {
+			return fmt.Errorf("internal error: found nil resource or uninitialized object in outputs at index %d", i)
+		}
+
 		yamlOut, err := yaml.Marshal(out.Object)
 		if err != nil {
 			return err

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -72,8 +72,8 @@ func (m *Migrator) RegisterConverter(c ResourceConverter) {
 	m.converters[c.ImportKey()] = c
 }
 
-// Run executes the migration flow and returns the summary report.
-func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
+// Run executes the migration flow and returns the summary report across multiple inputs.
+func (m *Migrator) Run(inputPaths ...string) (*MigrationReport, error) {
 	if m.Stdin == nil {
 		m.Stdin = os.Stdin
 	}
@@ -97,8 +97,10 @@ func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
 	m.logger = slog.New(handler)
 
 	// 1. Parse all inputs
-	if err := m.parseInputs(inputPath); err != nil {
-		return nil, fmt.Errorf("failed to parse inputs: %w", err)
+	for _, path := range inputPaths {
+		if err := m.parseInputs(path); err != nil {
+			return nil, fmt.Errorf("failed to parse input %q: %w", path, err)
+		}
 	}
 
 	// 2. Run converters
@@ -129,8 +131,8 @@ func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
 	return report, nil
 }
 
-// isRelevantKind returns true if the given resource Kind is either a target
-// resource with a registered converter, or a known cached dependency.
+// isRelevantKind returns true if the input resource Kind is either a target
+// resource with a registered converter, or a known dependency.
 func (m *Migrator) isRelevantKind(kind string) bool {
 	switch kind {
 	case "Service", "ConfigMap", "Secret":
@@ -253,7 +255,7 @@ func (m *Migrator) convertResources() []*unstructured.Unstructured {
 		for _, key := range keys {
 			res := nsMap[key].DeepCopy()
 
-			// Create the pre-scoped resource logger
+			// Create the resource logger
 			resourceLogger := m.logger.With(
 				slog.String("kind", kind),
 				slog.String("namespace", res.GetNamespace()),

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -176,31 +176,27 @@ func (m *Migrator) parseYAMLStream(r io.Reader) error {
 			return err
 		}
 
-		// 1. If it is completely empty of all three (comments/empty dividers), skip it safely.
-		if u.Object == nil || (u.GetAPIVersion() == "" && u.GetKind() == "" && u.GetName() == "") {
-			continue
-		}
-
-		// 2. A valid Kubernetes resource must specify apiVersion, kind, and metadata.name.
 		apiVersion := u.GetAPIVersion()
 		kind := u.GetKind()
 		name := u.GetName()
-		if apiVersion == "" || kind == "" || name == "" {
-			return fmt.Errorf("malformed resource: apiVersion, kind, and metadata.name must all be specified (got apiVersion=%q, kind=%q, name=%q)", apiVersion, kind, name)
-		}
 
-		// 2. Check if we care about this resource.
-		if !m.isRelevantKind(u.GetKind()) {
-			// If this is an unsupported Prometheus Operator resource, log an error before discarding.
-			if strings.HasPrefix(u.GetAPIVersion(), "monitoring.coreos.com") {
+		// 1. If it's not a resource we care about, skip it.
+		if !m.isRelevantKind(kind) {
+			// If it's a Prometheus Operator resource, log an ERROR first.
+			if strings.HasPrefix(apiVersion, "monitoring.coreos.com") {
 				m.Logger.Error("Skipping unsupported Prometheus Operator resource",
-					slog.String("apiVersion", u.GetAPIVersion()),
-					slog.String("kind", u.GetKind()),
+					slog.String("apiVersion", apiVersion),
+					slog.String("kind", kind),
 					slog.String("namespace", u.GetNamespace()),
-					slog.String("name", u.GetName()),
+					slog.String("name", name),
 				)
 			}
 			continue
+		}
+
+		// 2. Since this IS a resource we care about, it must be well-formed.
+		if apiVersion == "" || kind == "" || name == "" {
+			return fmt.Errorf("malformed resource: apiVersion, kind, and metadata.name must all be specified (got apiVersion=%q, kind=%q, name=%q)", apiVersion, kind, name)
 		}
 
 		m.cache.Add(&u)
@@ -219,17 +215,6 @@ func (m *Migrator) convertResources() []*unstructured.Unstructured {
 		nsMap := m.cache.resources[kind]
 		converter, registered := m.converters[kind]
 		if !registered {
-			// If this is a Prometheus Operator resource (group: monitoring.coreos.com),
-			// log an error then skip.
-			for _, res := range nsMap {
-				if strings.HasPrefix(res.GetAPIVersion(), "monitoring.coreos.com") {
-					m.Logger.Error("Skipping unsupported Prometheus Operator resource",
-						slog.String("kind", kind),
-						slog.String("namespace", res.GetNamespace()),
-						slog.String("name", res.GetName()),
-					)
-				}
-			}
 			continue
 		}
 

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -146,19 +146,37 @@ func (m *Migrator) isRelevantKind(kind string) bool {
 
 // parseInputs reads files, directories, or stdin and loads them into the cache.
 func (m *Migrator) parseInputs(path string) error {
+	// 1. Handle Stdin Strm
 	if path == "-" {
-		return m.parseYAMLStream(m.Stdin)
+		if err := m.parseYAMLStream(m.Stdin); err != nil {
+			// Log and track the error
+			m.logger.Error("Skipping stdin due to parse error",
+				slog.String("file", "-"),
+				slog.Any("error", err),
+			)
+		}
+		return nil
 	}
 
+	// 2. Resolve system  errors
 	info, err := os.Stat(path)
 	if err != nil {
 		return err
 	}
 
+	// 3. Handle Single Direct File
 	if !info.IsDir() {
-		return m.parseFile(path)
+		if err := m.parseFile(path); err != nil {
+			// Log and track the error
+			m.logger.Error("Skipping file due to parse error",
+				slog.String("file", path),
+				slog.Any("error", err),
+			)
+		}
+		return nil
 	}
 
+	// 4. Handle Directory Walk
 	return filepath.WalkDir(path, func(fp string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -173,10 +191,16 @@ func (m *Migrator) parseInputs(path string) error {
 			}
 			return nil
 		}
+
+		// Skip hidden files encountered during the walk (e.g. .yamllint.yaml)
+		if strings.HasPrefix(d.Name(), ".") {
+			return nil
+		}
+
 		ext := strings.ToLower(filepath.Ext(fp))
 		if ext == ".yaml" || ext == ".yml" {
 			if err := m.parseFile(fp); err != nil {
-				// A file failed to parse completely. Count as a failed run step.
+				// Log and track the error
 				m.logger.Error("Skipping file due to parse error",
 					slog.String("file", fp),
 					slog.Any("error", err),

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -1,0 +1,246 @@
+package migrate
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"maps"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
+)
+
+// MigrationReport accumulates the results and statistics of the migration run.
+type MigrationReport struct {
+	Logs         []LogMessage
+	SuccessCount int // Successfully migrated with no warnings
+	WarningCount int // Successfully migrated but had warnings
+	FailedCount  int // Fatal failure, resource skipped
+}
+
+// Migrator orchestrates the migration process.
+type Migrator struct {
+	converters map[string]ResourceConverter
+	cache      *ResourceCache
+
+	// Decoupled streams (defaults to os.Stdin/os.Stdout/os.Stderr)
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewMigrator creates a new Migrator.
+func NewMigrator() *Migrator {
+	return &Migrator{
+		converters: make(map[string]ResourceConverter),
+		cache:      NewResourceCache(),
+		Stdin:      os.Stdin,
+		Stdout:     os.Stdout,
+		Stderr:     os.Stderr,
+	}
+}
+
+// RegisterConverter registers a converter for a specific resource Kind.
+func (m *Migrator) RegisterConverter(c ResourceConverter) {
+	m.converters[c.ImportKey()] = c
+}
+
+// Run executes the migration flow and returns the summary report.
+func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
+	report := &MigrationReport{}
+
+	// 1. Parse all inputs and populate the cache
+	if err := m.parseInputs(inputPath, report); err != nil {
+		return nil, fmt.Errorf("failed to parse inputs: %w", err)
+	}
+
+	// 2. Run converters on cached resources
+	outputs, err := m.convertResources(report)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert resources: %w", err)
+	}
+
+	// 3. Write outputs (always to Stdout)
+	if err := m.writeOutputs(outputs); err != nil {
+		return nil, fmt.Errorf("failed to write outputs: %w", err)
+	}
+
+	// 4. Print Summary Stats
+	m.printSummary(report)
+
+	return report, nil
+}
+
+// parseInputs reads files, directories, or stdin and loads them into the cache.
+func (m *Migrator) parseInputs(path string, report *MigrationReport) error {
+	if path == "-" {
+		return m.parseYAMLStream(m.Stdin)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	if !info.IsDir() {
+		return m.parseFile(path)
+	}
+
+	return filepath.WalkDir(path, func(fp string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(fp, ".yaml") || strings.HasSuffix(fp, ".yml") {
+			if err := m.parseFile(fp); err != nil {
+				log := LogMessage{
+					Level:   LevelError,
+					Name:    fp, // Use file path as name since we don't have Kind/Namespace yet
+					Message: fmt.Sprintf("Skipping file due to parse error: %v", err),
+				}
+				report.Logs = append(report.Logs, log)
+				fmt.Fprintln(m.Stderr, log.String())
+			}
+		}
+		return nil
+	})
+}
+
+func (m *Migrator) parseFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return m.parseYAMLStream(f)
+}
+
+func (m *Migrator) parseYAMLStream(r io.Reader) error {
+	decoder := k8syaml.NewYAMLOrJSONDecoder(bufio.NewReader(r), 4096)
+	for {
+		var u unstructured.Unstructured
+		if err := decoder.Decode(&u); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		if u.Object == nil || u.GetKind() == "" {
+			continue
+		}
+		m.cache.Add(&u)
+	}
+	return nil
+}
+
+// convertResources runs registered converters and populates the MigrationReport.
+func (m *Migrator) convertResources(report *MigrationReport) ([]*unstructured.Unstructured, error) {
+	var allOutputs []*unstructured.Unstructured
+
+	// Sort Kinds alphabetically for deterministic execution order
+	kinds := slices.AppendSeq(make([]string, 0, len(m.cache.resources)), maps.Keys(m.cache.resources))
+	slices.Sort(kinds)
+
+	for _, kind := range kinds {
+		converter, registered := m.converters[kind]
+		if !registered {
+			continue
+		}
+
+		nsMap := m.cache.resources[kind]
+		// Sort Namespace/Name keys alphabetically for determinism
+		keys := slices.AppendSeq(make([]string, 0, len(nsMap)), maps.Keys(nsMap))
+		slices.Sort(keys)
+
+		for _, key := range keys {
+			res := nsMap[key]
+			outputs, logs, err := converter.Convert(res, m.cache)
+			report.Logs = append(report.Logs, logs...)
+
+			// Emitting operational logs (INFO, WARNING, SUCCESS)
+			for _, log := range logs {
+				fmt.Fprintln(m.Stderr, log.String())
+			}
+
+			// If conversion fails, increment fail count
+			if err != nil {
+				report.FailedCount++
+				errLog := LogMessage{
+					Level:     LevelError,
+					Kind:      kind,
+					Namespace: res.GetNamespace(),
+					Name:      res.GetName(),
+					Message:   err.Error(),
+				}
+				report.Logs = append(report.Logs, errLog)
+				fmt.Fprintln(m.Stderr, errLog.String())
+				continue
+			}
+
+			allOutputs = append(allOutputs, outputs...)
+
+			if len(outputs) > 0 {
+				// Distinguish migrated with warnings vs complete success
+				hasWarnings := false
+				for _, l := range logs {
+					if l.Level == LevelWarning {
+						hasWarnings = true
+						break
+					}
+				}
+
+				if hasWarnings {
+					report.WarningCount++
+				} else {
+					report.SuccessCount++
+				}
+
+				successLog := LogMessage{
+					Level:     LevelSuccess,
+					Kind:      kind,
+					Namespace: res.GetNamespace(),
+					Name:      res.GetName(),
+					Message:   "Translated successfully",
+				}
+				report.Logs = append(report.Logs, successLog)
+				fmt.Fprintln(m.Stderr, successLog.String())
+			}
+		}
+	}
+	return allOutputs, nil
+}
+
+// writeOutputs writes the translated resources to Stdout separated by ---.
+func (m *Migrator) writeOutputs(outputs []*unstructured.Unstructured) error {
+	for i, out := range outputs {
+		yamlOut, err := yaml.Marshal(out.Object)
+		if err != nil {
+			return err
+		}
+		if i > 0 {
+			fmt.Fprintln(m.Stdout, "---")
+		}
+		fmt.Fprint(m.Stdout, string(yamlOut))
+	}
+	return nil
+}
+
+// printSummary outputs the final execution statistics.
+func (m *Migrator) printSummary(r *MigrationReport) {
+	// Summary goes to Stderr so it doesn't pollute the redirected YAML payload
+	fmt.Fprintln(m.Stderr, "\n=========================================")
+	fmt.Fprintln(m.Stderr, "Migration Complete Summary:")
+	fmt.Fprintf(m.Stderr, "  Successfully Migrated: %d\n", r.SuccessCount)
+	fmt.Fprintf(m.Stderr, "  Migrated with Warnings: %d\n", r.WarningCount)
+	fmt.Fprintf(m.Stderr, "  Failed (Skipped):        %d\n", r.FailedCount)
+	fmt.Fprintln(m.Stderr, "=========================================")
+}

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -16,9 +16,11 @@ package migrate
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -31,9 +33,8 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// MigrationReport accumulates the results and statistics of the migration run.
+// MigrationReport accumulates the statistics of the migration run.
 type MigrationReport struct {
-	Logs         []LogMessage
 	SuccessCount int // Successfully migrated with no warnings
 	WarningCount int // Successfully migrated but had warnings
 	FailedCount  int // Fatal failure, resource skipped
@@ -48,6 +49,7 @@ type Migrator struct {
 	Stdin  io.Reader
 	Stdout io.Writer
 	Stderr io.Writer
+	Logger *slog.Logger
 }
 
 // NewMigrator creates a new Migrator.
@@ -58,6 +60,7 @@ func NewMigrator() *Migrator {
 		Stdin:      os.Stdin,
 		Stdout:     os.Stdout,
 		Stderr:     os.Stderr,
+		Logger:     slog.Default(),
 	}
 }
 
@@ -70,30 +73,49 @@ func (m *Migrator) RegisterConverter(c ResourceConverter) {
 func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
 	report := &MigrationReport{}
 
-	// 1. Parse all inputs and populate the cache
-	if err := m.parseInputs(inputPath, report); err != nil {
+	// Instantiate our custom ConsoleHandler
+	handler := NewConsoleHandler(m.Stderr)
+	m.Logger = slog.New(handler)
+
+	// Temporarily set as default so package-level slog calls route to our handler
+	oldLogger := slog.Default()
+	slog.SetDefault(m.Logger)
+	defer slog.SetDefault(oldLogger)
+
+	// 1. Parse all inputs
+	if err := m.parseInputs(inputPath); err != nil {
 		return nil, fmt.Errorf("failed to parse inputs: %w", err)
 	}
 
-	// 2. Run converters on cached resources
-	outputs, err := m.convertResources(report)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert resources: %w", err)
-	}
+	// 2. Run converters
+	outputs := m.convertResources()
 
-	// 3. Write outputs (always to Stdout)
+	// 3. Write GMP manifests
 	if err := m.writeOutputs(outputs); err != nil {
 		return nil, fmt.Errorf("failed to write outputs: %w", err)
 	}
 
-	// 4. Print Summary Stats
+	// 4. Calculate final statistics from the handler's tracked levels
+	for _, level := range handler.resourceLevels {
+		switch level {
+		case slog.LevelError:
+			report.FailedCount++
+		case slog.LevelWarn:
+			report.WarningCount++
+		default:
+			// Info or Success levels are counted as perfect successes
+			report.SuccessCount++
+		}
+	}
+
+	// 5. Print Summary Stats
 	m.printSummary(report)
 
 	return report, nil
 }
 
 // parseInputs reads files, directories, or stdin and loads them into the cache.
-func (m *Migrator) parseInputs(path string, report *MigrationReport) error {
+func (m *Migrator) parseInputs(path string) error {
 	if path == "-" {
 		return m.parseYAMLStream(m.Stdin)
 	}
@@ -114,15 +136,14 @@ func (m *Migrator) parseInputs(path string, report *MigrationReport) error {
 		if d.IsDir() {
 			return nil
 		}
-		if strings.HasSuffix(fp, ".yaml") || strings.HasSuffix(fp, ".yml") {
+		ext := strings.ToLower(filepath.Ext(fp))
+		if ext == ".yaml" || ext == ".yml" {
 			if err := m.parseFile(fp); err != nil {
-				log := LogMessage{
-					Level:   LevelError,
-					Name:    fp, // Use file path as name since we don't have Kind/Namespace yet
-					Message: fmt.Sprintf("Skipping file due to parse error: %v", err),
-				}
-				report.Logs = append(report.Logs, log)
-				fmt.Fprintln(m.Stderr, log.String())
+				// A file failed to parse completely. Count as a failed run step.
+				slog.Error("Skipping file due to parse error",
+					slog.String("file", fp),
+					slog.Any("error", err),
+				)
 			}
 		}
 		return nil
@@ -148,19 +169,26 @@ func (m *Migrator) parseYAMLStream(r io.Reader) error {
 			}
 			return err
 		}
-		if u.Object == nil || u.GetKind() == "" {
+
+		// Silent skip for empty blocks or comments
+		if u.Object == nil || (u.GetKind() == "" && u.GetName() == "") {
 			continue
 		}
+
+		// Return error for malformed K8s resources missing metadata.name
+		if u.GetKind() != "" && u.GetName() == "" {
+			return fmt.Errorf("resource of kind %q is missing metadata.name", u.GetKind())
+		}
+
 		m.cache.Add(&u)
 	}
 	return nil
 }
 
-// convertResources runs registered converters and populates the MigrationReport.
-func (m *Migrator) convertResources(report *MigrationReport) ([]*unstructured.Unstructured, error) {
+func (m *Migrator) convertResources() []*unstructured.Unstructured {
 	var allOutputs []*unstructured.Unstructured
+	ctx := context.Background()
 
-	// Sort Kinds alphabetically for deterministic execution order
 	kinds := slices.AppendSeq(make([]string, 0, len(m.cache.resources)), maps.Keys(m.cache.resources))
 	slices.Sort(kinds)
 
@@ -171,69 +199,36 @@ func (m *Migrator) convertResources(report *MigrationReport) ([]*unstructured.Un
 		}
 
 		nsMap := m.cache.resources[kind]
-		// Sort Namespace/Name keys alphabetically for determinism
 		keys := slices.AppendSeq(make([]string, 0, len(nsMap)), maps.Keys(nsMap))
 		slices.Sort(keys)
 
 		for _, key := range keys {
 			res := nsMap[key]
-			outputs, logs, err := converter.Convert(res, m.cache)
-			report.Logs = append(report.Logs, logs...)
 
-			// Emitting operational logs (INFO, WARNING, SUCCESS)
-			for _, log := range logs {
-				fmt.Fprintln(m.Stderr, log.String())
-			}
+			// Create the pre-scoped resource logger
+			resourceLogger := m.Logger.With(
+				slog.String("kind", kind),
+				slog.String("namespace", res.GetNamespace()),
+				slog.String("name", res.GetName()),
+			)
 
-			// If conversion fails, increment fail count
+			outputs, err := converter.Convert(ctx, resourceLogger, res, m.cache)
+
 			if err != nil {
-				report.FailedCount++
-				errLog := LogMessage{
-					Level:     LevelError,
-					Kind:      kind,
-					Namespace: res.GetNamespace(),
-					Name:      res.GetName(),
-					Message:   err.Error(),
-				}
-				report.Logs = append(report.Logs, errLog)
-				fmt.Fprintln(m.Stderr, errLog.String())
+				resourceLogger.Error(err.Error())
 				continue
 			}
 
 			allOutputs = append(allOutputs, outputs...)
 
 			if len(outputs) > 0 {
-				// Distinguish migrated with warnings vs complete success
-				hasWarnings := false
-				for _, l := range logs {
-					if l.Level == LevelWarning {
-						hasWarnings = true
-						break
-					}
-				}
-
-				if hasWarnings {
-					report.WarningCount++
-				} else {
-					report.SuccessCount++
-				}
-
-				successLog := LogMessage{
-					Level:     LevelSuccess,
-					Kind:      kind,
-					Namespace: res.GetNamespace(),
-					Name:      res.GetName(),
-					Message:   "Translated successfully",
-				}
-				report.Logs = append(report.Logs, successLog)
-				fmt.Fprintln(m.Stderr, successLog.String())
+				resourceLogger.Log(ctx, LevelSuccess, "Translated successfully")
 			}
 		}
 	}
-	return allOutputs, nil
+	return allOutputs
 }
 
-// writeOutputs writes the translated resources to Stdout separated by ---.
 func (m *Migrator) writeOutputs(outputs []*unstructured.Unstructured) error {
 	for i, out := range outputs {
 		yamlOut, err := yaml.Marshal(out.Object)
@@ -248,9 +243,7 @@ func (m *Migrator) writeOutputs(outputs []*unstructured.Unstructured) error {
 	return nil
 }
 
-// printSummary outputs the final execution statistics.
 func (m *Migrator) printSummary(r *MigrationReport) {
-	// Summary goes to Stderr so it doesn't pollute the redirected YAML payload
 	fmt.Fprintln(m.Stderr, "\n=========================================")
 	fmt.Fprintln(m.Stderr, "Migration Complete Summary:")
 	fmt.Fprintf(m.Stderr, "  Successfully Migrated: %d\n", r.SuccessCount)

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -109,6 +109,17 @@ func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
 	return report, nil
 }
 
+// isRelevantKind returns true if the given resource Kind is either a target
+// resource with a registered converter, or a known cached dependency.
+func (m *Migrator) isRelevantKind(kind string) bool {
+	switch kind {
+	case "Service", "ConfigMap", "Secret":
+		return true
+	}
+	_, registered := m.converters[kind]
+	return registered
+}
+
 // parseInputs reads files, directories, or stdin and loads them into the cache.
 func (m *Migrator) parseInputs(path string) error {
 	if path == "-" {
@@ -165,14 +176,31 @@ func (m *Migrator) parseYAMLStream(r io.Reader) error {
 			return err
 		}
 
-		// Silent skip for empty blocks or comments
-		if u.Object == nil || (u.GetKind() == "" && u.GetName() == "") {
+		// 1. If it is completely empty of all three (comments/empty dividers), skip it safely.
+		if u.Object == nil || (u.GetAPIVersion() == "" && u.GetKind() == "" && u.GetName() == "") {
 			continue
 		}
 
-		// Return error for malformed K8s resources missing metadata.name
-		if u.GetKind() != "" && u.GetName() == "" {
-			return fmt.Errorf("resource of kind %q is missing metadata.name", u.GetKind())
+		// 2. A valid Kubernetes resource must specify apiVersion, kind, and metadata.name.
+		apiVersion := u.GetAPIVersion()
+		kind := u.GetKind()
+		name := u.GetName()
+		if apiVersion == "" || kind == "" || name == "" {
+			return fmt.Errorf("malformed resource: apiVersion, kind, and metadata.name must all be specified (got apiVersion=%q, kind=%q, name=%q)", apiVersion, kind, name)
+		}
+
+		// 2. Check if we care about this resource.
+		if !m.isRelevantKind(u.GetKind()) {
+			// If this is an unsupported Prometheus Operator resource, log an error before discarding.
+			if strings.HasPrefix(u.GetAPIVersion(), "monitoring.coreos.com") {
+				m.Logger.Error("Skipping unsupported Prometheus Operator resource",
+					slog.String("apiVersion", u.GetAPIVersion()),
+					slog.String("kind", u.GetKind()),
+					slog.String("namespace", u.GetNamespace()),
+					slog.String("name", u.GetName()),
+				)
+			}
+			continue
 		}
 
 		m.cache.Add(&u)
@@ -227,9 +255,7 @@ func (m *Migrator) convertResources() []*unstructured.Unstructured {
 
 			allOutputs = append(allOutputs, outputs...)
 
-			if len(outputs) > 0 {
-				resourceLogger.Log(ctx, LevelSuccess, "Translated successfully")
-			}
+			resourceLogger.Log(ctx, LevelSuccess, "Converted successfully")
 		}
 	}
 	return allOutputs

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -34,12 +34,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// MigrationReport accumulates the statistics of the migration run.
+// MigrationReport accumulates the statistics and payloads of the migration run.
 type MigrationReport struct {
-	SuccessCount int // Successfully migrated with no warnings
-	WarningCount int // Successfully migrated but had warnings
-	SkippedCount int // Bypassed because resource is unsupported/out-of-scope
-	FailedCount  int // Fatal failure, resource skipped
+	SuccessCount int                          // Successfully migrated with no warnings
+	WarningCount int                          // Successfully migrated but had warnings
+	SkippedCount int                          // Bypassed because resource is unsupported/out-of-scope
+	FailedCount  int                          // Fatal failure, resource skipped
+	Outputs      []*unstructured.Unstructured // Converted GMP manifests in-memory
 }
 
 // Migrator orchestrates the migration process.
@@ -105,13 +106,9 @@ func (m *Migrator) Run(inputPaths ...string) (*MigrationReport, error) {
 		}
 	}
 
-	// 2. Run converters
+	// 2. Run converters across the cached resources
 	outputs := m.convertResources()
-
-	// 3. Write GMP manifests
-	if err := m.writeOutputs(outputs); err != nil {
-		return nil, fmt.Errorf("failed to write outputs: %w", err)
-	}
+	report.Outputs = outputs
 
 	// 4. Calculate final statistics from the handler's tracked statuses
 	for _, status := range handler.ResourceStatuses() {
@@ -139,6 +136,34 @@ func (m *Migrator) PrintSummary(r *MigrationReport) {
 	fmt.Fprintf(m.Stderr, "  Skipped (Unsupported):  %d\n", r.SkippedCount)
 	fmt.Fprintf(m.Stderr, "  Failed:                 %d\n", r.FailedCount)
 	fmt.Fprintln(m.Stderr, "=========================================")
+}
+
+// WriteOutputs serializes and writes the converted manifests to the migrator's Stdout stream
+// in standard Kubernetes multi-document YAML format (separated by "---").
+func (m *Migrator) WriteOutputs(outputs []*unstructured.Unstructured) error {
+	var buf strings.Builder
+	for i, out := range outputs {
+		if out == nil || out.Object == nil {
+			return fmt.Errorf("internal error: found nil resource or uninitialized object in outputs at index %d", i)
+		}
+
+		yamlOut, err := yaml.Marshal(out)
+		if err != nil {
+			return err
+		}
+		if i > 0 {
+			if _, err := fmt.Fprintln(&buf, "---"); err != nil {
+				return fmt.Errorf("failed to write document separator: %w", err)
+			}
+		}
+		if _, err := buf.Write(yamlOut); err != nil {
+			return fmt.Errorf("failed to write output: %w", err)
+		}
+	}
+	if _, err := io.WriteString(m.Stdout, buf.String()); err != nil {
+		return fmt.Errorf("failed to write output to destination: %w", err)
+	}
+	return nil
 }
 
 // isRelevantKind returns true if the input resource Kind is either a target
@@ -329,28 +354,3 @@ func (m *Migrator) convertResources() []*unstructured.Unstructured {
 	}
 	return allOutputs
 }
-
-func (m *Migrator) writeOutputs(outputs []*unstructured.Unstructured) error {
-	for i, out := range outputs {
-		if out == nil || out.Object == nil {
-			return fmt.Errorf("internal error: found nil resource or uninitialized object in outputs at index %d", i)
-		}
-
-		yamlOut, err := yaml.Marshal(out)
-		if err != nil {
-			return err
-		}
-		if i > 0 {
-			if _, err := fmt.Fprintln(m.Stdout, "---"); err != nil {
-				return fmt.Errorf("failed to write document separator: %w", err)
-			}
-		}
-		if _, err := m.Stdout.Write(yamlOut); err != nil {
-			return fmt.Errorf("failed to write output: %w", err)
-		}
-	}
-	return nil
-}
-
-// PrintSummary formats and writes the standardized migration report summary
-// to the migrator's Stderr stream, ensuring stream consistency.

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -264,7 +264,7 @@ func (m *Migrator) writeOutputs(outputs []*unstructured.Unstructured) error {
 			return fmt.Errorf("internal error: found nil resource or uninitialized object in outputs at index %d", i)
 		}
 
-		yamlOut, err := yaml.Marshal(out.Object)
+		yamlOut, err := yaml.Marshal(out)
 		if err != nil {
 			return err
 		}

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -71,6 +71,16 @@ func (m *Migrator) RegisterConverter(c ResourceConverter) {
 
 // Run executes the migration flow and returns the summary report.
 func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
+	if m.Stdin == nil {
+		m.Stdin = os.Stdin
+	}
+	if m.Stdout == nil {
+		m.Stdout = os.Stdout
+	}
+	if m.Stderr == nil {
+		m.Stderr = os.Stderr
+	}
+
 	report := &MigrationReport{}
 
 	// Instantiate our custom ConsoleHandler
@@ -259,9 +269,13 @@ func (m *Migrator) writeOutputs(outputs []*unstructured.Unstructured) error {
 			return err
 		}
 		if i > 0 {
-			fmt.Fprintln(m.Stdout, "---")
+			if _, err := fmt.Fprintln(m.Stdout, "---"); err != nil {
+				return fmt.Errorf("failed to write document separator: %w", err)
+			}
 		}
-		fmt.Fprint(m.Stdout, string(yamlOut))
+		if _, err := m.Stdout.Write(yamlOut); err != nil {
+			return fmt.Errorf("failed to write output: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -66,6 +66,9 @@ func NewMigrator() *Migrator {
 
 // RegisterConverter registers a converter for a specific resource Kind.
 func (m *Migrator) RegisterConverter(c ResourceConverter) {
+	if m.converters == nil {
+		m.converters = make(map[string]ResourceConverter)
+	}
 	m.converters[c.ImportKey()] = c
 }
 
@@ -79,6 +82,12 @@ func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
 	}
 	if m.Stderr == nil {
 		m.Stderr = os.Stderr
+	}
+	if m.cache == nil {
+		m.cache = NewResourceCache()
+	}
+	if m.converters == nil {
+		m.converters = make(map[string]ResourceConverter)
 	}
 
 	report := &MigrationReport{}
@@ -192,9 +201,9 @@ func (m *Migrator) parseYAMLStream(r io.Reader) error {
 
 		// 1. If it's not a resource we care about, skip it.
 		if !m.isRelevantKind(kind) {
-			// If it's a Prometheus Operator resource, log an ERROR first.
+			// If it's a Prometheus Operator resource, log a WARNING first.
 			if strings.HasPrefix(apiVersion, "monitoring.coreos.com") {
-				m.logger.Error("Skipping unsupported Prometheus Operator resource",
+				m.logger.Warn("Skipping unsupported Prometheus Operator resource",
 					slog.String("apiVersion", apiVersion),
 					slog.String("kind", kind),
 					slog.String("namespace", u.GetNamespace()),

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -77,11 +77,6 @@ func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
 	handler := NewConsoleHandler(m.Stderr)
 	m.Logger = slog.New(handler)
 
-	// Temporarily set as default so package-level slog calls route to our handler
-	oldLogger := slog.Default()
-	slog.SetDefault(m.Logger)
-	defer slog.SetDefault(oldLogger)
-
 	// 1. Parse all inputs
 	if err := m.parseInputs(inputPath); err != nil {
 		return nil, fmt.Errorf("failed to parse inputs: %w", err)
@@ -96,7 +91,7 @@ func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
 	}
 
 	// 4. Calculate final statistics from the handler's tracked levels
-	for _, level := range handler.resourceLevels {
+	for _, level := range handler.state.resourceLevels {
 		switch level {
 		case slog.LevelError:
 			report.FailedCount++
@@ -140,7 +135,7 @@ func (m *Migrator) parseInputs(path string) error {
 		if ext == ".yaml" || ext == ".yml" {
 			if err := m.parseFile(fp); err != nil {
 				// A file failed to parse completely. Count as a failed run step.
-				slog.Error("Skipping file due to parse error",
+				m.Logger.Error("Skipping file due to parse error",
 					slog.String("file", fp),
 					slog.Any("error", err),
 				)

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package migrate
 
 import (

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -101,7 +101,7 @@ func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
 	}
 
 	// 4. Calculate final statistics from the handler's tracked levels
-	for _, level := range handler.state.resourceLevels {
+	for _, level := range handler.ResourceLevels() {
 		switch level {
 		case slog.LevelError:
 			report.FailedCount++

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -16,6 +16,7 @@ package migrate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -28,6 +29,7 @@ import (
 	"maps"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
 )
@@ -205,32 +207,51 @@ func (m *Migrator) parseYAMLStream(r io.Reader) error {
 			return err
 		}
 
-		apiVersion := u.GetAPIVersion()
-		kind := u.GetKind()
-		name := u.GetName()
+		if err := m.processUnstructured(&u); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-		// 1. If it's not a resource we care about, skip it.
-		if !m.isRelevantKind(kind) {
-			// If it's a Prometheus Operator resource, log a SKIPPED milestone first.
-			if strings.HasPrefix(apiVersion, "monitoring.coreos.com") {
-				m.logger.Log(context.Background(), LevelSkipped, "Skipping unsupported Prometheus Operator resource",
-					slog.String("apiVersion", apiVersion),
-					slog.String("kind", kind),
-					slog.String("namespace", u.GetNamespace()),
-					slog.String("name", name),
-				)
+// processUnstructured processes a single unstructured resource.
+// If the resource is a List, it recursively processes all nested items.
+func (m *Migrator) processUnstructured(u *unstructured.Unstructured) error {
+	if u.IsList() {
+		return u.EachListItem(func(obj runtime.Object) error {
+			nested, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				return errors.New("internal error: failed to cast list item to unstructured")
 			}
-			continue
-		}
+			return m.processUnstructured(nested)
+		})
+	}
 
-		// 2. Since this IS a resource we care about, it must be well-formed.
-		if apiVersion == "" || kind == "" || name == "" {
-			return fmt.Errorf("malformed resource: apiVersion, kind, and metadata.name must all be specified (got apiVersion=%q, kind=%q, name=%q)", apiVersion, kind, name)
-		}
+	apiVersion := u.GetAPIVersion()
+	kind := u.GetKind()
+	name := u.GetName()
 
-		if err := m.cache.Add(&u); err != nil {
-			return fmt.Errorf("failed to cache resource: %w", err)
+	// 1. If it's not a resource we care about, skip it.
+	if !m.isRelevantKind(kind) {
+		// If it's a Prometheus Operator resource, log a SKIPPED milestone first.
+		if strings.HasPrefix(apiVersion, "monitoring.coreos.com") {
+			m.logger.Log(context.Background(), LevelSkipped, "Skipping unsupported Prometheus Operator resource",
+				slog.String("apiVersion", apiVersion),
+				slog.String("kind", kind),
+				slog.String("namespace", u.GetNamespace()),
+				slog.String("name", name),
+			)
 		}
+		return nil
+	}
+
+	// 2. Since this IS a resource we care about, it must be well-formed.
+	if apiVersion == "" || kind == "" || name == "" {
+		return fmt.Errorf("malformed resource: apiVersion, kind, and metadata.name must all be specified (got apiVersion=%q, kind=%q, name=%q)", apiVersion, kind, name)
+	}
+
+	if err := m.cache.Add(u); err != nil {
+		return fmt.Errorf("failed to cache resource: %w", err)
 	}
 	return nil
 }

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -85,12 +85,12 @@ func (m *Migrator) Run(inputPaths ...string) (*MigrationReport, error) {
 	if m.Stderr == nil {
 		m.Stderr = os.Stderr
 	}
-	if m.cache == nil {
-		m.cache = NewResourceCache()
-	}
+
 	if m.converters == nil {
 		m.converters = make(map[string]ResourceConverter)
 	}
+
+	m.cache = NewResourceCache()
 
 	report := &MigrationReport{}
 

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -15,7 +15,6 @@
 package migrate
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -37,6 +36,7 @@ import (
 type MigrationReport struct {
 	SuccessCount int // Successfully migrated with no warnings
 	WarningCount int // Successfully migrated but had warnings
+	SkippedCount int // Bypassed because resource is unsupported/out-of-scope
 	FailedCount  int // Fatal failure, resource skipped
 }
 
@@ -109,16 +109,17 @@ func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
 		return nil, fmt.Errorf("failed to write outputs: %w", err)
 	}
 
-	// 4. Calculate final statistics from the handler's tracked levels
-	for _, level := range handler.ResourceLevels() {
-		switch level {
-		case slog.LevelError:
-			report.FailedCount++
-		case slog.LevelWarn:
-			report.WarningCount++
-		default:
-			// Info or Success levels are counted as perfect successes
+	// 4. Calculate final statistics from the handler's tracked statuses
+	for _, status := range handler.ResourceStatuses() {
+		switch status {
+		case StatusSuccess:
 			report.SuccessCount++
+		case StatusSkipped:
+			report.SkippedCount++
+		case StatusWarning:
+			report.WarningCount++
+		case StatusFailed:
+			report.FailedCount++
 		}
 	}
 
@@ -159,6 +160,9 @@ func (m *Migrator) parseInputs(path string) error {
 			return err
 		}
 		if d.IsDir() {
+			if d.Name() != "." && d.Name() != ".." && strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		ext := strings.ToLower(filepath.Ext(fp))
@@ -185,7 +189,7 @@ func (m *Migrator) parseFile(path string) error {
 }
 
 func (m *Migrator) parseYAMLStream(r io.Reader) error {
-	decoder := k8syaml.NewYAMLOrJSONDecoder(bufio.NewReader(r), 4096)
+	decoder := k8syaml.NewYAMLOrJSONDecoder(r, 4096)
 	for {
 		var u unstructured.Unstructured
 		if err := decoder.Decode(&u); err != nil {
@@ -201,9 +205,9 @@ func (m *Migrator) parseYAMLStream(r io.Reader) error {
 
 		// 1. If it's not a resource we care about, skip it.
 		if !m.isRelevantKind(kind) {
-			// If it's a Prometheus Operator resource, log a WARNING first.
+			// If it's a Prometheus Operator resource, log a SKIPPED milestone first.
 			if strings.HasPrefix(apiVersion, "monitoring.coreos.com") {
-				m.logger.Warn("Skipping unsupported Prometheus Operator resource",
+				m.logger.Log(context.Background(), LevelSkipped, "Skipping unsupported Prometheus Operator resource",
 					slog.String("apiVersion", apiVersion),
 					slog.String("kind", kind),
 					slog.String("namespace", u.GetNamespace()),
@@ -292,8 +296,9 @@ func (m *Migrator) writeOutputs(outputs []*unstructured.Unstructured) error {
 func (m *Migrator) printSummary(r *MigrationReport) {
 	fmt.Fprintln(m.Stderr, "\n=========================================")
 	fmt.Fprintln(m.Stderr, "Migration Complete Summary:")
-	fmt.Fprintf(m.Stderr, "  Successfully Migrated: %d\n", r.SuccessCount)
+	fmt.Fprintf(m.Stderr, "  Successfully Migrated:  %d\n", r.SuccessCount)
 	fmt.Fprintf(m.Stderr, "  Migrated with Warnings: %d\n", r.WarningCount)
-	fmt.Fprintf(m.Stderr, "  Failed (Skipped):        %d\n", r.FailedCount)
+	fmt.Fprintf(m.Stderr, "  Skipped (Unsupported):  %d\n", r.SkippedCount)
+	fmt.Fprintf(m.Stderr, "  Failed:                 %d\n", r.FailedCount)
 	fmt.Fprintln(m.Stderr, "=========================================")
 }

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -127,10 +127,18 @@ func (m *Migrator) Run(inputPaths ...string) (*MigrationReport, error) {
 		}
 	}
 
-	// 5. Print Summary Stats
-	m.printSummary(report)
-
 	return report, nil
+}
+
+// PrintSummary formats and writes the standardized migration report summary.
+func (m *Migrator) PrintSummary(r *MigrationReport) {
+	fmt.Fprintln(m.Stderr, "\n=========================================")
+	fmt.Fprintln(m.Stderr, "Migration Complete Summary:")
+	fmt.Fprintf(m.Stderr, "  Successfully Migrated:  %d\n", r.SuccessCount)
+	fmt.Fprintf(m.Stderr, "  Migrated with Warnings: %d\n", r.WarningCount)
+	fmt.Fprintf(m.Stderr, "  Skipped (Unsupported):  %d\n", r.SkippedCount)
+	fmt.Fprintf(m.Stderr, "  Failed:                 %d\n", r.FailedCount)
+	fmt.Fprintln(m.Stderr, "=========================================")
 }
 
 // isRelevantKind returns true if the input resource Kind is either a target
@@ -344,12 +352,5 @@ func (m *Migrator) writeOutputs(outputs []*unstructured.Unstructured) error {
 	return nil
 }
 
-func (m *Migrator) printSummary(r *MigrationReport) {
-	fmt.Fprintln(m.Stderr, "\n=========================================")
-	fmt.Fprintln(m.Stderr, "Migration Complete Summary:")
-	fmt.Fprintf(m.Stderr, "  Successfully Migrated:  %d\n", r.SuccessCount)
-	fmt.Fprintf(m.Stderr, "  Migrated with Warnings: %d\n", r.WarningCount)
-	fmt.Fprintf(m.Stderr, "  Skipped (Unsupported):  %d\n", r.SkippedCount)
-	fmt.Fprintf(m.Stderr, "  Failed:                 %d\n", r.FailedCount)
-	fmt.Fprintln(m.Stderr, "=========================================")
-}
+// PrintSummary formats and writes the standardized migration report summary
+// to the migrator's Stderr stream, ensuring stream consistency.

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -49,7 +49,7 @@ type Migrator struct {
 	Stdin  io.Reader
 	Stdout io.Writer
 	Stderr io.Writer
-	Logger *slog.Logger
+	logger *slog.Logger
 }
 
 // NewMigrator creates a new Migrator.
@@ -60,7 +60,7 @@ func NewMigrator() *Migrator {
 		Stdin:      os.Stdin,
 		Stdout:     os.Stdout,
 		Stderr:     os.Stderr,
-		Logger:     slog.Default(),
+		logger:     slog.Default(),
 	}
 }
 
@@ -75,7 +75,7 @@ func (m *Migrator) Run(inputPath string) (*MigrationReport, error) {
 
 	// Instantiate our custom ConsoleHandler
 	handler := NewConsoleHandler(m.Stderr)
-	m.Logger = slog.New(handler)
+	m.logger = slog.New(handler)
 
 	// 1. Parse all inputs
 	if err := m.parseInputs(inputPath); err != nil {
@@ -146,7 +146,7 @@ func (m *Migrator) parseInputs(path string) error {
 		if ext == ".yaml" || ext == ".yml" {
 			if err := m.parseFile(fp); err != nil {
 				// A file failed to parse completely. Count as a failed run step.
-				m.Logger.Error("Skipping file due to parse error",
+				m.logger.Error("Skipping file due to parse error",
 					slog.String("file", fp),
 					slog.Any("error", err),
 				)
@@ -184,7 +184,7 @@ func (m *Migrator) parseYAMLStream(r io.Reader) error {
 		if !m.isRelevantKind(kind) {
 			// If it's a Prometheus Operator resource, log an ERROR first.
 			if strings.HasPrefix(apiVersion, "monitoring.coreos.com") {
-				m.Logger.Error("Skipping unsupported Prometheus Operator resource",
+				m.logger.Error("Skipping unsupported Prometheus Operator resource",
 					slog.String("apiVersion", apiVersion),
 					slog.String("kind", kind),
 					slog.String("namespace", u.GetNamespace()),
@@ -199,7 +199,9 @@ func (m *Migrator) parseYAMLStream(r io.Reader) error {
 			return fmt.Errorf("malformed resource: apiVersion, kind, and metadata.name must all be specified (got apiVersion=%q, kind=%q, name=%q)", apiVersion, kind, name)
 		}
 
-		m.cache.Add(&u)
+		if err := m.cache.Add(&u); err != nil {
+			return fmt.Errorf("failed to cache resource: %w", err)
+		}
 	}
 	return nil
 }
@@ -222,10 +224,10 @@ func (m *Migrator) convertResources() []*unstructured.Unstructured {
 		slices.Sort(keys)
 
 		for _, key := range keys {
-			res := nsMap[key]
+			res := nsMap[key].DeepCopy()
 
 			// Create the pre-scoped resource logger
-			resourceLogger := m.Logger.With(
+			resourceLogger := m.logger.With(
 				slog.String("kind", kind),
 				slog.String("namespace", res.GetNamespace()),
 				slog.String("name", res.GetName()),

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -188,12 +188,23 @@ func (m *Migrator) convertResources() []*unstructured.Unstructured {
 	slices.Sort(kinds)
 
 	for _, kind := range kinds {
+		nsMap := m.cache.resources[kind]
 		converter, registered := m.converters[kind]
 		if !registered {
+			// If this is a Prometheus Operator resource (group: monitoring.coreos.com),
+			// log an error then skip.
+			for _, res := range nsMap {
+				if strings.HasPrefix(res.GetAPIVersion(), "monitoring.coreos.com") {
+					m.Logger.Error("Skipping unsupported Prometheus Operator resource",
+						slog.String("kind", kind),
+						slog.String("namespace", res.GetNamespace()),
+						slog.String("name", res.GetName()),
+					)
+				}
+			}
 			continue
 		}
 
-		nsMap := m.cache.resources[kind]
 		keys := slices.AppendSeq(make([]string, 0, len(nsMap)), maps.Keys(nsMap))
 		slices.Sort(keys)
 

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -160,6 +160,10 @@ func (m *Migrator) parseInputs(path string) error {
 			return err
 		}
 		if d.IsDir() {
+			if fp == path {
+				return nil
+			}
+			// Skip hidden subdirectories encountered during the walk
 			if d.Name() != "." && d.Name() != ".." && strings.HasPrefix(d.Name(), ".") {
 				return filepath.SkipDir
 			}

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -291,14 +291,13 @@ func (m *Migrator) processUnstructured(u *unstructured.Unstructured) error {
 	// 1. If it's not a resource we care about, skip it.
 	if !m.isRelevantKind(kind) {
 		// If it's a Prometheus Operator resource, log a SKIPPED milestone first.
-		if strings.HasPrefix(apiVersion, "monitoring.coreos.com") {
-			m.logger.Log(context.Background(), LevelSkipped, "Skipping unsupported Prometheus Operator resource",
-				slog.String("apiVersion", apiVersion),
-				slog.String("kind", kind),
-				slog.String("namespace", u.GetNamespace()),
-				slog.String("name", name),
-			)
-		}
+		m.logger.Info("Skipping unsupported Prometheus Operator resource",
+			slog.String("migration_status", "skipped"),
+			slog.String("apiVersion", apiVersion),
+			slog.String("kind", kind),
+			slog.String("namespace", u.GetNamespace()),
+			slog.String("name", name),
+		)
 		return nil
 	}
 
@@ -349,7 +348,7 @@ func (m *Migrator) convertResources() []*unstructured.Unstructured {
 
 			allOutputs = append(allOutputs, outputs...)
 
-			resourceLogger.Log(ctx, LevelSuccess, "Converted successfully")
+			resourceLogger.Debug("Converted successfully")
 		}
 	}
 	return allOutputs

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -123,6 +123,7 @@ func TestResourceCacheNamespaceScoping(t *testing.T) {
 	cache := NewResourceCache()
 
 	omittedNsRes := &unstructured.Unstructured{}
+	omittedNsRes.SetAPIVersion("monitoring.coreos.com/v1")
 	omittedNsRes.SetKind("PodMonitor")
 	omittedNsRes.SetName("my-monitor-omitted")
 	omittedNsRes.SetNamespace("")
@@ -136,6 +137,7 @@ func TestResourceCacheNamespaceScoping(t *testing.T) {
 	}
 
 	nsARes := &unstructured.Unstructured{}
+	nsARes.SetAPIVersion("monitoring.coreos.com/v1")
 	nsARes.SetKind("PodMonitor")
 	nsARes.SetName("common-name")
 	nsARes.SetNamespace("namespace-a")

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -128,11 +128,11 @@ func TestResourceCacheNamespaceScoping(t *testing.T) {
 		t.Fatalf("Add failed: %v", err)
 	}
 
-	if _, found := cache.Get("PodMonitor", "default", "my-monitor-omitted"); !found {
-		t.Error("expected namespaced resource with omitted namespace to be defaulted to 'default'")
+	if _, found := cache.Get("PodMonitor", "default", "my-monitor-omitted"); found {
+		t.Error("expected namespaced resource with omitted namespace NOT to be found under 'default' namespace")
 	}
 	if _, found := cache.Get("PodMonitor", "", "my-monitor-omitted"); !found {
-		t.Error("expected namespaced resource with omitted namespace to be found under empty namespace due to consistent defaulting")
+		t.Error("expected namespaced resource with omitted namespace to be found under empty namespace")
 	}
 
 	nsARes := &unstructured.Unstructured{}

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -106,6 +106,9 @@ spec:
 	if report.WarningCount != 0 {
 		t.Errorf("expected WarningCount to be 0, got %d", report.WarningCount)
 	}
+	if report.SkippedCount != 0 {
+		t.Errorf("expected SkippedCount to be 0, got %d", report.SkippedCount)
+	}
 
 	stderrLogs := stderrBuf.String()
 	if !strings.Contains(stderrLogs, "[INFO] [PodMonitor:default/my-monitor] Successfully resolved backing-service") {
@@ -192,6 +195,12 @@ spec:
 	if report.SuccessCount != 0 {
 		t.Errorf("expected SuccessCount to be 0, got %d", report.SuccessCount)
 	}
+	if report.WarningCount != 0 {
+		t.Errorf("expected WarningCount to be 0, got %d", report.WarningCount)
+	}
+	if report.SkippedCount != 0 {
+		t.Errorf("expected SkippedCount to be 0, got %d", report.SkippedCount)
+	}
 
 	// Verify that a [ERROR] log was printed to Stderr showing the file path and exact parse error
 	stderrLogs := stderrBuf.String()
@@ -200,5 +209,55 @@ spec:
 	}
 	if !strings.Contains(stderrLogs, "malformed resource: apiVersion, kind, and metadata.name must all be specified") {
 		t.Errorf("expected underlying parse error in Stderr, got: %q", stderrLogs)
+	}
+}
+
+func TestMigratorSkippedResource(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Unsupported Prometheus Operator resource kind (Alertmanager)
+	skippedYAML := `
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: my-alertmanager
+spec:
+  replicas: 3
+`
+	inputFilePath := filepath.Join(tmpDir, "skipped_resource.yaml")
+	if err := os.WriteFile(inputFilePath, []byte(skippedYAML), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	migrator := NewMigrator()
+	migrator.RegisterConverter(&TestPodMonitorConverter{})
+	var stdoutBuf, stderrBuf bytes.Buffer
+	migrator.Stdout = &stdoutBuf
+	migrator.Stderr = &stderrBuf
+
+	// Run migration on the directory containing the skipped file
+	report, err := migrator.Run(tmpDir)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	// Verify report stats
+	if report.SkippedCount != 1 {
+		t.Errorf("expected SkippedCount to be 1, got %d", report.SkippedCount)
+	}
+	if report.SuccessCount != 0 {
+		t.Errorf("expected SuccessCount to be 0, got %d", report.SuccessCount)
+	}
+	if report.WarningCount != 0 {
+		t.Errorf("expected WarningCount to be 0, got %d", report.WarningCount)
+	}
+	if report.FailedCount != 0 {
+		t.Errorf("expected FailedCount to be 0, got %d", report.FailedCount)
+	}
+
+	// Verify that a [SKIPPED] log was printed to Stderr showing the resource details
+	stderrLogs := stderrBuf.String()
+	if !strings.Contains(stderrLogs, "[SKIPPED] [Alertmanager:my-alertmanager] Skipping unsupported Prometheus Operator resource") {
+		t.Errorf("expected formatted [SKIPPED] log in Stderr, got: %q", stderrLogs)
 	}
 }

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -26,17 +26,17 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// DummyConverter implements ResourceConverter for testing.
-type DummyConverter struct {
+// TestPodMonitorConverter implements ResourceConverter for testing.
+type TestPodMonitorConverter struct {
 	calls int
 }
 
-func (d *DummyConverter) ImportKey() string {
-	return "DummyResource"
+func (t *TestPodMonitorConverter) ImportKey() string {
+	return "PodMonitor"
 }
 
-func (d *DummyConverter) Convert(_ context.Context, logger *slog.Logger, unstruct *unstructured.Unstructured, cache *ResourceCache) ([]*unstructured.Unstructured, error) {
-	d.calls++
+func (t *TestPodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, unstruct *unstructured.Unstructured, cache *ResourceCache) ([]*unstructured.Unstructured, error) {
+	t.calls++
 
 	_, found := cache.Get("Service", unstruct.GetNamespace(), "backing-service")
 
@@ -60,9 +60,9 @@ func TestMigratorCacheAndExtensibility(t *testing.T) {
 
 	yamlContent := `
 apiVersion: monitoring.coreos.com/v1
-kind: DummyResource
+kind: PodMonitor
 metadata:
-  name: my-dummy
+  name: my-monitor
   namespace: default
 spec:
   foo: bar
@@ -86,8 +86,8 @@ spec:
 	migrator.Stdout = &stdoutBuf
 	migrator.Stderr = &stderrBuf
 
-	dummyConv := &DummyConverter{}
-	migrator.RegisterConverter(dummyConv)
+	testConv := &TestPodMonitorConverter{}
+	migrator.RegisterConverter(testConv)
 
 	// Run migration
 	report, err := migrator.Run(inputFilePath)
@@ -95,8 +95,8 @@ spec:
 		t.Fatalf("Run failed: %v", err)
 	}
 
-	if dummyConv.calls != 1 {
-		t.Errorf("expected DummyConverter to be called 1 time, got %d", dummyConv.calls)
+	if testConv.calls != 1 {
+		t.Errorf("expected TestPodMonitorConverter to be called 1 time, got %d", testConv.calls)
 	}
 
 	// Verify report stats
@@ -108,10 +108,10 @@ spec:
 	}
 
 	stderrLogs := stderrBuf.String()
-	if !strings.Contains(stderrLogs, "[INFO] [DummyResource:default/my-dummy] Successfully resolved backing-service") {
+	if !strings.Contains(stderrLogs, "[INFO] [PodMonitor:default/my-monitor] Successfully resolved backing-service") {
 		t.Errorf("expected formatted INFO log in Stderr, got: %q", stderrLogs)
 	}
-	if !strings.Contains(stderrLogs, "[SUCCESS] [DummyResource:default/my-dummy] Converted successfully") {
+	if !strings.Contains(stderrLogs, "[SUCCESS] [PodMonitor:default/my-monitor] Converted successfully") {
 		t.Errorf("expected formatted SUCCESS log in Stderr, got: %q", stderrLogs)
 	}
 }
@@ -124,7 +124,9 @@ func TestResourceCacheNamespaceScoping(t *testing.T) {
 	omittedNsRes.SetName("my-monitor-omitted")
 	omittedNsRes.SetNamespace("")
 
-	cache.Add(omittedNsRes)
+	if err := cache.Add(omittedNsRes); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
 
 	if _, found := cache.Get("PodMonitor", "default", "my-monitor-omitted"); !found {
 		t.Error("expected namespaced resource with omitted namespace to be defaulted to 'default'")
@@ -138,7 +140,9 @@ func TestResourceCacheNamespaceScoping(t *testing.T) {
 	nsARes.SetName("common-name")
 	nsARes.SetNamespace("namespace-a")
 
-	cache.Add(nsARes)
+	if err := cache.Add(nsARes); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
 
 	if _, found := cache.Get("PodMonitor", "namespace-b", "common-name"); found {
 		t.Error("expected strict namespace isolation; found resource from namespace-a when querying namespace-b")
@@ -173,6 +177,7 @@ spec:
 	}
 
 	migrator := NewMigrator()
+	migrator.RegisterConverter(&TestPodMonitorConverter{})
 	var stdoutBuf, stderrBuf bytes.Buffer
 	migrator.Stdout = &stdoutBuf
 	migrator.Stderr = &stderrBuf

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -128,9 +128,6 @@ func TestResourceCacheNamespaceScoping(t *testing.T) {
 		t.Fatalf("Add failed: %v", err)
 	}
 
-	if _, found := cache.Get("PodMonitor", "default", "my-monitor-omitted"); found {
-		t.Error("expected namespaced resource with omitted namespace NOT to be found under 'default' namespace")
-	}
 	if _, found := cache.Get("PodMonitor", "", "my-monitor-omitted"); !found {
 		t.Error("expected namespaced resource with omitted namespace to be found under empty namespace")
 	}

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -1,0 +1,166 @@
+package migrate
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// DummyConverter implements ResourceConverter for testing.
+type DummyConverter struct {
+	calls int
+}
+
+func (d *DummyConverter) ImportKey() string {
+	return "DummyResource"
+}
+
+func (d *DummyConverter) Convert(unstruct *unstructured.Unstructured, cache *ResourceCache) ([]*unstructured.Unstructured, []LogMessage, error) {
+	d.calls++
+
+	_, found := cache.Get("Service", unstruct.GetNamespace(), "backing-service")
+
+	logs := []LogMessage{}
+	if !found {
+		logs = append(logs, LogMessage{
+			Level:     LevelWarning,
+			Kind:      unstruct.GetKind(),
+			Namespace: unstruct.GetNamespace(),
+			Name:      unstruct.GetName(),
+			Message:   "backing-service not found in cache",
+		})
+	} else {
+		logs = append(logs, LogMessage{
+			Level:     LevelInfo,
+			Kind:      unstruct.GetKind(),
+			Namespace: unstruct.GetNamespace(),
+			Name:      unstruct.GetName(),
+			Message:   "Successfully resolved backing-service",
+		})
+	}
+
+	out := &unstructured.Unstructured{}
+	out.SetGroupVersionKind(unstruct.GroupVersionKind())
+	out.SetKind("TranslatedDummy")
+	out.SetName("translated-" + unstruct.GetName())
+	out.SetNamespace(unstruct.GetNamespace())
+
+	return []*unstructured.Unstructured{out}, logs, nil
+}
+
+func TestMigratorCacheAndExtensibility(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "migrate-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	yamlContent := `
+apiVersion: monitoring.coreos.com/v1
+kind: DummyResource
+metadata:
+  name: my-dummy
+  namespace: default
+spec:
+  foo: bar
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backing-service
+  namespace: default
+spec:
+  ports:
+  - port: 80
+`
+	inputFilePath := filepath.Join(tmpDir, "input.yaml")
+	if err := os.WriteFile(inputFilePath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	migrator := NewMigrator()
+	// Redirect output to buffers to avoid cluttering test logs and verify output
+	var stdoutBuf, stderrBuf bytes.Buffer
+	migrator.Stdout = &stdoutBuf
+	migrator.Stderr = &stderrBuf
+
+	dummyConv := &DummyConverter{}
+	migrator.RegisterConverter(dummyConv)
+
+	// Run migration
+	report, err := migrator.Run(inputFilePath)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	// Verify converter was called
+	if dummyConv.calls != 1 {
+		t.Errorf("expected DummyConverter to be called 1 time, got %d", dummyConv.calls)
+	}
+
+	// Verify report stats (should be success, since backing-service was found)
+	if report.SuccessCount != 1 {
+		t.Errorf("expected SuccessCount to be 1, got %d", report.SuccessCount)
+	}
+	if report.WarningCount != 0 {
+		t.Errorf("expected WarningCount to be 0, got %d", report.WarningCount)
+	}
+
+	// Verify logs contains the INFO log
+	foundInfo := false
+	for _, log := range report.Logs {
+		if log.Level == LevelInfo && strings.Contains(log.Message, "Successfully resolved backing-service") {
+			foundInfo = true
+		}
+	}
+	if !foundInfo {
+		t.Error("expected INFO log about resolving backing-service was not found in report")
+	}
+}
+
+func TestResourceCacheNamespaceScoping(t *testing.T) {
+	cache := NewResourceCache()
+
+	// 1. Test defaulting of omitted namespace for namespaced resources
+	omittedNsRes := &unstructured.Unstructured{}
+	omittedNsRes.SetKind("PodMonitor")
+	omittedNsRes.SetName("my-monitor-omitted")
+	omittedNsRes.SetNamespace("") // Omitted in YAML
+
+	cache.Add(omittedNsRes)
+
+	// It should be stored under "default"
+	if _, found := cache.Get("PodMonitor", "default", "my-monitor-omitted"); !found {
+		t.Error("expected namespaced resource with omitted namespace to be defaulted to 'default'")
+	}
+	// It should NOT be found under empty namespace
+	if _, found := cache.Get("PodMonitor", "", "my-monitor-omitted"); found {
+		t.Error("expected namespaced resource with omitted namespace NOT to be found under empty namespace")
+	}
+
+	// 2. Test strict namespace isolation
+	nsARes := &unstructured.Unstructured{}
+	nsARes.SetKind("PodMonitor")
+	nsARes.SetName("common-name")
+	nsARes.SetNamespace("namespace-a")
+
+	cache.Add(nsARes)
+
+	// Querying in namespace-b should NOT return the resource from namespace-a
+	if _, found := cache.Get("PodMonitor", "namespace-b", "common-name"); found {
+		t.Error("expected strict namespace isolation; found resource from namespace-a when querying namespace-b")
+	}
+
+	// Querying in namespace-a should find it
+	res, found := cache.Get("PodMonitor", "namespace-a", "common-name")
+	if !found {
+		t.Fatal("expected to find resource in namespace-a")
+	}
+	if res.GetNamespace() != "namespace-a" {
+		t.Errorf("expected found resource to have namespace 'namespace-a', got %q", res.GetNamespace())
+	}
+}

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -131,8 +131,8 @@ func TestResourceCacheNamespaceScoping(t *testing.T) {
 	if _, found := cache.Get("PodMonitor", "default", "my-monitor-omitted"); !found {
 		t.Error("expected namespaced resource with omitted namespace to be defaulted to 'default'")
 	}
-	if _, found := cache.Get("PodMonitor", "", "my-monitor-omitted"); found {
-		t.Error("expected namespaced resource with omitted namespace NOT to be found under empty namespace")
+	if _, found := cache.Get("PodMonitor", "", "my-monitor-omitted"); !found {
+		t.Error("expected namespaced resource with omitted namespace to be found under empty namespace due to consistent defaulting")
 	}
 
 	nsARes := &unstructured.Unstructured{}

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -334,3 +334,69 @@ spec:
 		t.Errorf("expected reference to be successfully resolved, got logs: %q", stderrLogs)
 	}
 }
+
+func TestMigratorPipedList(t *testing.T) {
+	// A standard v1.List containing a Service and a PodMonitor in its items array
+	listYAML := `
+apiVersion: v1
+kind: List
+metadata:
+  resourceVersion: ""
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: backing-service
+    namespace: default
+  spec:
+    ports:
+    - port: 80
+- apiVersion: monitoring.coreos.com/v1
+  kind: PodMonitor
+  metadata:
+    name: my-monitor
+    namespace: default
+  spec:
+    foo: bar
+`
+	migrator := NewMigrator()
+	var stdoutBuf, stderrBuf bytes.Buffer
+	migrator.Stdout = &stdoutBuf
+	migrator.Stderr = &stderrBuf
+
+	// Pipe the list YAML buffer directly into Stdin!
+	migrator.Stdin = strings.NewReader(listYAML)
+
+	testConv := &TestPodMonitorConverter{}
+	migrator.RegisterConverter(testConv)
+
+	// Run migration using "-" (Stdin)
+	report, err := migrator.Run("-")
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if testConv.calls != 1 {
+		t.Errorf("expected TestPodMonitorConverter to be called 1 time, got %d", testConv.calls)
+	}
+
+	// Verify report stats
+	if report.SuccessCount != 1 {
+		t.Errorf("expected SuccessCount to be 1, got %d", report.SuccessCount)
+	}
+	if report.WarningCount != 0 {
+		t.Errorf("expected WarningCount to be 0, got %d", report.WarningCount)
+	}
+	if report.SkippedCount != 0 {
+		t.Errorf("expected SkippedCount to be 0, got %d", report.SkippedCount)
+	}
+	if report.FailedCount != 0 {
+		t.Errorf("expected FailedCount to be 0, got %d", report.FailedCount)
+	}
+
+	// Verify that the PodMonitor resolved the Service successfully inside the list!
+	stderrLogs := stderrBuf.String()
+	if !strings.Contains(stderrLogs, "[INFO] [PodMonitor:default/my-monitor] Successfully resolved backing-service") {
+		t.Errorf("expected reference to be successfully resolved inside list, got logs: %q", stderrLogs)
+	}
+}

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -111,7 +111,7 @@ spec:
 	if !strings.Contains(stderrLogs, "[INFO] [DummyResource:default/my-dummy] Successfully resolved backing-service") {
 		t.Errorf("expected formatted INFO log in Stderr, got: %q", stderrLogs)
 	}
-	if !strings.Contains(stderrLogs, "[SUCCESS] [DummyResource:default/my-dummy] Translated successfully") {
+	if !strings.Contains(stderrLogs, "[SUCCESS] [DummyResource:default/my-dummy] Converted successfully") {
 		t.Errorf("expected formatted SUCCESS log in Stderr, got: %q", stderrLogs)
 	}
 }
@@ -196,7 +196,7 @@ spec:
 	if !strings.Contains(stderrLogs, "[ERROR] ["+inputFilePath+"] Skipping file due to parse error") {
 		t.Errorf("expected formatted [ERROR] log in Stderr, got: %q", stderrLogs)
 	}
-	if !strings.Contains(stderrLogs, "resource of kind \"PodMonitor\" is missing metadata.name") {
+	if !strings.Contains(stderrLogs, "malformed resource: apiVersion, kind, and metadata.name must all be specified") {
 		t.Errorf("expected underlying parse error in Stderr, got: %q", stderrLogs)
 	}
 }

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -16,6 +16,8 @@ package migrate
 
 import (
 	"bytes"
+	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,28 +35,15 @@ func (d *DummyConverter) ImportKey() string {
 	return "DummyResource"
 }
 
-func (d *DummyConverter) Convert(unstruct *unstructured.Unstructured, cache *ResourceCache) ([]*unstructured.Unstructured, []LogMessage, error) {
+func (d *DummyConverter) Convert(_ context.Context, logger *slog.Logger, unstruct *unstructured.Unstructured, cache *ResourceCache) ([]*unstructured.Unstructured, error) {
 	d.calls++
 
 	_, found := cache.Get("Service", unstruct.GetNamespace(), "backing-service")
 
-	logs := []LogMessage{}
 	if !found {
-		logs = append(logs, LogMessage{
-			Level:     LevelWarning,
-			Kind:      unstruct.GetKind(),
-			Namespace: unstruct.GetNamespace(),
-			Name:      unstruct.GetName(),
-			Message:   "backing-service not found in cache",
-		})
+		logger.Warn("backing-service not found in cache")
 	} else {
-		logs = append(logs, LogMessage{
-			Level:     LevelInfo,
-			Kind:      unstruct.GetKind(),
-			Namespace: unstruct.GetNamespace(),
-			Name:      unstruct.GetName(),
-			Message:   "Successfully resolved backing-service",
-		})
+		logger.Info("Successfully resolved backing-service")
 	}
 
 	out := &unstructured.Unstructured{}
@@ -63,7 +52,7 @@ func (d *DummyConverter) Convert(unstruct *unstructured.Unstructured, cache *Res
 	out.SetName("translated-" + unstruct.GetName())
 	out.SetNamespace(unstruct.GetNamespace())
 
-	return []*unstructured.Unstructured{out}, logs, nil
+	return []*unstructured.Unstructured{out}, nil
 }
 
 func TestMigratorCacheAndExtensibility(t *testing.T) {
@@ -93,7 +82,6 @@ spec:
 	}
 
 	migrator := NewMigrator()
-	// Redirect output to buffers to avoid cluttering test logs and verify output
 	var stdoutBuf, stderrBuf bytes.Buffer
 	migrator.Stdout = &stdoutBuf
 	migrator.Stderr = &stderrBuf
@@ -107,12 +95,11 @@ spec:
 		t.Fatalf("Run failed: %v", err)
 	}
 
-	// Verify converter was called
 	if dummyConv.calls != 1 {
 		t.Errorf("expected DummyConverter to be called 1 time, got %d", dummyConv.calls)
 	}
 
-	// Verify report stats (should be success, since backing-service was found)
+	// Verify report stats
 	if report.SuccessCount != 1 {
 		t.Errorf("expected SuccessCount to be 1, got %d", report.SuccessCount)
 	}
@@ -120,39 +107,32 @@ spec:
 		t.Errorf("expected WarningCount to be 0, got %d", report.WarningCount)
 	}
 
-	// Verify logs contains the INFO log
-	foundInfo := false
-	for _, log := range report.Logs {
-		if log.Level == LevelInfo && strings.Contains(log.Message, "Successfully resolved backing-service") {
-			foundInfo = true
-		}
+	stderrLogs := stderrBuf.String()
+	if !strings.Contains(stderrLogs, "[INFO] [DummyResource:default/my-dummy] Successfully resolved backing-service") {
+		t.Errorf("expected formatted INFO log in Stderr, got: %q", stderrLogs)
 	}
-	if !foundInfo {
-		t.Error("expected INFO log about resolving backing-service was not found in report")
+	if !strings.Contains(stderrLogs, "[SUCCESS] [DummyResource:default/my-dummy] Translated successfully") {
+		t.Errorf("expected formatted SUCCESS log in Stderr, got: %q", stderrLogs)
 	}
 }
 
 func TestResourceCacheNamespaceScoping(t *testing.T) {
 	cache := NewResourceCache()
 
-	// 1. Test defaulting of omitted namespace for namespaced resources
 	omittedNsRes := &unstructured.Unstructured{}
 	omittedNsRes.SetKind("PodMonitor")
 	omittedNsRes.SetName("my-monitor-omitted")
-	omittedNsRes.SetNamespace("") // Omitted in YAML
+	omittedNsRes.SetNamespace("")
 
 	cache.Add(omittedNsRes)
 
-	// It should be stored under "default"
 	if _, found := cache.Get("PodMonitor", "default", "my-monitor-omitted"); !found {
 		t.Error("expected namespaced resource with omitted namespace to be defaulted to 'default'")
 	}
-	// It should NOT be found under empty namespace
 	if _, found := cache.Get("PodMonitor", "", "my-monitor-omitted"); found {
 		t.Error("expected namespaced resource with omitted namespace NOT to be found under empty namespace")
 	}
 
-	// 2. Test strict namespace isolation
 	nsARes := &unstructured.Unstructured{}
 	nsARes.SetKind("PodMonitor")
 	nsARes.SetName("common-name")
@@ -160,17 +140,63 @@ func TestResourceCacheNamespaceScoping(t *testing.T) {
 
 	cache.Add(nsARes)
 
-	// Querying in namespace-b should NOT return the resource from namespace-a
 	if _, found := cache.Get("PodMonitor", "namespace-b", "common-name"); found {
 		t.Error("expected strict namespace isolation; found resource from namespace-a when querying namespace-b")
 	}
 
-	// Querying in namespace-a should find it
 	res, found := cache.Get("PodMonitor", "namespace-a", "common-name")
 	if !found {
 		t.Fatal("expected to find resource in namespace-a")
 	}
 	if res.GetNamespace() != "namespace-a" {
 		t.Errorf("expected found resource to have namespace 'namespace-a', got %q", res.GetNamespace())
+	}
+}
+
+func TestMigratorMalformedInput(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// YAML resource with a Kind but completely missing metadata.name
+	malformedYAML := `
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: my-app
+`
+	inputFilePath := filepath.Join(tmpDir, "bad_resource.yaml")
+	if err := os.WriteFile(inputFilePath, []byte(malformedYAML), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	migrator := NewMigrator()
+	var stdoutBuf, stderrBuf bytes.Buffer
+	migrator.Stdout = &stdoutBuf
+	migrator.Stderr = &stderrBuf
+
+	// Run migration on the directory containing the malformed file
+	report, err := migrator.Run(tmpDir)
+	if err != nil {
+		t.Fatalf("Run should not return a fatal error for directory walks, got: %v", err)
+	}
+
+	// Verify that the file parse error was caught and counted as a failure.
+	if report.FailedCount != 1 {
+		t.Errorf("expected FailedCount to be 1, got %d", report.FailedCount)
+	}
+	if report.SuccessCount != 0 {
+		t.Errorf("expected SuccessCount to be 0, got %d", report.SuccessCount)
+	}
+
+	// Verify that a [ERROR] log was printed to Stderr showing the file path and exact parse error
+	stderrLogs := stderrBuf.String()
+	if !strings.Contains(stderrLogs, "[ERROR] ["+inputFilePath+"] Skipping file due to parse error") {
+		t.Errorf("expected formatted [ERROR] log in Stderr, got: %q", stderrLogs)
+	}
+	if !strings.Contains(stderrLogs, "resource of kind \"PodMonitor\" is missing metadata.name") {
+		t.Errorf("expected underlying parse error in Stderr, got: %q", stderrLogs)
 	}
 }

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package migrate
 
 import (
@@ -53,11 +67,7 @@ func (d *DummyConverter) Convert(unstruct *unstructured.Unstructured, cache *Res
 }
 
 func TestMigratorCacheAndExtensibility(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "migrate-test-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	yamlContent := `
 apiVersion: monitoring.coreos.com/v1

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -261,3 +261,76 @@ spec:
 		t.Errorf("expected formatted [SKIPPED] log in Stderr, got: %q", stderrLogs)
 	}
 }
+
+func TestMigratorMultipleInputs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// 1. Write a Service manifest to a separate file
+	serviceYAML := `
+apiVersion: v1
+kind: Service
+metadata:
+  name: backing-service
+  namespace: default
+spec:
+  ports:
+  - port: 80
+`
+	servicePath := filepath.Join(tmpDir, "service.yaml")
+	if err := os.WriteFile(servicePath, []byte(serviceYAML), 0644); err != nil {
+		t.Fatalf("failed to write service file: %v", err)
+	}
+
+	// 2. Write a PodMonitor manifest referencing that service to a separate file
+	podMonitorYAML := `
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: my-monitor
+  namespace: default
+spec:
+  foo: bar
+`
+	podMonitorPath := filepath.Join(tmpDir, "podmonitor.yaml")
+	if err := os.WriteFile(podMonitorPath, []byte(podMonitorYAML), 0644); err != nil {
+		t.Fatalf("failed to write podmonitor file: %v", err)
+	}
+
+	migrator := NewMigrator()
+	var stdoutBuf, stderrBuf bytes.Buffer
+	migrator.Stdout = &stdoutBuf
+	migrator.Stderr = &stderrBuf
+
+	testConv := &TestPodMonitorConverter{}
+	migrator.RegisterConverter(testConv)
+
+	// Run migration passing both files explicitly!
+	report, err := migrator.Run(servicePath, podMonitorPath)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if testConv.calls != 1 {
+		t.Errorf("expected TestPodMonitorConverter to be called 1 time, got %d", testConv.calls)
+	}
+
+	// Verify report stats
+	if report.SuccessCount != 1 {
+		t.Errorf("expected SuccessCount to be 1, got %d", report.SuccessCount)
+	}
+	if report.WarningCount != 0 {
+		t.Errorf("expected WarningCount to be 0, got %d", report.WarningCount)
+	}
+	if report.SkippedCount != 0 {
+		t.Errorf("expected SkippedCount to be 0, got %d", report.SkippedCount)
+	}
+	if report.FailedCount != 0 {
+		t.Errorf("expected FailedCount to be 0, got %d", report.FailedCount)
+	}
+
+	// Verify that the reference was successfully resolved across the separate files!
+	stderrLogs := stderrBuf.String()
+	if !strings.Contains(stderrLogs, "[INFO] [PodMonitor:default/my-monitor] Successfully resolved backing-service") {
+		t.Errorf("expected reference to be successfully resolved, got logs: %q", stderrLogs)
+	}
+}

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -110,6 +110,19 @@ spec:
 		t.Errorf("expected SkippedCount to be 0, got %d", report.SkippedCount)
 	}
 
+	// Verify in-memory converted outputs
+	if len(report.Outputs) != 1 {
+		t.Errorf("expected 1 output resource, got %d", len(report.Outputs))
+	} else {
+		out := report.Outputs[0]
+		if out.GetKind() != "TranslatedDummy" {
+			t.Errorf("expected output kind 'TranslatedDummy', got %q", out.GetKind())
+		}
+		if out.GetName() != "translated-my-monitor" {
+			t.Errorf("expected output name 'translated-my-monitor', got %q", out.GetName())
+		}
+	}
+
 	stderrLogs := stderrBuf.String()
 	if !strings.Contains(stderrLogs, "[INFO] [PodMonitor:default/my-monitor] Successfully resolved backing-service") {
 		t.Errorf("expected formatted INFO log in Stderr, got: %q", stderrLogs)

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -57,19 +57,26 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
 	if name == "" {
 		return errors.New("cannot add resource with empty name to cache")
 	}
+	kind := u.GetKind()
+	if kind == "" {
+		return errors.New("cannot add resource with empty kind to cache")
+	}
+	apiVersion := u.GetAPIVersion()
+	if apiVersion == "" {
+		return errors.New("cannot add resource with empty apiVersion to cache")
+	}
 
 	if c.resources == nil {
 		c.resources = make(map[string]map[string]*unstructured.Unstructured)
 	}
 
-	kind := u.GetKind()
 	if _, ok := c.resources[kind]; !ok {
 		c.resources[kind] = make(map[string]*unstructured.Unstructured)
 	}
 
 	ns := u.GetNamespace()
 
-	key := fmt.Sprintf("%s/%s", ns, u.GetName())
+	key := fmt.Sprintf("%s/%s", ns, name)
 	c.resources[kind][key] = u
 	return nil
 }

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -57,6 +57,7 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) {
 		c.resources[kind] = make(map[string]*unstructured.Unstructured)
 	}
 
+	// Safe to default since we only ingest namespaced resources.
 	ns := u.GetNamespace()
 	if ns == "" {
 		ns = "default"

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -45,6 +45,13 @@ func NewResourceCache() *ResourceCache {
 
 // Add adds a resource to the cache, defaulting empty namespaces to "default".
 func (c *ResourceCache) Add(u *unstructured.Unstructured) {
+	if c == nil || u == nil {
+		return
+	}
+	if c.resources == nil {
+		c.resources = make(map[string]map[string]*unstructured.Unstructured)
+	}
+
 	kind := u.GetKind()
 	if _, ok := c.resources[kind]; !ok {
 		c.resources[kind] = make(map[string]*unstructured.Unstructured)
@@ -62,6 +69,9 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) {
 
 // Get retrieves a resource from the cache by kind, namespace, and name.
 func (c *ResourceCache) Get(kind, namespace, name string) (*unstructured.Unstructured, bool) {
+	if c == nil || c.resources == nil {
+		return nil, false
+	}
 	nsMap, ok := c.resources[kind]
 	if !ok {
 		return nil, false

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -15,45 +15,19 @@
 package migrate
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
-
-// LogLevel defines the severity of a migration log.
-type LogLevel string
-
-const (
-	LevelInfo    LogLevel = "INFO"
-	LevelWarning LogLevel = "WARNING"
-	LevelError   LogLevel = "ERROR"
-	LevelSuccess LogLevel = "SUCCESS"
-)
-
-// LogMessage represents a structured log entry associated with a specific resource.
-type LogMessage struct {
-	Level     LogLevel
-	Kind      string
-	Namespace string
-	Name      string
-	Message   string
-}
-
-// String formats the log message consistently: [LEVEL] [Kind: namespace/name] Message.
-func (l LogMessage) String() string {
-	if l.Kind == "" && l.Namespace == "" {
-		return fmt.Sprintf("[%s] [%s] %s", l.Level, l.Name, l.Message)
-	}
-	return fmt.Sprintf("[%s] [%s:%s/%s] %s", l.Level, l.Kind, l.Namespace, l.Name, l.Message)
-}
 
 // ResourceConverter defines the interface for converting a specific Kubernetes resource kind.
 type ResourceConverter interface {
 	// ImportKey returns the Kind of the resource this converter handles (e.g., "PodMonitor").
 	ImportKey() string
-	// Convert translates the input unstructured resource to one or more output unstructured resources.
-	// It returns the converted resources, structured log messages (warnings/infos), and any fatal error.
-	Convert(unstruct *unstructured.Unstructured, cache *ResourceCache) ([]*unstructured.Unstructured, []LogMessage, error)
+	// Convert translates the input unstructured resource to one or more GKE resources.
+	Convert(ctx context.Context, logger *slog.Logger, unstruct *unstructured.Unstructured, cache *ResourceCache) (outputs []*unstructured.Unstructured, err error)
 }
 
 // ResourceCache stores parsed Kubernetes resources for cross-resource resolution.
@@ -69,7 +43,7 @@ func NewResourceCache() *ResourceCache {
 	}
 }
 
-// Add adds a resource to the cache.
+// Add adds a resource to the cache, defaulting empty namespaces to "default".
 func (c *ResourceCache) Add(u *unstructured.Unstructured) {
 	kind := u.GetKind()
 	if _, ok := c.resources[kind]; !ok {
@@ -78,7 +52,8 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) {
 
 	ns := u.GetNamespace()
 	if ns == "" {
-		ns = "default" // All Prometheus Operator and K8s inputs are namespaced. Default to "default" if omitted.
+		ns = "default"
+		u.SetNamespace("default") // Explicitly write "default" namespace to the object.
 	}
 
 	key := fmt.Sprintf("%s/%s", ns, u.GetName())

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -23,11 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// ResourceConverter defines the interface for converting a specific Kubernetes resource kind.
+// ResourceConverter defines the interface for converting a specific Prometheus Operator resource kind.
 type ResourceConverter interface {
 	// ImportKey returns the Kind of the resource this converter handles (e.g., "PodMonitor").
 	ImportKey() string
-	// Convert translates the input unstructured resource to one or more GKE resources.
+	// Convert translates the input unstructured resource to one or more GMP resources.
 	Convert(ctx context.Context, logger *slog.Logger, unstruct *unstructured.Unstructured, cache *ResourceCache) (outputs []*unstructured.Unstructured, err error)
 }
 

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package migrate
 
 import (

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -63,11 +63,9 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
 		c.resources[kind] = make(map[string]*unstructured.Unstructured)
 	}
 
-	// Safe to default since we only ingest namespaced resources.
 	ns := u.GetNamespace()
 	if ns == "" {
 		ns = "default"
-		u.SetNamespace("default") // Explicitly write "default" namespace to the object.
 	}
 
 	key := fmt.Sprintf("%s/%s", ns, u.GetName())
@@ -79,6 +77,9 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
 func (c *ResourceCache) Get(kind, namespace, name string) (*unstructured.Unstructured, bool) {
 	if c == nil || c.resources == nil {
 		return nil, false
+	}
+	if namespace == "" {
+		namespace = "default"
 	}
 	nsMap, ok := c.resources[kind]
 	if !ok {

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -45,7 +45,6 @@ func NewResourceCache() *ResourceCache {
 }
 
 // Add adds a resource to the cache, returning an error if inputs are invalid.
-// Defaulting empty namespaces to "default".
 func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
 	if c == nil {
 		return errors.New("cannot add to nil ResourceCache")

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -1,0 +1,83 @@
+package migrate
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// LogLevel defines the severity of a migration log.
+type LogLevel string
+
+const (
+	LevelInfo    LogLevel = "INFO"
+	LevelWarning LogLevel = "WARNING"
+	LevelError   LogLevel = "ERROR"
+	LevelSuccess LogLevel = "SUCCESS"
+)
+
+// LogMessage represents a structured log entry associated with a specific resource.
+type LogMessage struct {
+	Level     LogLevel
+	Kind      string
+	Namespace string
+	Name      string
+	Message   string
+}
+
+// String formats the log message consistently: [LEVEL] [Kind: namespace/name] Message.
+func (l LogMessage) String() string {
+	if l.Kind == "" && l.Namespace == "" {
+		return fmt.Sprintf("[%s] [%s] %s", l.Level, l.Name, l.Message)
+	}
+	return fmt.Sprintf("[%s] [%s:%s/%s] %s", l.Level, l.Kind, l.Namespace, l.Name, l.Message)
+}
+
+// ResourceConverter defines the interface for converting a specific Kubernetes resource kind.
+type ResourceConverter interface {
+	// ImportKey returns the Kind of the resource this converter handles (e.g., "PodMonitor").
+	ImportKey() string
+	// Convert translates the input unstructured resource to one or more output unstructured resources.
+	// It returns the converted resources, structured log messages (warnings/infos), and any fatal error.
+	Convert(unstruct *unstructured.Unstructured, cache *ResourceCache) ([]*unstructured.Unstructured, []LogMessage, error)
+}
+
+// ResourceCache stores parsed Kubernetes resources for cross-resource resolution.
+type ResourceCache struct {
+	// Map of Kind -> Namespace/Name -> Resource
+	resources map[string]map[string]*unstructured.Unstructured
+}
+
+// NewResourceCache creates a new initialized ResourceCache.
+func NewResourceCache() *ResourceCache {
+	return &ResourceCache{
+		resources: make(map[string]map[string]*unstructured.Unstructured),
+	}
+}
+
+// Add adds a resource to the cache.
+func (c *ResourceCache) Add(u *unstructured.Unstructured) {
+	kind := u.GetKind()
+	if _, ok := c.resources[kind]; !ok {
+		c.resources[kind] = make(map[string]*unstructured.Unstructured)
+	}
+
+	ns := u.GetNamespace()
+	if ns == "" {
+		ns = "default" // All Prometheus Operator and K8s inputs are namespaced. Default to "default" if omitted.
+	}
+
+	key := fmt.Sprintf("%s/%s", ns, u.GetName())
+	c.resources[kind][key] = u
+}
+
+// Get retrieves a resource from the cache by kind, namespace, and name.
+func (c *ResourceCache) Get(kind, namespace, name string) (*unstructured.Unstructured, bool) {
+	nsMap, ok := c.resources[kind]
+	if !ok {
+		return nil, false
+	}
+	key := fmt.Sprintf("%s/%s", namespace, name)
+	r, ok := nsMap[key]
+	return r, ok
+}

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -16,6 +16,7 @@ package migrate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -43,11 +44,16 @@ func NewResourceCache() *ResourceCache {
 	}
 }
 
-// Add adds a resource to the cache, defaulting empty namespaces to "default".
-func (c *ResourceCache) Add(u *unstructured.Unstructured) {
-	if c == nil || u == nil {
-		return
+// Add adds a resource to the cache, returning an error if inputs are invalid.
+// Defaulting empty namespaces to "default".
+func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
+	if c == nil {
+		return errors.New("cannot add to nil ResourceCache")
 	}
+	if u == nil {
+		return errors.New("cannot add nil resource to cache")
+	}
+
 	if c.resources == nil {
 		c.resources = make(map[string]map[string]*unstructured.Unstructured)
 	}
@@ -66,6 +72,7 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) {
 
 	key := fmt.Sprintf("%s/%s", ns, u.GetName())
 	c.resources[kind][key] = u
+	return nil
 }
 
 // Get retrieves a resource from the cache by kind, namespace, and name.

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -77,6 +77,9 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
 	ns := u.GetNamespace()
 
 	key := fmt.Sprintf("%s/%s", ns, name)
+	if _, exists := c.resources[kind][key]; exists {
+		return fmt.Errorf("duplicate resource %s/%s found in cache", kind, key)
+	}
 	c.resources[kind][key] = u
 	return nil
 }

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -54,6 +54,11 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
 		return errors.New("cannot add nil resource to cache")
 	}
 
+	name := u.GetName()
+	if name == "" {
+		return errors.New("cannot add resource with empty name to cache")
+	}
+
 	if c.resources == nil {
 		c.resources = make(map[string]map[string]*unstructured.Unstructured)
 	}
@@ -64,9 +69,6 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
 	}
 
 	ns := u.GetNamespace()
-	if ns == "" {
-		ns = "default"
-	}
 
 	key := fmt.Sprintf("%s/%s", ns, u.GetName())
 	c.resources[kind][key] = u
@@ -77,9 +79,6 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
 func (c *ResourceCache) Get(kind, namespace, name string) (*unstructured.Unstructured, bool) {
 	if c == nil || c.resources == nil {
 		return nil, false
-	}
-	if namespace == "" {
-		namespace = "default"
 	}
 	nsMap, ok := c.resources[kind]
 	if !ok {


### PR DESCRIPTION
This PR implements the migration pipeline and CLI carriage boilerplate for the `gmp-migrate` tool.
*   **CLI Carriage:** Command-line entrypoint supporting files, directories, and stdin/stdout streams.
*   **Parsed-Resource Cache:** Stores parsed namespaced resources for cross-reference during migrations.
*   **Migration Pipeline:** Orchestrator handling YAML parsing and converter execution..
*   **Decoupled Logging:** Structured logging (`LogMessage`, `MigrationReport`) routed to `Stderr` to keep `Stdout` clean for Unix piping.
*   **Unit Tests:** Validates cache isolation, converter registration, and logging.