### PR TITLE
Update versions on all binaries

### DIFF
--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -16,7 +16,7 @@ commonLabels: false
 namespace:
   public: gmp-public
   system: gmp-system
-version: 0.17.3
+version: 0.19.0
 images:
   # NOTE: All tags have to be quoted otherwise they might be treated as a number.
   bash:
@@ -30,16 +30,16 @@ images:
     tag: "v2.53.5-gmp.2-gke.0"
   configReloader:
     image: gke.gcr.io/prometheus-engine/config-reloader
-    tag: "v0.17.3-gke.0"
+    tag: "v0.19.0-gke.0"
   operator:
     image: gke.gcr.io/prometheus-engine/operator
-    tag: "v0.17.3-gke.0"
+    tag: "v0.19.0-gke.0"
   ruleEvaluator:
     image: gke.gcr.io/prometheus-engine/rule-evaluator
-    tag: "v0.17.3-gke.0"
+    tag: "v0.19.0-gke.0"
   datasourceSyncer:
     image: gke.gcr.io/prometheus-engine/datasource-syncer
-    tag: "v0.17.3-gke.0"
+    tag: "v0.19.0-gke.0"
 resources:
   alertManager:
     limits:

--- a/cmd/datasource-syncer/datasource-syncer.yaml
+++ b/cmd/datasource-syncer/datasource-syncer.yaml
@@ -41,7 +41,7 @@ spec:
                 - linux
       containers:
       - name: datasource-syncer-init
-        image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.17.3-gke.0
+        image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.19.0-gke.0
         args:
         - "--datasource-uids=$DATASOURCE_UIDS"
         - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"
@@ -79,7 +79,7 @@ spec:
                     - linux
           containers:
           - name: datasource-syncer
-            image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.17.3-gke.0
+            image: gke.gcr.io/prometheus-engine/datasource-syncer:v0.19.0-gke.0
             args:
             - "--datasource-uids=$DATASOURCE_UIDS"
             - "--grafana-api-endpoint=$GRAFANA_API_ENDPOINT"

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -347,7 +347,7 @@ spec:
       labels:
         app: managed-prometheus-collector
         app.kubernetes.io/name: collector
-        app.kubernetes.io/version: 0.17.3
+        app.kubernetes.io/version: 0.19.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -379,7 +379,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.17.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.19.0-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -551,14 +551,14 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: gmp-operator
         app.kubernetes.io/part-of: gmp
-        app.kubernetes.io/version: 0.17.3
+        app.kubernetes.io/version: 0.19.0
     spec:
       serviceAccountName: operator
       automountServiceAccountToken: true
       priorityClassName: gmp-critical
       containers:
       - name: operator
-        image: gke.gcr.io/prometheus-engine/operator:v0.17.3-gke.0
+        image: gke.gcr.io/prometheus-engine/operator:v0.19.0-gke.0
         args:
         - "--operator-namespace=gmp-system"
         - "--public-namespace=gmp-public"
@@ -654,7 +654,7 @@ spec:
       labels:
         app.kubernetes.io/name: rule-evaluator
         app: managed-prometheus-rule-evaluator
-        app.kubernetes.io/version: 0.17.3
+        app.kubernetes.io/version: 0.19.0
       annotations:
         # The emptyDir for the storage and config directories prevents cluster
         # autoscaling unless this annotation is set.
@@ -680,7 +680,7 @@ spec:
           readOnlyRootFilesystem: true
       containers:
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.17.3-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.19.0-gke.0
         args:
         - --config.file=/prometheus/config_out/config.yaml
         - --web.listen-address=:19092
@@ -722,7 +722,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.17.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.19.0-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml
@@ -829,7 +829,7 @@ spec:
       labels:
         app: managed-prometheus-alertmanager
         app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 0.17.3
+        app.kubernetes.io/version: 0.19.0
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         components.gke.io/component-name: managed_prometheus
@@ -888,7 +888,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.17.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.19.0-gke.0
         args:
         - --config-file=/alertmanager/config.yaml
         - --config-file-output=/alertmanager/config_out/config.yaml

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -118,7 +118,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rule-evaluator
-        app.kubernetes.io/version: 0.17.3
+        app.kubernetes.io/version: 0.19.0
     spec:
       serviceAccountName: rule-evaluator
       automountServiceAccountToken: true
@@ -131,7 +131,7 @@ spec:
           mountPath: /prometheus/config_out
       containers:
       - name: evaluator
-        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.17.3-gke.0
+        image: gke.gcr.io/prometheus-engine/rule-evaluator:v0.19.0-gke.0
         args:
         - "--config.file=/prometheus/config_out/config.yaml"
         - "--web.listen-address=:9092"
@@ -169,7 +169,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
       - name: config-reloader
-        image: gke.gcr.io/prometheus-engine/config-reloader:v0.17.3-gke.0
+        image: gke.gcr.io/prometheus-engine/config-reloader:v0.19.0-gke.0
         args:
         - --config-file=/prometheus/config/config.yaml
         - --config-file-output=/prometheus/config_out/config.yaml

--- a/ops/gmpctl/prep-rc.sh
+++ b/ops/gmpctl/prep-rc.sh
@@ -84,6 +84,11 @@ if [[ "${PROJECT}" == "prometheus-engine" ]]; then
       echo "❌  sed didn't replace?"
       exit 1
     fi
+    # Ensure versioned image tags match the release version.
+    for img in configReloader operator ruleEvaluator datasourceSyncer; do
+      echo "🔄  Ensuring v${CLEAN_TAG}-gke.0 on ${values_file} for ${img} tag..."
+      go tool -modfile="${DIR}/tools/go.mod" yq -i ".images.${img}.tag = \"v${CLEAN_TAG}-gke.0\"" "${values_file}"
+    done
   fi
   # For versions with export embedded.
   if [[ -f "${DIR}/pkg/export/export.go" ]]; then


### PR DESCRIPTION
- Bumps the release version to `0.19.0` and the corresponding component
  image tags to `v0.19.0-gke.0` in `charts/values.global.yaml`.
- Regenerates all Kubernetes manifests (`manifests/operator.yaml`,
  `manifests/rule-evaluator.yaml`, `cmd/datasource-syncer/datasource-syncer.yaml`)
  to propagate the new version.
- Updates `ops/gmpctl/prep-rc.sh` to automatically align the component
  image tags (`configReloader`, `operator`, `ruleEvaluator`, `datasourceSyncer`)
  with the release version in `values.global.yaml`.