### PR TITLE
PO to GMP Migration Tool: Podmonitor Endpoint Params, Target Labels, and Metric Relabelings

### DIFF
--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -21,6 +21,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// protectedLabels contains the list of labels that are protected by GMP and cannot
+// be overwritten by targetLabels or relabeling rules.
+var protectedLabels = map[string]bool{
+	"project_id":                true,
+	"location":                  true,
+	"cluster":                   true,
+	"namespace":                 true,
+	"job":                       true,
+	"instance":                  true,
+	"top_level_controller":      true,
+	"top_level_controller_type": true,
+	"__address__":               true,
+}
+
 // BuildTypeMeta constructs standard TypeMeta for a GMP resource Kind.
 func BuildTypeMeta(kind string) metav1.TypeMeta {
 	return metav1.TypeMeta{

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -106,6 +106,8 @@ func (m *Migrator) Run(inputPaths ...string) (*MigrationReport, error) {
 		}
 	}
 
+	// TODO(M2): Implement Prometheus CR monitor discovery filtering (podMonitorSelector / serviceMonitorSelector) before converting.
+
 	// 2. Run converters across the cached resources.
 	outputs := m.convertResources()
 	report.Outputs = outputs

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -158,7 +158,7 @@ func (c *PodMonitorConverter) convertEndpoints(
 	for i, ep := range endpoints {
 		gmpEp := monitoringv1.ScrapeEndpoint{}
 
-		// 1. Port mapping
+		// 1. Port mapping.
 		if ep.Port != "" {
 			gmpEp.Port = intstr.FromString(ep.Port)
 		} else if ep.TargetPort != nil { // nolint:staticcheck // Map deprecated TargetPort for backwards compatibility.
@@ -167,12 +167,12 @@ func (c *PodMonitorConverter) convertEndpoints(
 			return nil, fmt.Errorf("endpoint [%d]: port or targetPort must be set", i)
 		}
 
-		// 2. Basic Fields
+		// 2. Basic Fields.
 		gmpEp.Path = ep.Path
 		gmpEp.Scheme = strings.ToLower(ep.Scheme)
 		gmpEp.Params = ep.Params
 
-		// 3. Scrape Intervals & Timeouts
+		// 3. Scrape Intervals & Timeouts.
 		gmpEp.Interval = string(ep.Interval)
 		gmpEp.Timeout = string(ep.ScrapeTimeout)
 
@@ -200,7 +200,7 @@ func (c *PodMonitorConverter) convertEndpoints(
 		}
 		// TODO(M2): Inherit global scrape timeout from Prometheus CR if empty.
 
-		// 4. Relabeling Rules (MetricRelabelings)
+		// 4. Relabeling Rules (MetricRelabelings).
 		if len(ep.MetricRelabelConfigs) > 0 {
 			rules, err := c.convertMetricRelabelings(logger, ep.MetricRelabelConfigs)
 			if err != nil {
@@ -209,7 +209,7 @@ func (c *PodMonitorConverter) convertEndpoints(
 			gmpEp.MetricRelabeling = rules
 		}
 
-		// 5. Warnings for Unsupported Fields in Endpoint
+		// 5. Warnings for Unsupported Fields in Endpoint.
 		if ep.HonorLabels {
 			logger.Warn("Field 'honorLabels: true' is unsupported and dropped. GMP always overrides conflicting labels. Clashing metric labels will be renamed with the 'exported_' prefix.")
 		}

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -134,6 +134,8 @@ func (c *PodMonitorConverter) convertFromPodLabels(logger *slog.Logger, pm *pomo
 				To:   target,
 			})
 			seenTargets[target] = true
+		} else {
+			logger.Warn(fmt.Sprintf("Job label %q could not be mapped to 'exported_job' because 'exported_job' is already taken by another target label mapping.", pm.Spec.JobLabel))
 		}
 	}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -175,10 +175,83 @@ func (c *PodMonitorConverter) convertEndpoints(
 			}
 		}
 
+		// 4. Relabeling Rules (MetricRelabelings)
+		if len(ep.MetricRelabelConfigs) > 0 {
+			rules, err := c.convertMetricRelabelings(logger, ep.MetricRelabelConfigs)
+			if err != nil {
+				return nil, fmt.Errorf("endpoint [%d]: %w", i, err)
+			}
+			gmpEp.MetricRelabeling = rules
+		}
+
+		// 5. Warnings for Unsupported Fields in Endpoint
+		if ep.HonorLabels {
+			logger.Warn("Field 'honorLabels: true' is unsupported and dropped. GMP always overrides conflicting labels. Clashing metric labels will be renamed with the 'exported_' prefix.")
+		}
+		if ep.HonorTimestamps != nil && *ep.HonorTimestamps {
+			logger.Warn("Field 'honorTimestamps: true' is unsupported and dropped. GMP always uses the scrape ingestion timestamp. Target metric timestamps will be ignored.")
+		}
+		if ep.TrackTimestampsStaleness != nil {
+			logger.Warn("Field 'trackTimestampsStaleness' is unsupported in GMP and has been dropped.")
+		}
+
 		gmpEndpoints = append(gmpEndpoints, gmpEp)
 	}
 
 	return gmpEndpoints, nil
+}
+
+func (c *PodMonitorConverter) convertMetricRelabelings(
+	logger *slog.Logger,
+	configs []pomonitoringv1.RelabelConfig,
+) ([]monitoringv1.RelabelingRule, error) {
+	var rules []monitoringv1.RelabelingRule
+
+	for _, config := range configs {
+		action := strings.ToLower(config.Action)
+		if action == "labelmap" {
+			logger.Warn("metricRelabelings rule uses 'action: labelmap' which is not supported by GMP and has been dropped.")
+			continue
+		}
+
+		targetLabel := config.TargetLabel
+		if action == "replace" || action == "hashmod" || action == "lowercase" || action == "uppercase" || action == "keepequal" || action == "dropequal" || action == "" {
+			if protectedLabels[config.TargetLabel] {
+				targetLabel = "exported_" + config.TargetLabel
+				logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.",
+					config.TargetLabel, targetLabel))
+			}
+		}
+
+		rule := monitoringv1.RelabelingRule{
+			TargetLabel: targetLabel,
+			Regex:       config.Regex,
+			Modulus:     config.Modulus,
+		}
+		if config.Action != "" {
+			rule.Action = action
+		} else {
+			rule.Action = "replace" // Default is replace
+		}
+
+		if len(config.SourceLabels) > 0 {
+			rule.SourceLabels = make([]string, len(config.SourceLabels))
+			for i, sl := range config.SourceLabels {
+				rule.SourceLabels[i] = string(sl)
+			}
+		}
+
+		if config.Separator != nil {
+			rule.Separator = *config.Separator
+		}
+		if config.Replacement != nil {
+			rule.Replacement = *config.Replacement
+		}
+
+		rules = append(rules, rule)
+	}
+
+	return rules, nil
 }
 
 func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonitor, logger *slog.Logger) (*unstructured.Unstructured, error) {

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -108,22 +108,33 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 
 func (c *PodMonitorConverter) convertFromPodLabels(logger *slog.Logger, pm *pomonitoringv1.PodMonitor) []monitoringv1.LabelMapping {
 	var fromPod []monitoringv1.LabelMapping
+	seenTargets := make(map[string]bool)
 
 	for _, l := range pm.Spec.PodTargetLabels {
 		mapping := monitoringv1.LabelMapping{From: l}
+		target := l
 		if protectedLabels[l] {
 			mapping.To = "exported_" + l
+			target = mapping.To
 			logger.Warn(fmt.Sprintf("Pod target label %q is protected in GMP. Renamed target to %q.", l, mapping.To))
 		}
+		if seenTargets[target] {
+			continue
+		}
+		seenTargets[target] = true
 		fromPod = append(fromPod, mapping)
 	}
 
 	if pm.Spec.JobLabel != "" {
-		logger.Warn(fmt.Sprintf("GMP does not support overriding the protected 'job' label. Value on label %q has been copied into the target label 'exported_job'.", pm.Spec.JobLabel))
-		fromPod = append(fromPod, monitoringv1.LabelMapping{
-			From: pm.Spec.JobLabel,
-			To:   "exported_job",
-		})
+		target := "exported_job"
+		if !seenTargets[target] {
+			logger.Warn(fmt.Sprintf("GMP does not support overriding the protected 'job' label. Value on label %q has been copied into the target label 'exported_job'.", pm.Spec.JobLabel))
+			fromPod = append(fromPod, monitoringv1.LabelMapping{
+				From: pm.Spec.JobLabel,
+				To:   target,
+			})
+			seenTargets[target] = true
+		}
 	}
 
 	return fromPod

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -52,6 +52,8 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 
 	logger.Info("Successfully decoded PodMonitor", slog.String("name", podMonitor.Name))
 
+	// TODO(M2): Override local namespace scoping if Prometheus CR specifies ignoreNamespaceSelectors.
+
 	// 2. Determine Scoping based on namespaceSelector.
 	nsSel := podMonitor.Spec.NamespaceSelector
 
@@ -154,16 +156,18 @@ func (c *PodMonitorConverter) convertEndpoints(
 		gmpEp.Interval = string(ep.Interval)
 		gmpEp.Timeout = string(ep.ScrapeTimeout)
 
+		// TODO(M2): Inherit global scrape interval from Prometheus CR if empty.
 		if gmpEp.Interval == "" {
 			logger.Warn("Scrape interval is empty. Defaulting to '30s' as GMP requires this field.")
 			gmpEp.Interval = "30s"
 		}
 
+		intDur, err := prommodel.ParseDuration(gmpEp.Interval)
+		if err != nil {
+			return nil, fmt.Errorf("endpoint [%d]: invalid interval %q: %w", i, gmpEp.Interval, err)
+		}
+
 		if gmpEp.Timeout != "" {
-			intDur, err := prommodel.ParseDuration(gmpEp.Interval)
-			if err != nil {
-				return nil, fmt.Errorf("endpoint [%d]: invalid interval %q: %w", i, gmpEp.Interval, err)
-			}
 			toDur, err := prommodel.ParseDuration(gmpEp.Timeout)
 			if err != nil {
 				return nil, fmt.Errorf("endpoint [%d]: invalid scrapeTimeout %q: %w", i, gmpEp.Timeout, err)
@@ -174,6 +178,7 @@ func (c *PodMonitorConverter) convertEndpoints(
 				gmpEp.Timeout = gmpEp.Interval
 			}
 		}
+		// TODO(M2): Inherit global scrape timeout from Prometheus CR if empty.
 
 		// 4. Relabeling Rules (MetricRelabelings)
 		if len(ep.MetricRelabelConfigs) > 0 {

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -111,17 +111,24 @@ func (c *PodMonitorConverter) convertFromPodLabels(logger *slog.Logger, pm *pomo
 	seenTargets := make(map[string]bool)
 
 	for _, l := range pm.Spec.PodTargetLabels {
-		mapping := monitoringv1.LabelMapping{From: l}
 		target := l
 		if protectedLabels[l] {
-			mapping.To = "exported_" + l
-			target = mapping.To
-			logger.Warn(fmt.Sprintf("Pod target label %q is protected in GMP. Renamed target to %q.", l, mapping.To))
+			target = "exported_" + l
 		}
+
 		if seenTargets[target] {
+			logger.Warn(fmt.Sprintf("Pod target label %q maps to target label %q which is already taken. Skipping.", l, target))
 			continue
 		}
+
 		seenTargets[target] = true
+		mapping := monitoringv1.LabelMapping{From: l}
+
+		if target != l {
+			mapping.To = target
+			logger.Warn(fmt.Sprintf("Pod target label %q is protected in GMP. Renamed target to %q.", l, target))
+		}
+
 		fromPod = append(fromPod, mapping)
 	}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -104,6 +104,29 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 	return []*unstructured.Unstructured{u}, nil
 }
 
+func (c *PodMonitorConverter) convertFromPodLabels(logger *slog.Logger, pm *pomonitoringv1.PodMonitor) []monitoringv1.LabelMapping {
+	var fromPod []monitoringv1.LabelMapping
+
+	for _, l := range pm.Spec.PodTargetLabels {
+		mapping := monitoringv1.LabelMapping{From: l}
+		if protectedLabels[l] {
+			mapping.To = "exported_" + l
+			logger.Warn(fmt.Sprintf("Pod target label %q is protected in GMP. Renamed target to %q.", l, mapping.To))
+		}
+		fromPod = append(fromPod, mapping)
+	}
+
+	if pm.Spec.JobLabel != "" {
+		logger.Warn(fmt.Sprintf("GMP does not support overriding the protected 'job' label. Value on label %q has been copied into the target label 'exported_job'.", pm.Spec.JobLabel))
+		fromPod = append(fromPod, monitoringv1.LabelMapping{
+			From: pm.Spec.JobLabel,
+			To:   "exported_job",
+		})
+	}
+
+	return fromPod
+}
+
 func (c *PodMonitorConverter) convertEndpoints(
 	logger *slog.Logger,
 	endpoints []pomonitoringv1.PodMetricsEndpoint,
@@ -170,6 +193,9 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		Spec: monitoringv1.PodMonitoringSpec{
 			Selector:  pm.Spec.Selector,
 			Endpoints: endpoints,
+			TargetLabels: monitoringv1.TargetLabels{
+				FromPod: c.convertFromPodLabels(logger, pm),
+			},
 		},
 	}
 
@@ -197,6 +223,9 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		Spec: monitoringv1.ClusterPodMonitoringSpec{
 			Selector:  pm.Spec.Selector,
 			Endpoints: endpoints,
+			TargetLabels: monitoringv1.ClusterTargetLabels{
+				FromPod: c.convertFromPodLabels(logger, pm),
+			},
 		},
 	}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -214,13 +214,17 @@ func (c *PodMonitorConverter) convertMetricRelabelings(
 
 	for _, config := range configs {
 		action := strings.ToLower(config.Action)
+		if action == "" {
+			action = "replace"
+		}
+
 		if action == "labelmap" {
 			logger.Warn("metricRelabelings rule uses 'action: labelmap' which is not supported by GMP and has been dropped.")
 			continue
 		}
 
 		targetLabel := config.TargetLabel
-		if action == "replace" || action == "hashmod" || action == "lowercase" || action == "uppercase" || action == "keepequal" || action == "dropequal" || action == "" {
+		if action == "replace" || action == "hashmod" || action == "lowercase" || action == "uppercase" {
 			if protectedLabels[config.TargetLabel] {
 				targetLabel = "exported_" + config.TargetLabel
 				logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.",
@@ -232,11 +236,7 @@ func (c *PodMonitorConverter) convertMetricRelabelings(
 			TargetLabel: targetLabel,
 			Regex:       config.Regex,
 			Modulus:     config.Modulus,
-		}
-		if config.Action != "" {
-			rule.Action = action
-		} else {
-			rule.Action = "replace" // Default is replace
+			Action:      action,
 		}
 
 		if len(config.SourceLabels) > 0 {

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -19,11 +19,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
 	pomonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	prommodel "github.com/prometheus/common/model"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // PodMonitorConverter implements ResourceConverter for PodMonitor resources.
@@ -101,13 +104,72 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 	return []*unstructured.Unstructured{u}, nil
 }
 
+func (c *PodMonitorConverter) convertEndpoints(
+	logger *slog.Logger,
+	endpoints []pomonitoringv1.PodMetricsEndpoint,
+) ([]monitoringv1.ScrapeEndpoint, error) {
+	var gmpEndpoints []monitoringv1.ScrapeEndpoint
+
+	for i, ep := range endpoints {
+		gmpEp := monitoringv1.ScrapeEndpoint{}
+
+		// 1. Port mapping
+		if ep.Port != "" {
+			gmpEp.Port = intstr.FromString(ep.Port)
+		} else if ep.TargetPort != nil { // nolint:staticcheck // Map deprecated TargetPort for backwards compatibility.
+			gmpEp.Port = *ep.TargetPort // nolint:staticcheck // Map deprecated TargetPort for backwards compatibility.
+		} else {
+			return nil, fmt.Errorf("endpoint [%d]: port or targetPort must be set", i)
+		}
+
+		// 2. Basic Fields
+		gmpEp.Path = ep.Path
+		gmpEp.Scheme = strings.ToLower(ep.Scheme)
+		gmpEp.Params = ep.Params
+
+		// 3. Scrape Intervals & Timeouts
+		gmpEp.Interval = string(ep.Interval)
+		gmpEp.Timeout = string(ep.ScrapeTimeout)
+
+		if gmpEp.Interval == "" {
+			logger.Warn("Scrape interval is empty. Defaulting to '30s' as GMP requires this field.")
+			gmpEp.Interval = "30s"
+		}
+
+		if gmpEp.Timeout != "" {
+			intDur, err := prommodel.ParseDuration(gmpEp.Interval)
+			if err != nil {
+				return nil, fmt.Errorf("endpoint [%d]: invalid interval %q: %w", i, gmpEp.Interval, err)
+			}
+			toDur, err := prommodel.ParseDuration(gmpEp.Timeout)
+			if err != nil {
+				return nil, fmt.Errorf("endpoint [%d]: invalid scrapeTimeout %q: %w", i, gmpEp.Timeout, err)
+			}
+			if toDur > intDur {
+				logger.Warn(fmt.Sprintf("Scrape timeout %q is larger than scrape interval %q. Capping timeout to %q.",
+					gmpEp.Timeout, gmpEp.Interval, gmpEp.Interval))
+				gmpEp.Timeout = gmpEp.Interval
+			}
+		}
+
+		gmpEndpoints = append(gmpEndpoints, gmpEp)
+	}
+
+	return gmpEndpoints, nil
+}
+
 func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonitor, logger *slog.Logger) (*unstructured.Unstructured, error) {
+	endpoints, err := c.convertEndpoints(logger, pm.Spec.PodMetricsEndpoints)
+	if err != nil {
+		return nil, err
+	}
+
 	gmpPM := &monitoringv1.PodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindPodMonitoring),
 		ObjectMeta: CopyObjectMeta(pm.ObjectMeta, pm.Namespace, logger),
 		Spec: monitoringv1.PodMonitoringSpec{
-			Selector: pm.Spec.Selector,
-			// TODO: Migrate pm.Spec.PodMetricsEndpoints to Spec.Endpoints in subsequent step.
+			Selector:  pm.Spec.Selector,
+			Endpoints: endpoints,
 		},
 	}
 
@@ -116,7 +178,6 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		return nil, fmt.Errorf("failed to marshal PodMonitoring: %w", err)
 	}
 
-	// Explicitly restore type meta as ToUnstructured sometimes strips it.
 	u := &unstructured.Unstructured{Object: unstructuredMap}
 	u.SetAPIVersion(GMPAPIVersion)
 	u.SetKind(KindPodMonitoring)
@@ -125,12 +186,17 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 }
 
 func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.PodMonitor, logger *slog.Logger) (*unstructured.Unstructured, error) {
+	endpoints, err := c.convertEndpoints(logger, pm.Spec.PodMetricsEndpoints)
+	if err != nil {
+		return nil, err
+	}
+
 	gmpCPM := &monitoringv1.ClusterPodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
-		ObjectMeta: CopyObjectMeta(pm.ObjectMeta, "", logger), // Cluster-scoped, namespace is omitted
+		ObjectMeta: CopyObjectMeta(pm.ObjectMeta, "", logger),
 		Spec: monitoringv1.ClusterPodMonitoringSpec{
-			Selector: pm.Spec.Selector,
-			// TODO: Migrate pm.Spec.PodMetricsEndpoints to Spec.Endpoints in subsequent step.
+			Selector:  pm.Spec.Selector,
+			Endpoints: endpoints,
 		},
 	}
 

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestPodMonitorConversion(t *testing.T) {
@@ -232,6 +233,228 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Valid Basic Mapping & Capping & Defaulting",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "frontend-monitor",
+					Namespace: "frontend",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "frontend"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:          "web",
+							Path:          "/telemetry",
+							Scheme:        "HTTPS",
+							Interval:      "15s",
+							ScrapeTimeout: "10s",
+							Params:        map[string][]string{"debug": {"true"}},
+						},
+						{
+							TargetPort:    &intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+							Interval:      "10s",
+							ScrapeTimeout: "15s",
+						},
+						{
+							Port: "metrics",
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "monitoring.googleapis.com/v1",
+						Kind:       KindPodMonitoring,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "frontend-monitor",
+						Namespace: "frontend",
+					},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app": "frontend",
+							},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("web"),
+								Path:     "/telemetry",
+								Scheme:   "https",
+								Interval: "15s",
+								Timeout:  "10s",
+								Params:   map[string][]string{"debug": {"true"}},
+							},
+							{
+								Port:     intstr.FromInt(8080),
+								Interval: "10s",
+								Timeout:  "10s",
+							},
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Target Labels Mapping",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "label-monitor",
+					Namespace: "frontend",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					JobLabel:        "app-name",
+					PodTargetLabels: []string{"env", "instance", "version"},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "monitoring.googleapis.com/v1",
+						Kind:       KindPodMonitoring,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "label-monitor",
+						Namespace: "frontend",
+					},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+						TargetLabels: monitoringv1.TargetLabels{
+							FromPod: []monitoringv1.LabelMapping{
+								{From: "env"},
+								{From: "instance", To: "exported_instance"},
+								{From: "version"},
+								{From: "app-name", To: "exported_job"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Relabeling and Unsupported Warnings Mapping",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "relabel-monitor",
+					Namespace: "frontend",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "relabel-app"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:            "metrics",
+							HonorLabels:     true,
+							HonorTimestamps: ptrTo(true),
+							MetricRelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__name__"},
+									TargetLabel:  "instance",
+									Action:       "Replace",
+								},
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"container"},
+									TargetLabel:  "container_name",
+									Action:       "replace",
+								},
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"temp"},
+									Action:       "LabelMap",
+								},
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"namespace"},
+									Regex:        "default",
+									Action:       "keep",
+								},
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"job"},
+									Regex:        "api-.*",
+									Action:       "drop",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "monitoring.googleapis.com/v1",
+						Kind:       KindPodMonitoring,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "relabel-monitor",
+						Namespace: "frontend",
+					},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app": "relabel-app",
+							},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+								MetricRelabeling: []monitoringv1.RelabelingRule{
+									{
+										SourceLabels: []string{"__name__"},
+										TargetLabel:  "exported_instance",
+										Action:       "replace",
+									},
+									{
+										SourceLabels: []string{"container"},
+										TargetLabel:  "container_name",
+										Action:       "replace",
+									},
+									{
+										SourceLabels: []string{"namespace"},
+										Regex:        "default",
+										Action:       "keep",
+									},
+									{
+										SourceLabels: []string{"job"},
+										Regex:        "api-.*",
+										Action:       "drop",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}
@@ -294,6 +517,10 @@ func toUnstructured(t *testing.T, obj any) *unstructured.Unstructured {
 		t.Fatalf("failed to convert object to unstructured: %v", err)
 	}
 	return &unstructured.Unstructured{Object: m}
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
 }
 
 type testingWriter struct {


### PR DESCRIPTION
Features added:
*   **Endpoint Mapping**: Translates metric endpoints, handles scheme lowercasing, scrape interval defaulting, and caps timeouts to prevent them from exceeding scrape intervals.
*   **Target Labels Mapping**: Maps pod target labels and custom job labels, automatically renaming protected GMP labels (e.g., `instance` to `exported_instance` and `job` to `exported_job`).
*   **Metric Relabelings**: Converts relabel configs to GMP rules, warning on and dropping unsupported actions like `labelmap`, and preventing writes to protected target labels.
*   **Unit Tests**: Integrates a supporting unit test suite 