### PR TITLE
PO to GMP Migration Tool: Podmonitor Auth, TLS and Proxy Migration

### DIFF
--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -109,16 +109,16 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 }
 
 // extractResourceKey is a consolidated helper that fetches a key from a ConfigMap or Secret.
-func extractResourceKey(convCtx *conversionContext, kind, name, key string) string {
+func (c *conversionContext) extractResourceKey(kind, name, key string) string {
 	kindUpper := strings.ToUpper(kind)
 	if name == "" {
-		convCtx.logger.Warn(fmt.Sprintf("%sKeySelector has empty name for key %q. Hardcoding placeholder.", kind, key))
+		c.logger.Warn(fmt.Sprintf("%sKeySelector has empty name for key %q. Hardcoding placeholder.", kind, key))
 		return fmt.Sprintf("<MISSING_%s_NAME_KEY_%s>", kindUpper, key)
 	}
 
-	obj, ok := convCtx.cache.Get(kind, convCtx.namespace, name)
+	obj, ok := c.cache.Get(kind, c.namespace, name)
 	if !ok {
-		convCtx.logger.Warn(fmt.Sprintf("%s %q not found in cache. Cannot extract key %q. Hardcoding placeholder.", kind, name, key))
+		c.logger.Warn(fmt.Sprintf("%s %q not found in cache. Cannot extract key %q. Hardcoding placeholder.", kind, name, key))
 		return fmt.Sprintf("<MISSING_%s_%s_KEY_%s>", kindUpper, name, key)
 	}
 
@@ -136,7 +136,7 @@ func extractResourceKey(convCtx *conversionContext, kind, name, key string) stri
 		if kind == KindSecret {
 			decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(val))
 			if err != nil {
-				convCtx.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in secret %q. Hardcoding placeholder.", key, name))
+				c.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in secret %q. Hardcoding placeholder.", key, name))
 				return fmt.Sprintf("<MALFORMED_SECRET_%s_KEY_%s>", name, key)
 			}
 			return string(decoded)
@@ -150,41 +150,41 @@ func extractResourceKey(convCtx *conversionContext, kind, name, key string) stri
 		if found {
 			decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(val))
 			if err != nil {
-				convCtx.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in configmap %q. Hardcoding placeholder.", key, name))
+				c.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in configmap %q. Hardcoding placeholder.", key, name))
 				return fmt.Sprintf("<MALFORMED_CONFIGMAP_%s_KEY_%s>", name, key)
 			}
 			return string(decoded)
 		}
 	}
 
-	convCtx.logger.Warn(fmt.Sprintf("Key %q not found in %s %q. Hardcoding placeholder.", key, strings.ToLower(kind), name))
+	c.logger.Warn(fmt.Sprintf("Key %q not found in %s %q. Hardcoding placeholder.", key, strings.ToLower(kind), name))
 	return fmt.Sprintf("<MISSING_KEY_%s_IN_%s_%s>", key, kindUpper, name)
 }
 
 // extractSecretKey extracts a string value from a Secret, returning a placeholder and warning if not found.
-func extractSecretKey(convCtx *conversionContext, sel corev1.SecretKeySelector) string {
-	return extractResourceKey(convCtx, KindSecret, sel.Name, sel.Key)
+func (c *conversionContext) extractSecretKey(sel corev1.SecretKeySelector) string {
+	return c.extractResourceKey(KindSecret, sel.Name, sel.Key)
 }
 
 // extractConfigMapKey extracts a string value from a ConfigMap, returning a placeholder and warning if not found.
-func extractConfigMapKey(convCtx *conversionContext, sel corev1.ConfigMapKeySelector) string {
-	return extractResourceKey(convCtx, KindConfigMap, sel.Name, sel.Key)
+func (c *conversionContext) extractConfigMapKey(sel corev1.ConfigMapKeySelector) string {
+	return c.extractResourceKey(KindConfigMap, sel.Name, sel.Key)
 }
 
-func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.ConfigMapKeySelector) *monitoringv1.SecretSelector {
+func (c *conversionContext) convertConfigMapToSecretSelector(sel *corev1.ConfigMapKeySelector) *monitoringv1.SecretSelector {
 	if sel == nil || (sel.Name == "" && sel.Key == "") {
 		return nil
 	}
 	if sel.Name == "" {
-		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference for key %q has an empty name. Hardcoding placeholder and skipping Secret manifest generation. You must fix this reference and ensure the Secret is created before applying.", sel.Key))
+		c.logger.Warn(fmt.Sprintf("ConfigMap reference for key %q has an empty name. Hardcoding placeholder and skipping Secret manifest generation. You must fix this reference and ensure the Secret is created before applying.", sel.Key))
 		return &monitoringv1.SecretSelector{
-			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_CONFIGMAP_NAME>", Key: sel.Key, Namespace: convCtx.namespace},
+			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_CONFIGMAP_NAME>", Key: sel.Key, Namespace: c.namespace},
 		}
 	}
 	if sel.Key == "" {
-		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference %q has an empty key. Hardcoding placeholder. You must fix this reference before applying.", sel.Name))
+		c.logger.Warn(fmt.Sprintf("ConfigMap reference %q has an empty key. Hardcoding placeholder. You must fix this reference before applying.", sel.Name))
 		return &monitoringv1.SecretSelector{
-			Secret: &monitoringv1.SecretKeySelector{Name: "secret-" + sel.Name, Key: "<MISSING_CONFIGMAP_KEY>", Namespace: convCtx.namespace},
+			Secret: &monitoringv1.SecretKeySelector{Name: "secret-" + sel.Name, Key: "<MISSING_CONFIGMAP_KEY>", Namespace: c.namespace},
 		}
 	}
 
@@ -192,25 +192,25 @@ func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.Co
 	secretKey := sel.Key
 
 	if sel.Optional != nil && *sel.Optional {
-		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference %q had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.", sel.Name))
+		c.logger.Warn(fmt.Sprintf("ConfigMap reference %q had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.", sel.Name))
 	}
 
-	if convCtx.generatedSecrets == nil {
-		convCtx.generatedSecrets = make(map[string]*unstructured.Unstructured)
+	if c.generatedSecrets == nil {
+		c.generatedSecrets = make(map[string]*unstructured.Unstructured)
 	}
 
-	if _, exists := convCtx.generatedSecrets[secretName]; !exists {
-		obj, ok := convCtx.cache.Get(KindConfigMap, convCtx.namespace, sel.Name)
+	if _, exists := c.generatedSecrets[secretName]; !exists {
+		obj, ok := c.cache.Get(KindConfigMap, c.namespace, sel.Name)
 		if !ok {
-			convCtx.logger.Warn(fmt.Sprintf("TLS ConfigMap reference %q was not found in the inputs. Updated reference to GMP Secret %q, but you must manually convert your ConfigMap to a Secret with this name in GMP.", sel.Name, secretName))
+			c.logger.Warn(fmt.Sprintf("TLS ConfigMap reference %q was not found in the inputs. Updated reference to GMP Secret %q, but you must manually convert your ConfigMap to a Secret with this name in GMP.", sel.Name, secretName))
 		} else {
-			convCtx.logger.Info(fmt.Sprintf("Translated TLS ConfigMap reference %q to GMP Secret. Generated new Secret manifest %q.", sel.Name, secretName))
+			c.logger.Info(fmt.Sprintf("Translated TLS ConfigMap reference %q to GMP Secret. Generated new Secret manifest %q.", sel.Name, secretName))
 
 			newSecret := &unstructured.Unstructured{}
 			newSecret.SetAPIVersion("v1")
 			newSecret.SetKind(KindSecret)
 			newSecret.SetName(secretName)
-			newSecret.SetNamespace(convCtx.namespace)
+			newSecret.SetNamespace(c.namespace)
 
 			data, found, _ := unstructured.NestedMap(obj.Object, "data")
 			if found {
@@ -220,63 +220,63 @@ func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.Co
 			if found {
 				_ = unstructured.SetNestedMap(newSecret.Object, binaryData, "data")
 			}
-			convCtx.generatedSecrets[secretName] = newSecret
+			c.generatedSecrets[secretName] = newSecret
 		}
 	}
 
-	secretRef := &monitoringv1.SecretKeySelector{Name: secretName, Key: secretKey, Namespace: convCtx.namespace}
+	secretRef := &monitoringv1.SecretKeySelector{Name: secretName, Key: secretKey, Namespace: c.namespace}
 	return &monitoringv1.SecretSelector{Secret: secretRef}
 }
 
 // convertSecretOrConfigMapToSecretSelector translates to a SecretSelector and warns on missing caches or optional configs.
-func convertSecretOrConfigMapToSecretSelector(convCtx *conversionContext, sel pomonitoringv1.SecretOrConfigMap) *monitoringv1.SecretSelector {
+func (c *conversionContext) convertSecretOrConfigMapToSecretSelector(sel pomonitoringv1.SecretOrConfigMap) *monitoringv1.SecretSelector {
 	if sel.Secret != nil {
-		return convertSecretSelector(convCtx, sel.Secret)
+		return c.convertSecretSelector(sel.Secret)
 	}
 
 	if sel.ConfigMap != nil {
-		return convertConfigMapToSecretSelector(convCtx, sel.ConfigMap)
+		return c.convertConfigMapToSecretSelector(sel.ConfigMap)
 	}
 
 	return nil
 }
 
-func convertSecretSelector(convCtx *conversionContext, sel *corev1.SecretKeySelector) *monitoringv1.SecretSelector {
+func (c *conversionContext) convertSecretSelector(sel *corev1.SecretKeySelector) *monitoringv1.SecretSelector {
 	if sel == nil || (sel.Name == "" && sel.Key == "") {
 		return nil
 	}
 	if sel.Name == "" {
-		convCtx.logger.Warn(fmt.Sprintf("Secret reference for key %q has an empty name. Hardcoding placeholder. You must fix this reference and ensure the Secret is created before applying.", sel.Key))
+		c.logger.Warn(fmt.Sprintf("Secret reference for key %q has an empty name. Hardcoding placeholder. You must fix this reference and ensure the Secret is created before applying.", sel.Key))
 		return &monitoringv1.SecretSelector{
-			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_SECRET_NAME>", Key: sel.Key, Namespace: convCtx.namespace},
+			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_SECRET_NAME>", Key: sel.Key, Namespace: c.namespace},
 		}
 	}
 	if sel.Key == "" {
-		convCtx.logger.Warn(fmt.Sprintf("Secret reference %q has an empty key. Hardcoding placeholder. You must fix this reference before applying.", sel.Name))
+		c.logger.Warn(fmt.Sprintf("Secret reference %q has an empty key. Hardcoding placeholder. You must fix this reference before applying.", sel.Name))
 		return &monitoringv1.SecretSelector{
-			Secret: &monitoringv1.SecretKeySelector{Name: sel.Name, Key: "<MISSING_SECRET_KEY>", Namespace: convCtx.namespace},
+			Secret: &monitoringv1.SecretKeySelector{Name: sel.Name, Key: "<MISSING_SECRET_KEY>", Namespace: c.namespace},
 		}
 	}
 	if sel.Optional != nil && *sel.Optional {
-		convCtx.logger.Warn(fmt.Sprintf("Secret reference %q had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.", sel.Name))
+		c.logger.Warn(fmt.Sprintf("Secret reference %q had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.", sel.Name))
 	}
-	secretRef := &monitoringv1.SecretKeySelector{Name: sel.Name, Key: sel.Key, Namespace: convCtx.namespace}
+	secretRef := &monitoringv1.SecretKeySelector{Name: sel.Name, Key: sel.Key, Namespace: c.namespace}
 	return &monitoringv1.SecretSelector{Secret: secretRef}
 }
 
 // convertBasicAuth maps PO BasicAuth to GMP BasicAuth, extracting the username string.
-func convertBasicAuth(convCtx *conversionContext, ba *pomonitoringv1.BasicAuth) *monitoringv1.BasicAuth {
+func (c *conversionContext) convertBasicAuth(ba *pomonitoringv1.BasicAuth) *monitoringv1.BasicAuth {
 	if ba == nil {
 		return nil
 	}
 	return &monitoringv1.BasicAuth{
-		Username: extractSecretKey(convCtx, ba.Username),
-		Password: convertSecretSelector(convCtx, &ba.Password),
+		Username: c.extractSecretKey(ba.Username),
+		Password: c.convertSecretSelector(&ba.Password),
 	}
 }
 
 // convertSafeTLSConfig maps PO SafeTLSConfig to GMP TLS, wrapping ConfigMaps into Secrets.
-func convertSafeTLSConfig(convCtx *conversionContext, tls *pomonitoringv1.SafeTLSConfig) *monitoringv1.TLS {
+func (c *conversionContext) convertSafeTLSConfig(tls *pomonitoringv1.SafeTLSConfig) *monitoringv1.TLS {
 	if tls == nil {
 		return nil
 	}
@@ -288,35 +288,35 @@ func convertSafeTLSConfig(convCtx *conversionContext, tls *pomonitoringv1.SafeTL
 		gmpTLS.ServerName = *tls.ServerName
 	}
 	if tls.CA.Secret != nil || tls.CA.ConfigMap != nil {
-		gmpTLS.CA = convertSecretOrConfigMapToSecretSelector(convCtx, tls.CA)
+		gmpTLS.CA = c.convertSecretOrConfigMapToSecretSelector(tls.CA)
 	}
 	if tls.Cert.Secret != nil || tls.Cert.ConfigMap != nil {
-		gmpTLS.Cert = convertSecretOrConfigMapToSecretSelector(convCtx, tls.Cert)
+		gmpTLS.Cert = c.convertSecretOrConfigMapToSecretSelector(tls.Cert)
 	}
 	if tls.KeySecret != nil {
-		gmpTLS.Key = convertSecretSelector(convCtx, tls.KeySecret)
+		gmpTLS.Key = c.convertSecretSelector(tls.KeySecret)
 	}
 	return gmpTLS
 }
 
 // convertOAuth2 maps PO OAuth2 to GMP OAuth2, extracting the clientID string.
-func convertOAuth2(convCtx *conversionContext, oa *pomonitoringv1.OAuth2) *monitoringv1.OAuth2 {
+func (c *conversionContext) convertOAuth2(oa *pomonitoringv1.OAuth2) *monitoringv1.OAuth2 {
 	if oa == nil {
 		return nil
 	}
 	clientID := ""
 	if oa.ClientID.Secret != nil {
-		clientID = extractSecretKey(convCtx, *oa.ClientID.Secret)
+		clientID = c.extractSecretKey(*oa.ClientID.Secret)
 	} else if oa.ClientID.ConfigMap != nil {
-		clientID = extractConfigMapKey(convCtx, *oa.ClientID.ConfigMap)
+		clientID = c.extractConfigMapKey(*oa.ClientID.ConfigMap)
 	} else {
-		convCtx.logger.Warn("OAuth2 clientID neither defined as Secret nor ConfigMap. Hardcoding placeholder.")
+		c.logger.Warn("OAuth2 clientID neither defined as Secret nor ConfigMap. Hardcoding placeholder.")
 		clientID = "<MISSING_OAUTH2_CLIENT_ID>"
 	}
 
 	return &monitoringv1.OAuth2{
 		ClientID:       clientID,
-		ClientSecret:   convertSecretSelector(convCtx, &oa.ClientSecret),
+		ClientSecret:   c.convertSecretSelector(&oa.ClientSecret),
 		TokenURL:       oa.TokenURL,
 		Scopes:         oa.Scopes,
 		EndpointParams: oa.EndpointParams,
@@ -324,13 +324,13 @@ func convertOAuth2(convCtx *conversionContext, oa *pomonitoringv1.OAuth2) *monit
 }
 
 // convertAuthorization maps PO SafeAuthorization to GMP Auth.
-func convertAuthorization(convCtx *conversionContext, auth *pomonitoringv1.SafeAuthorization) *monitoringv1.Auth {
+func (c *conversionContext) convertAuthorization(auth *pomonitoringv1.SafeAuthorization) *monitoringv1.Auth {
 	if auth == nil {
 		return nil
 	}
 	return &monitoringv1.Auth{
 		Type:        auth.Type,
-		Credentials: convertSecretSelector(convCtx, auth.Credentials),
+		Credentials: c.convertSecretSelector(auth.Credentials),
 	}
 }
 
@@ -346,13 +346,12 @@ func convertMetricRelabelings(
 			action = "replace"
 		}
 
-		if action == "labelmap" {
+		targetLabel := config.TargetLabel
+		switch action {
+		case "labelmap":
 			logger.Warn("metricRelabelings rule uses 'action: labelmap' which is not supported by GMP and has been dropped.")
 			continue
-		}
-
-		targetLabel := config.TargetLabel
-		if action == "replace" || action == "hashmod" || action == "lowercase" || action == "uppercase" {
+		case "replace", "hashmod", "lowercase", "uppercase":
 			if protectedLabels[config.TargetLabel] {
 				targetLabel = "exported_" + config.TargetLabel
 				logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.",

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -154,15 +154,20 @@ func extractConfigMapKey(convCtx *conversionContext, sel corev1.ConfigMapKeySele
 	return fmt.Sprintf("<MISSING_KEY_%s_IN_CONFIGMAP_%s>", sel.Key, sel.Name)
 }
 
-// convertConfigMapToSecretSelector translates a ConfigMapKeySelector to a SecretSelector and generates the corresponding Secret manifest.
 func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.ConfigMapKeySelector) *monitoringv1.SecretSelector {
-	if sel == nil {
+	if sel == nil || (sel.Name == "" && sel.Key == "") {
 		return nil
 	}
 	if sel.Name == "" {
-		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference for key %q has an empty name. Hardcoding placeholder and skipping Secret manifest generation. You must fix this reference and create the Secret.", sel.Key))
+		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference for key %q has an empty name. Hardcoding placeholder and skipping Secret manifest generation. You must fix this reference and ensure the Secret is created before applying.", sel.Key))
 		return &monitoringv1.SecretSelector{
 			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_CONFIGMAP_NAME>", Key: sel.Key, Namespace: convCtx.namespace},
+		}
+	}
+	if sel.Key == "" {
+		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference %q has an empty key. Hardcoding placeholder. You must fix this reference before applying.", sel.Name))
+		return &monitoringv1.SecretSelector{
+			Secret: &monitoringv1.SecretKeySelector{Name: "secret-" + sel.Name, Key: "<MISSING_CONFIGMAP_KEY>", Namespace: convCtx.namespace},
 		}
 	}
 
@@ -219,15 +224,20 @@ func convertSecretOrConfigMapToSecretSelector(convCtx *conversionContext, sel po
 	return nil
 }
 
-// convertSecretSelector wraps a corev1.SecretKeySelector and logs warnings for optional fields.
 func convertSecretSelector(convCtx *conversionContext, sel *corev1.SecretKeySelector) *monitoringv1.SecretSelector {
-	if sel == nil {
+	if sel == nil || (sel.Name == "" && sel.Key == "") {
 		return nil
 	}
 	if sel.Name == "" {
 		convCtx.logger.Warn(fmt.Sprintf("Secret reference for key %q has an empty name. Hardcoding placeholder. You must fix this reference and ensure the Secret is created before applying.", sel.Key))
 		return &monitoringv1.SecretSelector{
 			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_SECRET_NAME>", Key: sel.Key, Namespace: convCtx.namespace},
+		}
+	}
+	if sel.Key == "" {
+		convCtx.logger.Warn(fmt.Sprintf("Secret reference %q has an empty key. Hardcoding placeholder. You must fix this reference before applying.", sel.Name))
+		return &monitoringv1.SecretSelector{
+			Secret: &monitoringv1.SecretKeySelector{Name: sel.Name, Key: "<MISSING_SECRET_KEY>", Namespace: convCtx.namespace},
 		}
 	}
 	if sel.Optional != nil && *sel.Optional {

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -148,7 +148,7 @@ func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.Co
 		return nil
 	}
 	if sel.Name == "" {
-		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference for key %q has an empty name. Hardcoding placeholder.", sel.Key))
+		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference for key %q has an empty name. Hardcoding placeholder and skipping Secret manifest generation. You must fix this reference and create the Secret.", sel.Key))
 		return &monitoringv1.SecretSelector{
 			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_CONFIGMAP_NAME>", Key: sel.Key, Namespace: convCtx.namespace},
 		}
@@ -207,7 +207,7 @@ func convertSecretSelector(convCtx *conversionContext, sel *corev1.SecretKeySele
 		return nil
 	}
 	if sel.Name == "" {
-		convCtx.logger.Warn(fmt.Sprintf("Secret reference for key %q has an empty name. Hardcoding placeholder.", sel.Key))
+		convCtx.logger.Warn(fmt.Sprintf("Secret reference for key %q has an empty name. Hardcoding placeholder. You must fix this reference and ensure the Secret is created before applying.", sel.Key))
 		return &monitoringv1.SecretSelector{
 			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_SECRET_NAME>", Key: sel.Key, Namespace: convCtx.namespace},
 		}

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -84,8 +84,20 @@ type conversionContext struct {
 	cache *ResourceCache
 	// namespace is the source namespace of the primary resource.
 	namespace string
-	// generatedSecrets accumulates created Secrets when migrating ConfigMaps.
-	generatedSecrets []*unstructured.Unstructured
+	// generatedSecrets accumulates created Secrets when migrating ConfigMaps, keyed by Secret name.
+	generatedSecrets map[string]*unstructured.Unstructured
+}
+
+// getGeneratedSecrets returns the generated secrets accumulated in the context as a slice.
+func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
+	if len(c.generatedSecrets) == 0 {
+		return nil
+	}
+	secrets := make([]*unstructured.Unstructured, 0, len(c.generatedSecrets))
+	for _, sec := range c.generatedSecrets {
+		secrets = append(secrets, sec)
+	}
+	return secrets
 }
 
 // extractSecretKey extracts a string value from a Secret, returning a placeholder and warning if not found.
@@ -161,27 +173,33 @@ func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.Co
 		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference %q had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.", sel.Name))
 	}
 
-	obj, ok := convCtx.cache.Get("ConfigMap", convCtx.namespace, sel.Name)
-	if !ok {
-		convCtx.logger.Warn(fmt.Sprintf("TLS ConfigMap reference %q was not found in the inputs. Updated reference to GMP Secret %q, but you must manually convert your ConfigMap to a Secret with this name in GMP.", sel.Name, secretName))
-	} else {
-		convCtx.logger.Info(fmt.Sprintf("Translated TLS ConfigMap reference %q to GMP Secret. Generated new Secret manifest %q.", sel.Name, secretName))
+	if convCtx.generatedSecrets == nil {
+		convCtx.generatedSecrets = make(map[string]*unstructured.Unstructured)
+	}
 
-		newSecret := &unstructured.Unstructured{}
-		newSecret.SetAPIVersion("v1")
-		newSecret.SetKind("Secret")
-		newSecret.SetName(secretName)
-		newSecret.SetNamespace(convCtx.namespace)
+	if _, exists := convCtx.generatedSecrets[secretName]; !exists {
+		obj, ok := convCtx.cache.Get("ConfigMap", convCtx.namespace, sel.Name)
+		if !ok {
+			convCtx.logger.Warn(fmt.Sprintf("TLS ConfigMap reference %q was not found in the inputs. Updated reference to GMP Secret %q, but you must manually convert your ConfigMap to a Secret with this name in GMP.", sel.Name, secretName))
+		} else {
+			convCtx.logger.Info(fmt.Sprintf("Translated TLS ConfigMap reference %q to GMP Secret. Generated new Secret manifest %q.", sel.Name, secretName))
 
-		data, found, _ := unstructured.NestedMap(obj.Object, "data")
-		if found {
-			_ = unstructured.SetNestedMap(newSecret.Object, data, "stringData")
+			newSecret := &unstructured.Unstructured{}
+			newSecret.SetAPIVersion("v1")
+			newSecret.SetKind("Secret")
+			newSecret.SetName(secretName)
+			newSecret.SetNamespace(convCtx.namespace)
+
+			data, found, _ := unstructured.NestedMap(obj.Object, "data")
+			if found {
+				_ = unstructured.SetNestedMap(newSecret.Object, data, "stringData")
+			}
+			binaryData, found, _ := unstructured.NestedMap(obj.Object, "binaryData")
+			if found {
+				_ = unstructured.SetNestedMap(newSecret.Object, binaryData, "data")
+			}
+			convCtx.generatedSecrets[secretName] = newSecret
 		}
-		binaryData, found, _ := unstructured.NestedMap(obj.Object, "binaryData")
-		if found {
-			_ = unstructured.SetNestedMap(newSecret.Object, binaryData, "data")
-		}
-		convCtx.generatedSecrets = append(convCtx.generatedSecrets, newSecret)
 	}
 
 	secretRef := &monitoringv1.SecretKeySelector{Name: secretName, Key: secretKey, Namespace: convCtx.namespace}

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -15,10 +15,16 @@
 package migrate
 
 import (
+	"encoding/base64"
+	"fmt"
 	"log/slog"
 	"strings"
 
+	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
+	pomonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // protectedLabels contains the list of labels that are protected by GMP and cannot
@@ -69,4 +75,287 @@ func ParseAndCleanNamespaces(namespaces []string) []string {
 		}
 	}
 	return cleaned
+}
+
+// conversionContext groups common parameters passed down to conversion helper functions.
+type conversionContext struct {
+	logger *slog.Logger
+	// cache provides access to dependent resources.
+	cache *ResourceCache
+	// namespace is the source namespace of the primary resource.
+	namespace string
+	// generatedSecrets accumulates created Secrets when migrating ConfigMaps.
+	generatedSecrets []*unstructured.Unstructured
+}
+
+// extractSecretKey extracts a string value from a Secret, returning a placeholder and warning if not found.
+func extractSecretKey(convCtx *conversionContext, sel corev1.SecretKeySelector) string {
+	obj, ok := convCtx.cache.Get("Secret", convCtx.namespace, sel.Name)
+	if !ok {
+		convCtx.logger.Warn(fmt.Sprintf("Secret %q not found. Cannot extract key %q. Hardcoding placeholder.", sel.Name, sel.Key))
+		return fmt.Sprintf("<MISSING_SECRET_%s_KEY_%s>", sel.Name, sel.Key)
+	}
+
+	val, found, _ := unstructured.NestedString(obj.Object, "stringData", sel.Key)
+	if found {
+		return val
+	}
+
+	val, found, _ = unstructured.NestedString(obj.Object, "data", sel.Key)
+	if found {
+		decoded, err := base64.StdEncoding.DecodeString(val)
+		if err != nil {
+			convCtx.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in secret %q. Hardcoding placeholder.", sel.Key, sel.Name))
+			return fmt.Sprintf("<MALFORMED_SECRET_%s_KEY_%s>", sel.Name, sel.Key)
+		}
+		return string(decoded)
+	}
+
+	convCtx.logger.Warn(fmt.Sprintf("Key %q not found in secret %q. Hardcoding placeholder.", sel.Key, sel.Name))
+	return fmt.Sprintf("<MISSING_KEY_%s_IN_SECRET_%s>", sel.Key, sel.Name)
+}
+
+// extractConfigMapKey extracts a string value from a ConfigMap, returning a placeholder and warning if not found.
+func extractConfigMapKey(convCtx *conversionContext, sel corev1.ConfigMapKeySelector) string {
+	obj, ok := convCtx.cache.Get("ConfigMap", convCtx.namespace, sel.Name)
+	if !ok {
+		convCtx.logger.Warn(fmt.Sprintf("ConfigMap %q not found in cache. Cannot extract key %q. Hardcoding placeholder.", sel.Name, sel.Key))
+		return fmt.Sprintf("<MISSING_CONFIGMAP_%s_KEY_%s>", sel.Name, sel.Key)
+	}
+
+	val, found, _ := unstructured.NestedString(obj.Object, "data", sel.Key)
+	if found {
+		return val
+	}
+
+	convCtx.logger.Warn(fmt.Sprintf("Key %q not found in configmap %q. Hardcoding placeholder.", sel.Key, sel.Name))
+	return fmt.Sprintf("<MISSING_KEY_%s_IN_CONFIGMAP_%s>", sel.Key, sel.Name)
+}
+
+// convertConfigMapToSecretSelector translates a ConfigMapKeySelector to a SecretSelector and generates the corresponding Secret manifest.
+func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.ConfigMapKeySelector) *monitoringv1.SecretSelector {
+	if sel == nil {
+		return nil
+	}
+
+	secretName := "secret-" + sel.Name
+	secretKey := sel.Key
+
+	if sel.Optional != nil && *sel.Optional {
+		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference %q had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.", sel.Name))
+	}
+
+	obj, ok := convCtx.cache.Get("ConfigMap", convCtx.namespace, sel.Name)
+	if !ok {
+		convCtx.logger.Warn(fmt.Sprintf("TLS ConfigMap reference %q was not found in the inputs. Updated reference to GMP Secret %q, but you must manually convert your ConfigMap to a Secret with this name in GMP.", sel.Name, secretName))
+	} else {
+		convCtx.logger.Info(fmt.Sprintf("Translated TLS ConfigMap reference %q to GMP Secret. Generated new Secret manifest %q.", sel.Name, secretName))
+
+		newSecret := &unstructured.Unstructured{}
+		newSecret.SetAPIVersion("v1")
+		newSecret.SetKind("Secret")
+		newSecret.SetName(secretName)
+		newSecret.SetNamespace(convCtx.namespace)
+
+		data, found, _ := unstructured.NestedMap(obj.Object, "data")
+		if found {
+			_ = unstructured.SetNestedMap(newSecret.Object, data, "stringData")
+		}
+		binaryData, found, _ := unstructured.NestedMap(obj.Object, "binaryData")
+		if found {
+			_ = unstructured.SetNestedMap(newSecret.Object, binaryData, "data")
+		}
+		convCtx.generatedSecrets = append(convCtx.generatedSecrets, newSecret)
+	}
+
+	return &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: secretName, Key: secretKey}}
+}
+
+// convertSecretOrConfigMapToSecretSelector translates to a SecretSelector and warns on missing caches or optional configs.
+func convertSecretOrConfigMapToSecretSelector(convCtx *conversionContext, sel pomonitoringv1.SecretOrConfigMap) *monitoringv1.SecretSelector {
+	if sel.Secret != nil {
+		return convertSecretSelector(convCtx, sel.Secret)
+	}
+
+	if sel.ConfigMap != nil {
+		return convertConfigMapToSecretSelector(convCtx, sel.ConfigMap)
+	}
+
+	return nil
+}
+
+// convertSecretSelector wraps a corev1.SecretKeySelector and logs warnings for optional fields.
+func convertSecretSelector(convCtx *conversionContext, sel *corev1.SecretKeySelector) *monitoringv1.SecretSelector {
+	if sel == nil {
+		return nil
+	}
+	if sel.Optional != nil && *sel.Optional {
+		convCtx.logger.Warn(fmt.Sprintf("Secret reference %q had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.", sel.Name))
+	}
+	return &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: sel.Name, Key: sel.Key}}
+}
+
+// convertBasicAuth maps PO BasicAuth to GMP BasicAuth, extracting the username string.
+func convertBasicAuth(convCtx *conversionContext, ba *pomonitoringv1.BasicAuth) *monitoringv1.BasicAuth {
+	if ba == nil {
+		return nil
+	}
+	return &monitoringv1.BasicAuth{
+		Username: extractSecretKey(convCtx, ba.Username),
+		Password: convertSecretSelector(convCtx, &ba.Password),
+	}
+}
+
+// convertSafeTLSConfig maps PO SafeTLSConfig to GMP TLS, wrapping ConfigMaps into Secrets.
+func convertSafeTLSConfig(convCtx *conversionContext, tls *pomonitoringv1.SafeTLSConfig) *monitoringv1.TLS {
+	if tls == nil {
+		return nil
+	}
+	gmpTLS := &monitoringv1.TLS{}
+	if tls.InsecureSkipVerify != nil {
+		gmpTLS.InsecureSkipVerify = *tls.InsecureSkipVerify
+	}
+	if tls.ServerName != nil {
+		gmpTLS.ServerName = *tls.ServerName
+	}
+	if tls.CA.Secret != nil || tls.CA.ConfigMap != nil {
+		gmpTLS.CA = convertSecretOrConfigMapToSecretSelector(convCtx, tls.CA)
+	}
+	if tls.Cert.Secret != nil || tls.Cert.ConfigMap != nil {
+		gmpTLS.Cert = convertSecretOrConfigMapToSecretSelector(convCtx, tls.Cert)
+	}
+	if tls.KeySecret != nil {
+		gmpTLS.Key = convertSecretSelector(convCtx, tls.KeySecret)
+	}
+	return gmpTLS
+}
+
+// convertOAuth2 maps PO OAuth2 to GMP OAuth2, extracting the clientID string.
+func convertOAuth2(convCtx *conversionContext, oa *pomonitoringv1.OAuth2) *monitoringv1.OAuth2 {
+	if oa == nil {
+		return nil
+	}
+	clientID := ""
+	if oa.ClientID.Secret != nil {
+		clientID = extractSecretKey(convCtx, *oa.ClientID.Secret)
+	} else if oa.ClientID.ConfigMap != nil {
+		clientID = extractConfigMapKey(convCtx, *oa.ClientID.ConfigMap)
+	} else {
+		convCtx.logger.Warn("OAuth2 clientID neither defined as Secret nor ConfigMap. Hardcoding placeholder.")
+		clientID = "<MISSING_OAUTH2_CLIENT_ID>"
+	}
+
+	return &monitoringv1.OAuth2{
+		ClientID:     clientID,
+		ClientSecret: convertSecretSelector(convCtx, &oa.ClientSecret),
+		TokenURL:     oa.TokenURL,
+		Scopes:       oa.Scopes,
+	}
+}
+
+// convertAuthorization maps PO SafeAuthorization to GMP Auth.
+func convertAuthorization(convCtx *conversionContext, auth *pomonitoringv1.SafeAuthorization) *monitoringv1.Auth {
+	if auth == nil {
+		return nil
+	}
+	return &monitoringv1.Auth{
+		Type:        auth.Type,
+		Credentials: convertSecretSelector(convCtx, auth.Credentials),
+	}
+}
+
+func convertMetricRelabelings(
+	logger *slog.Logger,
+	configs []pomonitoringv1.RelabelConfig,
+) ([]monitoringv1.RelabelingRule, error) {
+	var rules []monitoringv1.RelabelingRule
+
+	for _, config := range configs {
+		action := strings.ToLower(config.Action)
+		if action == "" {
+			action = "replace"
+		}
+
+		if action == "labelmap" {
+			logger.Warn("metricRelabelings rule uses 'action: labelmap' which is not supported by GMP and has been dropped.")
+			continue
+		}
+
+		targetLabel := config.TargetLabel
+		if action == "replace" || action == "hashmod" || action == "lowercase" || action == "uppercase" {
+			if protectedLabels[config.TargetLabel] {
+				targetLabel = "exported_" + config.TargetLabel
+				logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.",
+					config.TargetLabel, targetLabel))
+			}
+		}
+
+		rule := monitoringv1.RelabelingRule{
+			TargetLabel: targetLabel,
+			Regex:       config.Regex,
+			Modulus:     config.Modulus,
+			Action:      action,
+		}
+
+		if len(config.SourceLabels) > 0 {
+			rule.SourceLabels = make([]string, len(config.SourceLabels))
+			for i, sl := range config.SourceLabels {
+				rule.SourceLabels[i] = string(sl)
+			}
+		}
+
+		if config.Separator != nil {
+			rule.Separator = *config.Separator
+		}
+		if config.Replacement != nil {
+			rule.Replacement = *config.Replacement
+		}
+
+		rules = append(rules, rule)
+	}
+
+	return rules, nil
+}
+
+func convertTargetLabels(logger *slog.Logger, sourceLabels []string, jobLabel string, labelKind string) []monitoringv1.LabelMapping {
+	var fromPod []monitoringv1.LabelMapping
+	seenTargets := make(map[string]bool)
+
+	for _, l := range sourceLabels {
+		target := l
+		if protectedLabels[l] {
+			target = "exported_" + l
+		}
+
+		if seenTargets[target] {
+			logger.Warn(fmt.Sprintf("%s target label %q maps to target label %q which is already taken. Skipping.", labelKind, l, target))
+			continue
+		}
+
+		seenTargets[target] = true
+		mapping := monitoringv1.LabelMapping{From: l}
+
+		if target != l {
+			mapping.To = target
+			logger.Warn(fmt.Sprintf("%s target label %q is protected in GMP. Renamed target to %q.", labelKind, l, target))
+		}
+
+		fromPod = append(fromPod, mapping)
+	}
+
+	if jobLabel != "" {
+		target := "exported_job"
+		if !seenTargets[target] {
+			logger.Warn(fmt.Sprintf("GMP does not support overriding the protected 'job' label. Value on label %q has been copied into the target label 'exported_job'.", jobLabel))
+			fromPod = append(fromPod, monitoringv1.LabelMapping{
+				From: jobLabel,
+				To:   target,
+			})
+			seenTargets[target] = true
+		} else {
+			logger.Warn(fmt.Sprintf("Job label %q could not be mapped to 'exported_job' because 'exported_job' is already taken by another target label mapping.", jobLabel))
+		}
+	}
+
+	return fromPod
 }

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
@@ -93,9 +94,16 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 	if len(c.generatedSecrets) == 0 {
 		return nil
 	}
+	// Extract and sort names to guarantee deterministic output order.
+	names := make([]string, 0, len(c.generatedSecrets))
+	for name := range c.generatedSecrets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	secrets := make([]*unstructured.Unstructured, 0, len(c.generatedSecrets))
-	for _, sec := range c.generatedSecrets {
-		secrets = append(secrets, sec)
+	for _, name := range names {
+		secrets = append(secrets, c.generatedSecrets[name])
 	}
 	return secrets
 }

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -109,13 +109,18 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 }
 
 // extractResourceKey is a consolidated helper that fetches a key from a ConfigMap or Secret.
-func (c *conversionContext) extractResourceKey(kind, name, key string) string {
+// It returns an error if the reference is malformed or if data is corrupt.
+// It returns a placeholder and logs a warning if the resource itself is not found in the cache.
+func (c *conversionContext) extractResourceKey(kind, name, key string) (string, error) {
 	kindUpper := strings.ToUpper(kind)
+	if name == "" && key == "" {
+		return "", nil
+	}
 	if name == "" {
-		c.logger.Warn("KeySelector has empty name. Hardcoding placeholder.",
-			slog.String("selector_kind", kind),
-			slog.String("key", key))
-		return fmt.Sprintf("<MISSING_%s_NAME_KEY_%s>", kindUpper, key)
+		return "", fmt.Errorf("%s reference has an empty name for key %q", kindUpper, key)
+	}
+	if key == "" {
+		return "", fmt.Errorf("%s reference has an empty key for name %q", kindUpper, name)
 	}
 
 	obj, ok := c.cache.Get(kind, c.namespace, name)
@@ -124,14 +129,14 @@ func (c *conversionContext) extractResourceKey(kind, name, key string) string {
 			slog.String("referenced_kind", kind),
 			slog.String("referenced_name", name),
 			slog.String("key", key))
-		return fmt.Sprintf("<MISSING_%s_%s_KEY_%s>", kindUpper, name, key)
+		return fmt.Sprintf("<MISSING_%s_%s_KEY_%s>", kindUpper, name, key), nil
 	}
 
 	// Secrets support unencoded stringData.
 	if kind == KindSecret {
 		val, found, _ := unstructured.NestedString(obj.Object, "stringData", key)
 		if found {
-			return val
+			return val, nil
 		}
 	}
 
@@ -141,14 +146,11 @@ func (c *conversionContext) extractResourceKey(kind, name, key string) string {
 		if kind == KindSecret {
 			decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(val))
 			if err != nil {
-				c.logger.Warn("Failed to decode base64 data. Hardcoding placeholder.",
-					slog.String("key", key),
-					slog.String("secret", name))
-				return fmt.Sprintf("<MALFORMED_SECRET_%s_KEY_%s>", name, key)
+				return "", fmt.Errorf("failed to decode base64 data for key %q in secret %q: %w", key, name, err)
 			}
-			return string(decoded)
+			return string(decoded), nil
 		}
-		return val
+		return val, nil
 	}
 
 	// ConfigMaps can store base64 binaryData.
@@ -157,49 +159,44 @@ func (c *conversionContext) extractResourceKey(kind, name, key string) string {
 		if found {
 			decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(val))
 			if err != nil {
-				c.logger.Warn("Failed to decode base64 data. Hardcoding placeholder.",
-					slog.String("key", key),
-					slog.String("configmap", name))
-				return fmt.Sprintf("<MALFORMED_CONFIGMAP_%s_KEY_%s>", name, key)
+				return "", fmt.Errorf("failed to decode base64 binaryData for key %q in configmap %q: %w", key, name, err)
 			}
-			return string(decoded)
+			return string(decoded), nil
 		}
 	}
 
-	c.logger.Warn("Key not found in resource. Hardcoding placeholder.",
-		slog.String("key", key),
-		slog.String("referenced_kind", kind),
-		slog.String("referenced_name", name))
-	return fmt.Sprintf("<MISSING_KEY_%s_IN_%s_%s>", key, kindUpper, name)
+	return "", fmt.Errorf("key %q not found in %s %q", key, kindUpper, name)
 }
 
-// extractSecretKey extracts a string value from a Secret, returning a placeholder and warning if not found.
-func (c *conversionContext) extractSecretKey(sel corev1.SecretKeySelector) string {
+// extractSecretKey extracts a string value from a Secret.
+// It returns an error if the reference or data is malformed, or a placeholder if the resource is not found.
+func (c *conversionContext) extractSecretKey(sel corev1.SecretKeySelector) (string, error) {
+	if sel.Name == "" && sel.Key == "" {
+		return "", nil
+	}
 	return c.extractResourceKey(KindSecret, sel.Name, sel.Key)
 }
 
-// extractConfigMapKey extracts a string value from a ConfigMap, returning a placeholder and warning if not found.
-func (c *conversionContext) extractConfigMapKey(sel corev1.ConfigMapKeySelector) string {
+// extractConfigMapKey extracts a string value from a ConfigMap.
+// It returns an error if the reference or data is malformed, or a placeholder if the resource is not found.
+func (c *conversionContext) extractConfigMapKey(sel corev1.ConfigMapKeySelector) (string, error) {
+	if sel.Name == "" && sel.Key == "" {
+		return "", nil
+	}
 	return c.extractResourceKey(KindConfigMap, sel.Name, sel.Key)
 }
 
-func (c *conversionContext) convertConfigMapToSecretSelector(sel *corev1.ConfigMapKeySelector) *monitoringv1.SecretSelector {
+// convertConfigMapToSecretSelector translates a ConfigMapKeySelector to a SecretSelector.
+// It returns an error if the reference is malformed.
+func (c *conversionContext) convertConfigMapToSecretSelector(sel *corev1.ConfigMapKeySelector) (*monitoringv1.SecretSelector, error) {
 	if sel == nil || (sel.Name == "" && sel.Key == "") {
-		return nil
+		return nil, nil
 	}
 	if sel.Name == "" {
-		c.logger.Warn("ConfigMap reference has an empty name. Hardcoding placeholder and skipping Secret manifest generation. You must fix this reference and ensure the Secret is created before applying.",
-			slog.String("key", sel.Key))
-		return &monitoringv1.SecretSelector{
-			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_CONFIGMAP_NAME>", Key: sel.Key, Namespace: c.namespace},
-		}
+		return nil, fmt.Errorf("configmap reference has an empty name for key %q", sel.Key)
 	}
 	if sel.Key == "" {
-		c.logger.Warn("ConfigMap reference has an empty key. Hardcoding placeholder. You must fix this reference before applying.",
-			slog.String("configmap", sel.Name))
-		return &monitoringv1.SecretSelector{
-			Secret: &monitoringv1.SecretKeySelector{Name: "secret-" + sel.Name, Key: "<MISSING_CONFIGMAP_KEY>", Namespace: c.namespace},
-		}
+		return nil, fmt.Errorf("configmap reference has an empty key for name %q", sel.Name)
 	}
 
 	secretName := "secret-" + sel.Name
@@ -244,11 +241,12 @@ func (c *conversionContext) convertConfigMapToSecretSelector(sel *corev1.ConfigM
 	}
 
 	secretRef := &monitoringv1.SecretKeySelector{Name: secretName, Key: secretKey, Namespace: c.namespace}
-	return &monitoringv1.SecretSelector{Secret: secretRef}
+	return &monitoringv1.SecretSelector{Secret: secretRef}, nil
 }
 
-// convertSecretOrConfigMapToSecretSelector translates to a SecretSelector and warns on missing caches or optional configs.
-func (c *conversionContext) convertSecretOrConfigMapToSecretSelector(sel pomonitoringv1.SecretOrConfigMap) *monitoringv1.SecretSelector {
+// convertSecretOrConfigMapToSecretSelector translates a SecretOrConfigMap to a SecretSelector.
+// It returns an error if the selected configuration reference is malformed.
+func (c *conversionContext) convertSecretOrConfigMapToSecretSelector(sel pomonitoringv1.SecretOrConfigMap) (*monitoringv1.SecretSelector, error) {
 	if sel.Secret != nil {
 		return c.convertSecretSelector(sel.Secret)
 	}
@@ -257,50 +255,54 @@ func (c *conversionContext) convertSecretOrConfigMapToSecretSelector(sel pomonit
 		return c.convertConfigMapToSecretSelector(sel.ConfigMap)
 	}
 
-	return nil
+	return nil, nil
 }
 
-func (c *conversionContext) convertSecretSelector(sel *corev1.SecretKeySelector) *monitoringv1.SecretSelector {
+// convertSecretSelector translates a SecretKeySelector to a SecretSelector.
+// It returns an error if the reference is malformed.
+func (c *conversionContext) convertSecretSelector(sel *corev1.SecretKeySelector) (*monitoringv1.SecretSelector, error) {
 	if sel == nil || (sel.Name == "" && sel.Key == "") {
-		return nil
+		return nil, nil
 	}
 	if sel.Name == "" {
-		c.logger.Warn("Secret reference has an empty name. Hardcoding placeholder. You must fix this reference and ensure the Secret is created before applying.",
-			slog.String("key", sel.Key))
-		return &monitoringv1.SecretSelector{
-			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_SECRET_NAME>", Key: sel.Key, Namespace: c.namespace},
-		}
+		return nil, fmt.Errorf("secret reference has an empty name for key %q", sel.Key)
 	}
 	if sel.Key == "" {
-		c.logger.Warn("Secret reference has an empty key. Hardcoding placeholder. You must fix this reference before applying.",
-			slog.String("secret", sel.Name))
-		return &monitoringv1.SecretSelector{
-			Secret: &monitoringv1.SecretKeySelector{Name: sel.Name, Key: "<MISSING_SECRET_KEY>", Namespace: c.namespace},
-		}
+		return nil, fmt.Errorf("secret reference has an empty key for name %q", sel.Name)
 	}
 	if sel.Optional != nil && *sel.Optional {
 		c.logger.Warn("Secret reference had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.",
 			slog.String("secret", sel.Name))
 	}
 	secretRef := &monitoringv1.SecretKeySelector{Name: sel.Name, Key: sel.Key, Namespace: c.namespace}
-	return &monitoringv1.SecretSelector{Secret: secretRef}
+	return &monitoringv1.SecretSelector{Secret: secretRef}, nil
 }
 
 // convertBasicAuth maps PO BasicAuth to GMP BasicAuth, extracting the username string.
-func (c *conversionContext) convertBasicAuth(ba *pomonitoringv1.BasicAuth) *monitoringv1.BasicAuth {
+// It returns an error if either the username or password secret reference is malformed or invalid.
+func (c *conversionContext) convertBasicAuth(ba *pomonitoringv1.BasicAuth) (*monitoringv1.BasicAuth, error) {
 	if ba == nil {
-		return nil
+		return nil, nil
+	}
+	username, err := c.extractSecretKey(ba.Username)
+	if err != nil {
+		return nil, err
+	}
+	password, err := c.convertSecretSelector(&ba.Password)
+	if err != nil {
+		return nil, err
 	}
 	return &monitoringv1.BasicAuth{
-		Username: c.extractSecretKey(ba.Username),
-		Password: c.convertSecretSelector(&ba.Password),
-	}
+		Username: username,
+		Password: password,
+	}, nil
 }
 
 // convertSafeTLSConfig maps PO SafeTLSConfig to GMP TLS, wrapping ConfigMaps into Secrets.
-func (c *conversionContext) convertSafeTLSConfig(tls *pomonitoringv1.SafeTLSConfig) *monitoringv1.TLS {
+// It returns an error if any referenced certificate secret or configmap is malformed.
+func (c *conversionContext) convertSafeTLSConfig(tls *pomonitoringv1.SafeTLSConfig) (*monitoringv1.TLS, error) {
 	if tls == nil {
-		return nil
+		return nil, nil
 	}
 	gmpTLS := &monitoringv1.TLS{}
 	if tls.InsecureSkipVerify != nil {
@@ -310,50 +312,81 @@ func (c *conversionContext) convertSafeTLSConfig(tls *pomonitoringv1.SafeTLSConf
 		gmpTLS.ServerName = *tls.ServerName
 	}
 	if tls.CA.Secret != nil || tls.CA.ConfigMap != nil {
-		gmpTLS.CA = c.convertSecretOrConfigMapToSecretSelector(tls.CA)
+		ca, err := c.convertSecretOrConfigMapToSecretSelector(tls.CA)
+		if err != nil {
+			return nil, err
+		}
+		gmpTLS.CA = ca
 	}
 	if tls.Cert.Secret != nil || tls.Cert.ConfigMap != nil {
-		gmpTLS.Cert = c.convertSecretOrConfigMapToSecretSelector(tls.Cert)
+		cert, err := c.convertSecretOrConfigMapToSecretSelector(tls.Cert)
+		if err != nil {
+			return nil, err
+		}
+		gmpTLS.Cert = cert
 	}
 	if tls.KeySecret != nil {
-		gmpTLS.Key = c.convertSecretSelector(tls.KeySecret)
+		key, err := c.convertSecretSelector(tls.KeySecret)
+		if err != nil {
+			return nil, err
+		}
+		gmpTLS.Key = key
 	}
-	return gmpTLS
+	return gmpTLS, nil
 }
 
 // convertOAuth2 maps PO OAuth2 to GMP OAuth2, extracting the clientID string.
-func (c *conversionContext) convertOAuth2(oa *pomonitoringv1.OAuth2) *monitoringv1.OAuth2 {
+// It returns an error if any secret or configmap reference is malformed or invalid.
+func (c *conversionContext) convertOAuth2(oa *pomonitoringv1.OAuth2) (*monitoringv1.OAuth2, error) {
 	if oa == nil {
-		return nil
+		return nil, nil
 	}
 	clientID := ""
+	var err error
 	if oa.ClientID.Secret != nil {
-		clientID = c.extractSecretKey(*oa.ClientID.Secret)
+		clientID, err = c.extractSecretKey(*oa.ClientID.Secret)
 	} else if oa.ClientID.ConfigMap != nil {
-		clientID = c.extractConfigMapKey(*oa.ClientID.ConfigMap)
+		clientID, err = c.extractConfigMapKey(*oa.ClientID.ConfigMap)
 	} else {
 		c.logger.Warn("OAuth2 clientID neither defined as Secret nor ConfigMap. Hardcoding placeholder.")
 		clientID = "<MISSING_OAUTH2_CLIENT_ID>"
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	clientSecret, err := c.convertSecretSelector(&oa.ClientSecret)
+	if err != nil {
+		return nil, err
+	}
 
 	return &monitoringv1.OAuth2{
 		ClientID:       clientID,
-		ClientSecret:   c.convertSecretSelector(&oa.ClientSecret),
+		ClientSecret:   clientSecret,
 		TokenURL:       oa.TokenURL,
 		Scopes:         oa.Scopes,
 		EndpointParams: oa.EndpointParams,
-	}
+	}, nil
 }
 
 // convertAuthorization maps PO SafeAuthorization to GMP Auth.
-func (c *conversionContext) convertAuthorization(auth *pomonitoringv1.SafeAuthorization) *monitoringv1.Auth {
+// It returns an error if the credentials secret reference is malformed.
+func (c *conversionContext) convertAuthorization(auth *pomonitoringv1.SafeAuthorization) (*monitoringv1.Auth, error) {
 	if auth == nil {
-		return nil
+		return nil, nil
+	}
+	var credentials *monitoringv1.SecretSelector
+	var err error
+	if auth.Credentials != nil {
+		credentials, err = c.convertSecretSelector(auth.Credentials)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &monitoringv1.Auth{
 		Type:        auth.Type,
-		Credentials: c.convertSecretSelector(auth.Credentials),
-	}
+		Credentials: credentials,
+	}, nil
 }
 
 func convertMetricRelabelings(

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -90,6 +90,11 @@ type conversionContext struct {
 
 // extractSecretKey extracts a string value from a Secret, returning a placeholder and warning if not found.
 func extractSecretKey(convCtx *conversionContext, sel corev1.SecretKeySelector) string {
+	if sel.Name == "" {
+		convCtx.logger.Warn(fmt.Sprintf("SecretKeySelector has empty name for key %q. Hardcoding placeholder.", sel.Key))
+		return fmt.Sprintf("<MISSING_SECRET_NAME_KEY_%s>", sel.Key)
+	}
+
 	obj, ok := convCtx.cache.Get("Secret", convCtx.namespace, sel.Name)
 	if !ok {
 		convCtx.logger.Warn(fmt.Sprintf("Secret %q not found. Cannot extract key %q. Hardcoding placeholder.", sel.Name, sel.Key))
@@ -117,6 +122,11 @@ func extractSecretKey(convCtx *conversionContext, sel corev1.SecretKeySelector) 
 
 // extractConfigMapKey extracts a string value from a ConfigMap, returning a placeholder and warning if not found.
 func extractConfigMapKey(convCtx *conversionContext, sel corev1.ConfigMapKeySelector) string {
+	if sel.Name == "" {
+		convCtx.logger.Warn(fmt.Sprintf("ConfigMapKeySelector has empty name for key %q. Hardcoding placeholder.", sel.Key))
+		return fmt.Sprintf("<MISSING_CONFIGMAP_NAME_KEY_%s>", sel.Key)
+	}
+
 	obj, ok := convCtx.cache.Get("ConfigMap", convCtx.namespace, sel.Name)
 	if !ok {
 		convCtx.logger.Warn(fmt.Sprintf("ConfigMap %q not found in cache. Cannot extract key %q. Hardcoding placeholder.", sel.Name, sel.Key))
@@ -136,6 +146,12 @@ func extractConfigMapKey(convCtx *conversionContext, sel corev1.ConfigMapKeySele
 func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.ConfigMapKeySelector) *monitoringv1.SecretSelector {
 	if sel == nil {
 		return nil
+	}
+	if sel.Name == "" {
+		convCtx.logger.Warn(fmt.Sprintf("ConfigMap reference for key %q has an empty name. Hardcoding placeholder.", sel.Key))
+		return &monitoringv1.SecretSelector{
+			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_CONFIGMAP_NAME>", Key: sel.Key, Namespace: convCtx.namespace},
+		}
 	}
 
 	secretName := "secret-" + sel.Name
@@ -168,7 +184,8 @@ func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.Co
 		convCtx.generatedSecrets = append(convCtx.generatedSecrets, newSecret)
 	}
 
-	return &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: secretName, Key: secretKey}}
+	secretRef := &monitoringv1.SecretKeySelector{Name: secretName, Key: secretKey, Namespace: convCtx.namespace}
+	return &monitoringv1.SecretSelector{Secret: secretRef}
 }
 
 // convertSecretOrConfigMapToSecretSelector translates to a SecretSelector and warns on missing caches or optional configs.
@@ -189,10 +206,17 @@ func convertSecretSelector(convCtx *conversionContext, sel *corev1.SecretKeySele
 	if sel == nil {
 		return nil
 	}
+	if sel.Name == "" {
+		convCtx.logger.Warn(fmt.Sprintf("Secret reference for key %q has an empty name. Hardcoding placeholder.", sel.Key))
+		return &monitoringv1.SecretSelector{
+			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_SECRET_NAME>", Key: sel.Key, Namespace: convCtx.namespace},
+		}
+	}
 	if sel.Optional != nil && *sel.Optional {
 		convCtx.logger.Warn(fmt.Sprintf("Secret reference %q had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.", sel.Name))
 	}
-	return &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: sel.Name, Key: sel.Key}}
+	secretRef := &monitoringv1.SecretKeySelector{Name: sel.Name, Key: sel.Key, Namespace: convCtx.namespace}
+	return &monitoringv1.SecretSelector{Secret: secretRef}
 }
 
 // convertBasicAuth maps PO BasicAuth to GMP BasicAuth, extracting the username string.

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -18,7 +18,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
-	"sort"
+	"slices"
 	"strings"
 
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
@@ -99,7 +99,7 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 	for name := range c.generatedSecrets {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 
 	secrets := make([]*unstructured.Unstructured, 0, len(c.generatedSecrets))
 	for _, name := range names {

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -134,7 +134,7 @@ func extractResourceKey(convCtx *conversionContext, kind, name, key string) stri
 	val, found, _ := unstructured.NestedString(obj.Object, "data", key)
 	if found {
 		if kind == KindSecret {
-			decoded, err := base64.StdEncoding.DecodeString(val)
+			decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(val))
 			if err != nil {
 				convCtx.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in secret %q. Hardcoding placeholder.", key, name))
 				return fmt.Sprintf("<MALFORMED_SECRET_%s_KEY_%s>", name, key)
@@ -148,7 +148,7 @@ func extractResourceKey(convCtx *conversionContext, kind, name, key string) stri
 	if kind == KindConfigMap {
 		val, found, _ = unstructured.NestedString(obj.Object, "binaryData", key)
 		if found {
-			decoded, err := base64.StdEncoding.DecodeString(val)
+			decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(val))
 			if err != nil {
 				convCtx.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in configmap %q. Hardcoding placeholder.", key, name))
 				return fmt.Sprintf("<MALFORMED_CONFIGMAP_%s_KEY_%s>", name, key)
@@ -200,7 +200,7 @@ func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.Co
 	}
 
 	if _, exists := convCtx.generatedSecrets[secretName]; !exists {
-		obj, ok := convCtx.cache.Get("ConfigMap", convCtx.namespace, sel.Name)
+		obj, ok := convCtx.cache.Get(KindConfigMap, convCtx.namespace, sel.Name)
 		if !ok {
 			convCtx.logger.Warn(fmt.Sprintf("TLS ConfigMap reference %q was not found in the inputs. Updated reference to GMP Secret %q, but you must manually convert your ConfigMap to a Secret with this name in GMP.", sel.Name, secretName))
 		} else {
@@ -208,7 +208,7 @@ func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.Co
 
 			newSecret := &unstructured.Unstructured{}
 			newSecret.SetAPIVersion("v1")
-			newSecret.SetKind("Secret")
+			newSecret.SetKind(KindSecret)
 			newSecret.SetName(secretName)
 			newSecret.SetNamespace(convCtx.namespace)
 

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -112,13 +112,18 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 func (c *conversionContext) extractResourceKey(kind, name, key string) string {
 	kindUpper := strings.ToUpper(kind)
 	if name == "" {
-		c.logger.Warn(fmt.Sprintf("%sKeySelector has empty name for key %q. Hardcoding placeholder.", kind, key))
+		c.logger.Warn("KeySelector has empty name. Hardcoding placeholder.",
+			slog.String("selector_kind", kind),
+			slog.String("key", key))
 		return fmt.Sprintf("<MISSING_%s_NAME_KEY_%s>", kindUpper, key)
 	}
 
 	obj, ok := c.cache.Get(kind, c.namespace, name)
 	if !ok {
-		c.logger.Warn(fmt.Sprintf("%s %q not found in cache. Cannot extract key %q. Hardcoding placeholder.", kind, name, key))
+		c.logger.Warn("Resource not found in cache. Cannot extract key. Hardcoding placeholder.",
+			slog.String("referenced_kind", kind),
+			slog.String("referenced_name", name),
+			slog.String("key", key))
 		return fmt.Sprintf("<MISSING_%s_%s_KEY_%s>", kindUpper, name, key)
 	}
 
@@ -136,7 +141,9 @@ func (c *conversionContext) extractResourceKey(kind, name, key string) string {
 		if kind == KindSecret {
 			decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(val))
 			if err != nil {
-				c.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in secret %q. Hardcoding placeholder.", key, name))
+				c.logger.Warn("Failed to decode base64 data. Hardcoding placeholder.",
+					slog.String("key", key),
+					slog.String("secret", name))
 				return fmt.Sprintf("<MALFORMED_SECRET_%s_KEY_%s>", name, key)
 			}
 			return string(decoded)
@@ -150,14 +157,19 @@ func (c *conversionContext) extractResourceKey(kind, name, key string) string {
 		if found {
 			decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(val))
 			if err != nil {
-				c.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in configmap %q. Hardcoding placeholder.", key, name))
+				c.logger.Warn("Failed to decode base64 data. Hardcoding placeholder.",
+					slog.String("key", key),
+					slog.String("configmap", name))
 				return fmt.Sprintf("<MALFORMED_CONFIGMAP_%s_KEY_%s>", name, key)
 			}
 			return string(decoded)
 		}
 	}
 
-	c.logger.Warn(fmt.Sprintf("Key %q not found in %s %q. Hardcoding placeholder.", key, strings.ToLower(kind), name))
+	c.logger.Warn("Key not found in resource. Hardcoding placeholder.",
+		slog.String("key", key),
+		slog.String("referenced_kind", kind),
+		slog.String("referenced_name", name))
 	return fmt.Sprintf("<MISSING_KEY_%s_IN_%s_%s>", key, kindUpper, name)
 }
 
@@ -176,13 +188,15 @@ func (c *conversionContext) convertConfigMapToSecretSelector(sel *corev1.ConfigM
 		return nil
 	}
 	if sel.Name == "" {
-		c.logger.Warn(fmt.Sprintf("ConfigMap reference for key %q has an empty name. Hardcoding placeholder and skipping Secret manifest generation. You must fix this reference and ensure the Secret is created before applying.", sel.Key))
+		c.logger.Warn("ConfigMap reference has an empty name. Hardcoding placeholder and skipping Secret manifest generation. You must fix this reference and ensure the Secret is created before applying.",
+			slog.String("key", sel.Key))
 		return &monitoringv1.SecretSelector{
 			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_CONFIGMAP_NAME>", Key: sel.Key, Namespace: c.namespace},
 		}
 	}
 	if sel.Key == "" {
-		c.logger.Warn(fmt.Sprintf("ConfigMap reference %q has an empty key. Hardcoding placeholder. You must fix this reference before applying.", sel.Name))
+		c.logger.Warn("ConfigMap reference has an empty key. Hardcoding placeholder. You must fix this reference before applying.",
+			slog.String("configmap", sel.Name))
 		return &monitoringv1.SecretSelector{
 			Secret: &monitoringv1.SecretKeySelector{Name: "secret-" + sel.Name, Key: "<MISSING_CONFIGMAP_KEY>", Namespace: c.namespace},
 		}
@@ -192,7 +206,8 @@ func (c *conversionContext) convertConfigMapToSecretSelector(sel *corev1.ConfigM
 	secretKey := sel.Key
 
 	if sel.Optional != nil && *sel.Optional {
-		c.logger.Warn(fmt.Sprintf("ConfigMap reference %q had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.", sel.Name))
+		c.logger.Warn("ConfigMap reference had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.",
+			slog.String("configmap", sel.Name))
 	}
 
 	if c.generatedSecrets == nil {
@@ -202,9 +217,13 @@ func (c *conversionContext) convertConfigMapToSecretSelector(sel *corev1.ConfigM
 	if _, exists := c.generatedSecrets[secretName]; !exists {
 		obj, ok := c.cache.Get(KindConfigMap, c.namespace, sel.Name)
 		if !ok {
-			c.logger.Warn(fmt.Sprintf("TLS ConfigMap reference %q was not found in the inputs. Updated reference to GMP Secret %q, but you must manually convert your ConfigMap to a Secret with this name in GMP.", sel.Name, secretName))
+			c.logger.Warn("TLS ConfigMap reference was not found in the inputs. Updated reference to GMP Secret, but you must manually convert your ConfigMap to a Secret with this name in GMP.",
+				slog.String("configmap", sel.Name),
+				slog.String("expected_secret", secretName))
 		} else {
-			c.logger.Info(fmt.Sprintf("Translated TLS ConfigMap reference %q to GMP Secret. Generated new Secret manifest %q.", sel.Name, secretName))
+			c.logger.Info("Translated TLS ConfigMap reference to GMP Secret. Generated new Secret manifest.",
+				slog.String("configmap", sel.Name),
+				slog.String("generated_secret", secretName))
 
 			newSecret := &unstructured.Unstructured{}
 			newSecret.SetAPIVersion("v1")
@@ -246,19 +265,22 @@ func (c *conversionContext) convertSecretSelector(sel *corev1.SecretKeySelector)
 		return nil
 	}
 	if sel.Name == "" {
-		c.logger.Warn(fmt.Sprintf("Secret reference for key %q has an empty name. Hardcoding placeholder. You must fix this reference and ensure the Secret is created before applying.", sel.Key))
+		c.logger.Warn("Secret reference has an empty name. Hardcoding placeholder. You must fix this reference and ensure the Secret is created before applying.",
+			slog.String("key", sel.Key))
 		return &monitoringv1.SecretSelector{
 			Secret: &monitoringv1.SecretKeySelector{Name: "<MISSING_SECRET_NAME>", Key: sel.Key, Namespace: c.namespace},
 		}
 	}
 	if sel.Key == "" {
-		c.logger.Warn(fmt.Sprintf("Secret reference %q has an empty key. Hardcoding placeholder. You must fix this reference before applying.", sel.Name))
+		c.logger.Warn("Secret reference has an empty key. Hardcoding placeholder. You must fix this reference before applying.",
+			slog.String("secret", sel.Name))
 		return &monitoringv1.SecretSelector{
 			Secret: &monitoringv1.SecretKeySelector{Name: sel.Name, Key: "<MISSING_SECRET_KEY>", Namespace: c.namespace},
 		}
 	}
 	if sel.Optional != nil && *sel.Optional {
-		c.logger.Warn(fmt.Sprintf("Secret reference %q had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.", sel.Name))
+		c.logger.Warn("Secret reference had 'optional: true'. GMP does not support optional secrets. The reference is now mandatory.",
+			slog.String("secret", sel.Name))
 	}
 	secretRef := &monitoringv1.SecretKeySelector{Name: sel.Name, Key: sel.Key, Namespace: c.namespace}
 	return &monitoringv1.SecretSelector{Secret: secretRef}
@@ -354,8 +376,9 @@ func convertMetricRelabelings(
 		case "replace", "hashmod", "lowercase", "uppercase":
 			if protectedLabels[config.TargetLabel] {
 				targetLabel = "exported_" + config.TargetLabel
-				logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.",
-					config.TargetLabel, targetLabel))
+				logger.Warn("Relabeling rule attempts to write to protected target label. Renamed target.",
+					slog.String("protected_label", config.TargetLabel),
+					slog.String("renamed_target", targetLabel))
 			}
 		}
 
@@ -397,7 +420,10 @@ func convertTargetLabels(logger *slog.Logger, sourceLabels []string, jobLabel st
 		}
 
 		if seenTargets[target] {
-			logger.Warn(fmt.Sprintf("%s target label %q maps to target label %q which is already taken. Skipping.", labelKind, l, target))
+			logger.Warn("Target label mapping collision. Skipping.",
+				slog.String("label_kind", labelKind),
+				slog.String("source_label", l),
+				slog.String("target_label", target))
 			continue
 		}
 
@@ -406,7 +432,10 @@ func convertTargetLabels(logger *slog.Logger, sourceLabels []string, jobLabel st
 
 		if target != l {
 			mapping.To = target
-			logger.Warn(fmt.Sprintf("%s target label %q is protected in GMP. Renamed target to %q.", labelKind, l, target))
+			logger.Warn("Target label is protected in GMP. Renamed target.",
+				slog.String("label_kind", labelKind),
+				slog.String("source_label", l),
+				slog.String("renamed_target", target))
 		}
 
 		fromPod = append(fromPod, mapping)
@@ -415,14 +444,16 @@ func convertTargetLabels(logger *slog.Logger, sourceLabels []string, jobLabel st
 	if jobLabel != "" {
 		target := "exported_job"
 		if !seenTargets[target] {
-			logger.Warn(fmt.Sprintf("GMP does not support overriding the protected 'job' label. Value on label %q has been copied into the target label 'exported_job'.", jobLabel))
+			logger.Warn("GMP does not support overriding the protected 'job' label. Value has been copied into the target label 'exported_job'.",
+				slog.String("source_label", jobLabel))
 			fromPod = append(fromPod, monitoringv1.LabelMapping{
 				From: jobLabel,
 				To:   target,
 			})
 			seenTargets[target] = true
 		} else {
-			logger.Warn(fmt.Sprintf("Job label %q could not be mapped to 'exported_job' because 'exported_job' is already taken by another target label mapping.", jobLabel))
+			logger.Warn("Job label could not be mapped to 'exported_job' because 'exported_job' is already taken.",
+				slog.String("source_label", jobLabel))
 		}
 	}
 

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -108,58 +108,67 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 	return secrets
 }
 
-// extractSecretKey extracts a string value from a Secret, returning a placeholder and warning if not found.
-func extractSecretKey(convCtx *conversionContext, sel corev1.SecretKeySelector) string {
-	if sel.Name == "" {
-		convCtx.logger.Warn(fmt.Sprintf("SecretKeySelector has empty name for key %q. Hardcoding placeholder.", sel.Key))
-		return fmt.Sprintf("<MISSING_SECRET_NAME_KEY_%s>", sel.Key)
+// extractResourceKey is a consolidated helper that fetches a key from a ConfigMap or Secret.
+func extractResourceKey(convCtx *conversionContext, kind, name, key string) string {
+	kindUpper := strings.ToUpper(kind)
+	if name == "" {
+		convCtx.logger.Warn(fmt.Sprintf("%sKeySelector has empty name for key %q. Hardcoding placeholder.", kind, key))
+		return fmt.Sprintf("<MISSING_%s_NAME_KEY_%s>", kindUpper, key)
 	}
 
-	obj, ok := convCtx.cache.Get("Secret", convCtx.namespace, sel.Name)
+	obj, ok := convCtx.cache.Get(kind, convCtx.namespace, name)
 	if !ok {
-		convCtx.logger.Warn(fmt.Sprintf("Secret %q not found. Cannot extract key %q. Hardcoding placeholder.", sel.Name, sel.Key))
-		return fmt.Sprintf("<MISSING_SECRET_%s_KEY_%s>", sel.Name, sel.Key)
+		convCtx.logger.Warn(fmt.Sprintf("%s %q not found in cache. Cannot extract key %q. Hardcoding placeholder.", kind, name, key))
+		return fmt.Sprintf("<MISSING_%s_%s_KEY_%s>", kindUpper, name, key)
 	}
 
-	val, found, _ := unstructured.NestedString(obj.Object, "stringData", sel.Key)
+	// Secrets support unencoded stringData.
+	if kind == KindSecret {
+		val, found, _ := unstructured.NestedString(obj.Object, "stringData", key)
+		if found {
+			return val
+		}
+	}
+
+	// Check standard data field (plain string for ConfigMap, base64 for Secret).
+	val, found, _ := unstructured.NestedString(obj.Object, "data", key)
 	if found {
+		if kind == KindSecret {
+			decoded, err := base64.StdEncoding.DecodeString(val)
+			if err != nil {
+				convCtx.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in secret %q. Hardcoding placeholder.", key, name))
+				return fmt.Sprintf("<MALFORMED_SECRET_%s_KEY_%s>", name, key)
+			}
+			return string(decoded)
+		}
 		return val
 	}
 
-	val, found, _ = unstructured.NestedString(obj.Object, "data", sel.Key)
-	if found {
-		decoded, err := base64.StdEncoding.DecodeString(val)
-		if err != nil {
-			convCtx.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in secret %q. Hardcoding placeholder.", sel.Key, sel.Name))
-			return fmt.Sprintf("<MALFORMED_SECRET_%s_KEY_%s>", sel.Name, sel.Key)
+	// ConfigMaps can store base64 binaryData.
+	if kind == KindConfigMap {
+		val, found, _ = unstructured.NestedString(obj.Object, "binaryData", key)
+		if found {
+			decoded, err := base64.StdEncoding.DecodeString(val)
+			if err != nil {
+				convCtx.logger.Warn(fmt.Sprintf("Failed to decode base64 data for key %q in configmap %q. Hardcoding placeholder.", key, name))
+				return fmt.Sprintf("<MALFORMED_CONFIGMAP_%s_KEY_%s>", name, key)
+			}
+			return string(decoded)
 		}
-		return string(decoded)
 	}
 
-	convCtx.logger.Warn(fmt.Sprintf("Key %q not found in secret %q. Hardcoding placeholder.", sel.Key, sel.Name))
-	return fmt.Sprintf("<MISSING_KEY_%s_IN_SECRET_%s>", sel.Key, sel.Name)
+	convCtx.logger.Warn(fmt.Sprintf("Key %q not found in %s %q. Hardcoding placeholder.", key, strings.ToLower(kind), name))
+	return fmt.Sprintf("<MISSING_KEY_%s_IN_%s_%s>", key, kindUpper, name)
+}
+
+// extractSecretKey extracts a string value from a Secret, returning a placeholder and warning if not found.
+func extractSecretKey(convCtx *conversionContext, sel corev1.SecretKeySelector) string {
+	return extractResourceKey(convCtx, KindSecret, sel.Name, sel.Key)
 }
 
 // extractConfigMapKey extracts a string value from a ConfigMap, returning a placeholder and warning if not found.
 func extractConfigMapKey(convCtx *conversionContext, sel corev1.ConfigMapKeySelector) string {
-	if sel.Name == "" {
-		convCtx.logger.Warn(fmt.Sprintf("ConfigMapKeySelector has empty name for key %q. Hardcoding placeholder.", sel.Key))
-		return fmt.Sprintf("<MISSING_CONFIGMAP_NAME_KEY_%s>", sel.Key)
-	}
-
-	obj, ok := convCtx.cache.Get("ConfigMap", convCtx.namespace, sel.Name)
-	if !ok {
-		convCtx.logger.Warn(fmt.Sprintf("ConfigMap %q not found in cache. Cannot extract key %q. Hardcoding placeholder.", sel.Name, sel.Key))
-		return fmt.Sprintf("<MISSING_CONFIGMAP_%s_KEY_%s>", sel.Name, sel.Key)
-	}
-
-	val, found, _ := unstructured.NestedString(obj.Object, "data", sel.Key)
-	if found {
-		return val
-	}
-
-	convCtx.logger.Warn(fmt.Sprintf("Key %q not found in configmap %q. Hardcoding placeholder.", sel.Key, sel.Name))
-	return fmt.Sprintf("<MISSING_KEY_%s_IN_CONFIGMAP_%s>", sel.Key, sel.Name)
+	return extractResourceKey(convCtx, KindConfigMap, sel.Name, sel.Key)
 }
 
 func convertConfigMapToSecretSelector(convCtx *conversionContext, sel *corev1.ConfigMapKeySelector) *monitoringv1.SecretSelector {
@@ -306,10 +315,11 @@ func convertOAuth2(convCtx *conversionContext, oa *pomonitoringv1.OAuth2) *monit
 	}
 
 	return &monitoringv1.OAuth2{
-		ClientID:     clientID,
-		ClientSecret: convertSecretSelector(convCtx, &oa.ClientSecret),
-		TokenURL:     oa.TokenURL,
-		Scopes:       oa.Scopes,
+		ClientID:       clientID,
+		ClientSecret:   convertSecretSelector(convCtx, &oa.ClientSecret),
+		TokenURL:       oa.TokenURL,
+		Scopes:         oa.Scopes,
+		EndpointParams: oa.EndpointParams,
 	}
 }
 

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -34,7 +34,7 @@ func newTestConversionContext() *conversionContext {
 	}
 }
 
-func addSecretToCache(cache *ResourceCache, namespace, name, key, value string, isStringData bool) {
+func addSecretToCache(cache *ResourceCache, namespace, name, key, value string, isStringData bool) error {
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -49,10 +49,10 @@ func addSecretToCache(cache *ResourceCache, namespace, name, key, value string, 
 	}
 
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
-	cache.Add(&unstructured.Unstructured{Object: u})
+	return cache.Add(&unstructured.Unstructured{Object: u})
 }
 
-func addConfigMapToCache(cache *ResourceCache, namespace, name, key, value string) {
+func addConfigMapToCache(cache *ResourceCache, namespace, name, key, value string) error {
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -63,34 +63,34 @@ func addConfigMapToCache(cache *ResourceCache, namespace, name, key, value strin
 	}
 
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
-	cache.Add(&unstructured.Unstructured{Object: u})
+	return cache.Add(&unstructured.Unstructured{Object: u})
 }
 
 func TestExtractSecretKey(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupCache  func(cache *ResourceCache)
+		setupCache  func(cache *ResourceCache) error
 		selector    corev1.SecretKeySelector
 		expectedVal string
 	}{
 		{
 			name:        "Missing secret",
-			setupCache:  func(cache *ResourceCache) {}, // Empty cache
+			setupCache:  func(_ *ResourceCache) error { return nil }, // Empty cache
 			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "missing"}, Key: "user"},
 			expectedVal: "<MISSING_SECRET_missing_KEY_user>",
 		},
 		{
 			name: "Secret with StringData",
-			setupCache: func(cache *ResourceCache) {
-				addSecretToCache(cache, "default", "my-secret", "user", "admin", true)
+			setupCache: func(cache *ResourceCache) error {
+				return addSecretToCache(cache, "default", "my-secret", "user", "admin", true)
 			},
 			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"}, Key: "user"},
 			expectedVal: "admin",
 		},
 		{
 			name: "Secret with Base64 Data",
-			setupCache: func(cache *ResourceCache) {
-				addSecretToCache(cache, "default", "my-secret-2", "pass", "supersecret", false)
+			setupCache: func(cache *ResourceCache) error {
+				return addSecretToCache(cache, "default", "my-secret-2", "pass", "supersecret", false)
 			},
 			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret-2"}, Key: "pass"},
 			expectedVal: "supersecret",
@@ -100,7 +100,9 @@ func TestExtractSecretKey(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := newTestConversionContext()
-			tc.setupCache(ctx.cache)
+			if err := tc.setupCache(ctx.cache); err != nil {
+				t.Fatalf("failed to setup cache: %v", err)
+			}
 
 			val := extractSecretKey(ctx, tc.selector)
 			if val != tc.expectedVal {
@@ -113,20 +115,20 @@ func TestExtractSecretKey(t *testing.T) {
 func TestExtractConfigMapKey(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupCache  func(cache *ResourceCache)
+		setupCache  func(cache *ResourceCache) error
 		selector    corev1.ConfigMapKeySelector
 		expectedVal string
 	}{
 		{
 			name:        "Missing configmap",
-			setupCache:  func(cache *ResourceCache) {}, // Empty cache
+			setupCache:  func(_ *ResourceCache) error { return nil }, // Empty cache
 			selector:    corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "missing"}, Key: "user"},
 			expectedVal: "<MISSING_CONFIGMAP_missing_KEY_user>",
 		},
 		{
 			name: "Found configmap",
-			setupCache: func(cache *ResourceCache) {
-				addConfigMapToCache(cache, "default", "my-cm", "id", "client-123")
+			setupCache: func(cache *ResourceCache) error {
+				return addConfigMapToCache(cache, "default", "my-cm", "id", "client-123")
 			},
 			selector:    corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-cm"}, Key: "id"},
 			expectedVal: "client-123",
@@ -136,7 +138,9 @@ func TestExtractConfigMapKey(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := newTestConversionContext()
-			tc.setupCache(ctx.cache)
+			if err := tc.setupCache(ctx.cache); err != nil {
+				t.Fatalf("failed to setup cache: %v", err)
+			}
 
 			val := extractConfigMapKey(ctx, tc.selector)
 			if val != tc.expectedVal {
@@ -149,7 +153,7 @@ func TestExtractConfigMapKey(t *testing.T) {
 func TestConvertConfigMapToSecretSelector(t *testing.T) {
 	tests := []struct {
 		name                  string
-		setupCache            func(cache *ResourceCache)
+		setupCache            func(cache *ResourceCache) error
 		selector              *corev1.ConfigMapKeySelector
 		expectedSecretName    string
 		expectedSecretKey     string
@@ -157,8 +161,8 @@ func TestConvertConfigMapToSecretSelector(t *testing.T) {
 	}{
 		{
 			name: "Convert ConfigMap to Secret",
-			setupCache: func(cache *ResourceCache) {
-				addConfigMapToCache(cache, "default", "tls-cm", "ca.crt", "cert-data")
+			setupCache: func(cache *ResourceCache) error {
+				return addConfigMapToCache(cache, "default", "tls-cm", "ca.crt", "cert-data")
 			},
 			selector: &corev1.ConfigMapKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: "tls-cm"},
@@ -170,7 +174,7 @@ func TestConvertConfigMapToSecretSelector(t *testing.T) {
 		},
 		{
 			name:                  "Nil selector",
-			setupCache:            func(cache *ResourceCache) {},
+			setupCache:            func(_ *ResourceCache) error { return nil },
 			selector:              nil,
 			expectedSecretName:    "",
 			expectedSecretKey:     "",
@@ -181,7 +185,9 @@ func TestConvertConfigMapToSecretSelector(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := newTestConversionContext()
-			tc.setupCache(ctx.cache)
+			if err := tc.setupCache(ctx.cache); err != nil {
+				t.Fatalf("failed to setup cache: %v", err)
+			}
 
 			gmpSel := convertConfigMapToSecretSelector(ctx, tc.selector)
 
@@ -212,7 +218,7 @@ func TestConvertConfigMapToSecretSelector(t *testing.T) {
 func TestConvertBasicAuth(t *testing.T) {
 	tests := []struct {
 		name             string
-		setupCache       func(cache *ResourceCache)
+		setupCache       func(cache *ResourceCache) error
 		basicAuth        *pomonitoringv1.BasicAuth
 		expectedUser     string
 		expectedPassName string
@@ -220,8 +226,8 @@ func TestConvertBasicAuth(t *testing.T) {
 	}{
 		{
 			name: "Valid BasicAuth conversion",
-			setupCache: func(cache *ResourceCache) {
-				addSecretToCache(cache, "default", "auth-secret", "user", "myuser", true)
+			setupCache: func(cache *ResourceCache) error {
+				return addSecretToCache(cache, "default", "auth-secret", "user", "myuser", true)
 			},
 			basicAuth: &pomonitoringv1.BasicAuth{
 				Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "auth-secret"}, Key: "user"},
@@ -233,7 +239,7 @@ func TestConvertBasicAuth(t *testing.T) {
 		},
 		{
 			name:       "Nil BasicAuth",
-			setupCache: func(cache *ResourceCache) {},
+			setupCache: func(_ *ResourceCache) error { return nil },
 			basicAuth:  nil,
 		},
 	}
@@ -241,7 +247,9 @@ func TestConvertBasicAuth(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := newTestConversionContext()
-			tc.setupCache(ctx.cache)
+			if err := tc.setupCache(ctx.cache); err != nil {
+				t.Fatalf("failed to setup cache: %v", err)
+			}
 
 			gmpBA := convertBasicAuth(ctx, tc.basicAuth)
 
@@ -266,7 +274,7 @@ func TestConvertSafeTLSConfig(t *testing.T) {
 	trueVal := true
 	tests := []struct {
 		name               string
-		setupCache         func(cache *ResourceCache)
+		setupCache         func(cache *ResourceCache) error
 		tlsConfig          *pomonitoringv1.SafeTLSConfig
 		expectedCAName     string
 		expectedCAKey      string
@@ -277,8 +285,8 @@ func TestConvertSafeTLSConfig(t *testing.T) {
 	}{
 		{
 			name: "Full TLS Config Conversion",
-			setupCache: func(cache *ResourceCache) {
-				addConfigMapToCache(cache, "default", "ca-cm", "ca.crt", "ca-data")
+			setupCache: func(cache *ResourceCache) error {
+				return addConfigMapToCache(cache, "default", "ca-cm", "ca.crt", "ca-data")
 			},
 			tlsConfig: &pomonitoringv1.SafeTLSConfig{
 				CA: pomonitoringv1.SecretOrConfigMap{
@@ -299,7 +307,7 @@ func TestConvertSafeTLSConfig(t *testing.T) {
 		},
 		{
 			name:       "Nil TLS Config",
-			setupCache: func(cache *ResourceCache) {},
+			setupCache: func(_ *ResourceCache) error { return nil },
 			tlsConfig:  nil,
 		},
 	}
@@ -307,7 +315,9 @@ func TestConvertSafeTLSConfig(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := newTestConversionContext()
-			tc.setupCache(ctx.cache)
+			if err := tc.setupCache(ctx.cache); err != nil {
+				t.Fatalf("failed to setup cache: %v", err)
+			}
 
 			gmpTLS := convertSafeTLSConfig(ctx, tc.tlsConfig)
 

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -104,7 +104,7 @@ func TestExtractSecretKey(t *testing.T) {
 				t.Fatalf("failed to setup cache: %v", err)
 			}
 
-			val := extractSecretKey(ctx, tc.selector)
+			val := ctx.extractSecretKey(tc.selector)
 			if val != tc.expectedVal {
 				t.Errorf("expected %s, got %s", tc.expectedVal, val)
 			}
@@ -142,7 +142,7 @@ func TestExtractConfigMapKey(t *testing.T) {
 				t.Fatalf("failed to setup cache: %v", err)
 			}
 
-			val := extractConfigMapKey(ctx, tc.selector)
+			val := ctx.extractConfigMapKey(tc.selector)
 			if val != tc.expectedVal {
 				t.Errorf("expected %s, got %s", tc.expectedVal, val)
 			}
@@ -189,7 +189,7 @@ func TestConvertConfigMapToSecretSelector(t *testing.T) {
 				t.Fatalf("failed to setup cache: %v", err)
 			}
 
-			gmpSel := convertConfigMapToSecretSelector(ctx, tc.selector)
+			gmpSel := ctx.convertConfigMapToSecretSelector(tc.selector)
 
 			if tc.selector == nil {
 				if gmpSel != nil {
@@ -252,7 +252,7 @@ func TestConvertBasicAuth(t *testing.T) {
 				t.Fatalf("failed to setup cache: %v", err)
 			}
 
-			gmpBA := convertBasicAuth(ctx, tc.basicAuth)
+			gmpBA := ctx.convertBasicAuth(tc.basicAuth)
 
 			if tc.basicAuth == nil {
 				if gmpBA != nil {
@@ -320,7 +320,7 @@ func TestConvertSafeTLSConfig(t *testing.T) {
 				t.Fatalf("failed to setup cache: %v", err)
 			}
 
-			gmpTLS := convertSafeTLSConfig(ctx, tc.tlsConfig)
+			gmpTLS := ctx.convertSafeTLSConfig(tc.tlsConfig)
 
 			if tc.tlsConfig == nil {
 				if gmpTLS != nil {
@@ -358,13 +358,13 @@ func TestConvertConfigMapToSecretSelectorDeduplication(t *testing.T) {
 	}
 
 	// Call first time.
-	gmpSel1 := convertConfigMapToSecretSelector(ctx, selector)
+	gmpSel1 := ctx.convertConfigMapToSecretSelector(selector)
 	if gmpSel1 == nil || gmpSel1.Secret.Name != "secret-tls-cm" {
 		t.Fatal("first call failed to translate selector")
 	}
 
 	// Call second time.
-	gmpSel2 := convertConfigMapToSecretSelector(ctx, selector)
+	gmpSel2 := ctx.convertConfigMapToSecretSelector(selector)
 	if gmpSel2 == nil || gmpSel2.Secret.Name != "secret-tls-cm" {
 		t.Fatal("second call failed to translate selector")
 	}

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -72,12 +72,14 @@ func TestExtractSecretKey(t *testing.T) {
 		setupCache  func(cache *ResourceCache) error
 		selector    corev1.SecretKeySelector
 		expectedVal string
+		wantErr     bool
 	}{
 		{
 			name:        "Missing secret",
 			setupCache:  func(_ *ResourceCache) error { return nil }, // Empty cache.
 			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "missing"}, Key: "user"},
 			expectedVal: "<MISSING_SECRET_missing_KEY_user>",
+			wantErr:     false,
 		},
 		{
 			name: "Secret with StringData",
@@ -86,6 +88,7 @@ func TestExtractSecretKey(t *testing.T) {
 			},
 			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"}, Key: "user"},
 			expectedVal: "admin",
+			wantErr:     false,
 		},
 		{
 			name: "Secret with Base64 Data",
@@ -94,6 +97,52 @@ func TestExtractSecretKey(t *testing.T) {
 			},
 			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret-2"}, Key: "pass"},
 			expectedVal: "supersecret",
+			wantErr:     false,
+		},
+		{
+			name:        "Secret reference with empty Name",
+			setupCache:  func(_ *ResourceCache) error { return nil },
+			selector:    corev1.SecretKeySelector{Key: "user"},
+			expectedVal: "",
+			wantErr:     true,
+		},
+		{
+			name:        "Secret reference with empty Key",
+			setupCache:  func(_ *ResourceCache) error { return nil },
+			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"}},
+			expectedVal: "",
+			wantErr:     true,
+		},
+		{
+			name: "Secret exists but key missing",
+			setupCache: func(cache *ResourceCache) error {
+				return addSecretToCache(cache, "default", "my-secret", "user", "admin", true)
+			},
+			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"}, Key: "password"},
+			expectedVal: "",
+			wantErr:     true,
+		},
+		{
+			name: "Secret exists but data corrupted",
+			setupCache: func(cache *ResourceCache) error {
+				secret := &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata": map[string]any{
+							"name":      "corrupted-secret",
+							"namespace": "default",
+						},
+						"data": map[string]any{
+							"pass": "not-base64-data-with-invalid-chars-@!#",
+						},
+					},
+				}
+				return cache.Add(secret)
+			},
+			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "corrupted-secret"}, Key: "pass"},
+			expectedVal: "",
+			wantErr:     true,
 		},
 	}
 
@@ -104,8 +153,11 @@ func TestExtractSecretKey(t *testing.T) {
 				t.Fatalf("failed to setup cache: %v", err)
 			}
 
-			val := ctx.extractSecretKey(tc.selector)
-			if val != tc.expectedVal {
+			val, err := ctx.extractSecretKey(tc.selector)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("extractSecretKey() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && val != tc.expectedVal {
 				t.Errorf("expected %s, got %s", tc.expectedVal, val)
 			}
 		})
@@ -118,12 +170,14 @@ func TestExtractConfigMapKey(t *testing.T) {
 		setupCache  func(cache *ResourceCache) error
 		selector    corev1.ConfigMapKeySelector
 		expectedVal string
+		wantErr     bool
 	}{
 		{
 			name:        "Missing configmap",
 			setupCache:  func(_ *ResourceCache) error { return nil }, // Empty cache.
 			selector:    corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "missing"}, Key: "user"},
 			expectedVal: "<MISSING_CONFIGMAP_missing_KEY_user>",
+			wantErr:     false,
 		},
 		{
 			name: "Found configmap",
@@ -132,6 +186,30 @@ func TestExtractConfigMapKey(t *testing.T) {
 			},
 			selector:    corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-cm"}, Key: "id"},
 			expectedVal: "client-123",
+			wantErr:     false,
+		},
+		{
+			name:        "Configmap reference with empty Name",
+			setupCache:  func(_ *ResourceCache) error { return nil },
+			selector:    corev1.ConfigMapKeySelector{Key: "user"},
+			expectedVal: "",
+			wantErr:     true,
+		},
+		{
+			name:        "Configmap reference with empty Key",
+			setupCache:  func(_ *ResourceCache) error { return nil },
+			selector:    corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-cm"}},
+			expectedVal: "",
+			wantErr:     true,
+		},
+		{
+			name: "Configmap exists but key missing",
+			setupCache: func(cache *ResourceCache) error {
+				return addConfigMapToCache(cache, "default", "my-cm", "id", "client-123")
+			},
+			selector:    corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-cm"}, Key: "secret"},
+			expectedVal: "",
+			wantErr:     true,
 		},
 	}
 
@@ -142,8 +220,11 @@ func TestExtractConfigMapKey(t *testing.T) {
 				t.Fatalf("failed to setup cache: %v", err)
 			}
 
-			val := ctx.extractConfigMapKey(tc.selector)
-			if val != tc.expectedVal {
+			val, err := ctx.extractConfigMapKey(tc.selector)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("extractConfigMapKey() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && val != tc.expectedVal {
 				t.Errorf("expected %s, got %s", tc.expectedVal, val)
 			}
 		})
@@ -158,6 +239,7 @@ func TestConvertConfigMapToSecretSelector(t *testing.T) {
 		expectedSecretName    string
 		expectedSecretKey     string
 		expectGeneratedSecret bool
+		wantErr               bool
 	}{
 		{
 			name: "Convert ConfigMap to Secret",
@@ -171,6 +253,7 @@ func TestConvertConfigMapToSecretSelector(t *testing.T) {
 			expectedSecretName:    "secret-tls-cm",
 			expectedSecretKey:     "ca.crt",
 			expectGeneratedSecret: true,
+			wantErr:               false,
 		},
 		{
 			name:                  "Nil selector",
@@ -179,6 +262,25 @@ func TestConvertConfigMapToSecretSelector(t *testing.T) {
 			expectedSecretName:    "",
 			expectedSecretKey:     "",
 			expectGeneratedSecret: false,
+			wantErr:               false,
+		},
+		{
+			name:                  "Empty name reference",
+			setupCache:            func(_ *ResourceCache) error { return nil },
+			selector:              &corev1.ConfigMapKeySelector{Key: "ca.crt"},
+			expectedSecretName:    "",
+			expectedSecretKey:     "",
+			expectGeneratedSecret: false,
+			wantErr:               true,
+		},
+		{
+			name:                  "Empty key reference",
+			setupCache:            func(_ *ResourceCache) error { return nil },
+			selector:              &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "tls-cm"}},
+			expectedSecretName:    "",
+			expectedSecretKey:     "",
+			expectGeneratedSecret: false,
+			wantErr:               true,
 		},
 	}
 
@@ -189,12 +291,18 @@ func TestConvertConfigMapToSecretSelector(t *testing.T) {
 				t.Fatalf("failed to setup cache: %v", err)
 			}
 
-			gmpSel := ctx.convertConfigMapToSecretSelector(tc.selector)
+			gmpSel, err := ctx.convertConfigMapToSecretSelector(tc.selector)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("convertConfigMapToSecretSelector() error = %v, wantErr %v", err, tc.wantErr)
+			}
 
 			if tc.selector == nil {
 				if gmpSel != nil {
 					t.Errorf("expected nil result for nil selector, got %+v", gmpSel)
 				}
+				return
+			}
+			if tc.wantErr {
 				return
 			}
 
@@ -224,6 +332,7 @@ func TestConvertBasicAuth(t *testing.T) {
 		expectedUser     string
 		expectedPassName string
 		expectedPassKey  string
+		wantErr          bool
 	}{
 		{
 			name: "Valid BasicAuth conversion",
@@ -237,11 +346,22 @@ func TestConvertBasicAuth(t *testing.T) {
 			expectedUser:     "myuser",
 			expectedPassName: "auth-secret",
 			expectedPassKey:  "pass",
+			wantErr:          false,
 		},
 		{
 			name:       "Nil BasicAuth",
 			setupCache: func(_ *ResourceCache) error { return nil },
 			basicAuth:  nil,
+			wantErr:    false,
+		},
+		{
+			name:       "Malformed Username reference",
+			setupCache: func(_ *ResourceCache) error { return nil },
+			basicAuth: &pomonitoringv1.BasicAuth{
+				Username: corev1.SecretKeySelector{Key: "user"},
+				Password: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "auth-secret"}, Key: "pass"},
+			},
+			wantErr: true,
 		},
 	}
 
@@ -252,12 +372,18 @@ func TestConvertBasicAuth(t *testing.T) {
 				t.Fatalf("failed to setup cache: %v", err)
 			}
 
-			gmpBA := ctx.convertBasicAuth(tc.basicAuth)
+			gmpBA, err := ctx.convertBasicAuth(tc.basicAuth)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("convertBasicAuth() error = %v, wantErr %v", err, tc.wantErr)
+			}
 
 			if tc.basicAuth == nil {
 				if gmpBA != nil {
 					t.Errorf("expected nil result for nil BasicAuth, got %+v", gmpBA)
 				}
+				return
+			}
+			if tc.wantErr {
 				return
 			}
 
@@ -283,6 +409,7 @@ func TestConvertSafeTLSConfig(t *testing.T) {
 		expectedCertKey    string
 		expectedSkipVerify bool
 		expectedServerName string
+		wantErr            bool
 	}{
 		{
 			name: "Full TLS Config Conversion",
@@ -305,11 +432,23 @@ func TestConvertSafeTLSConfig(t *testing.T) {
 			expectedCertKey:    "tls.crt",
 			expectedSkipVerify: true,
 			expectedServerName: "my-server",
+			wantErr:            false,
 		},
 		{
 			name:       "Nil TLS Config",
 			setupCache: func(_ *ResourceCache) error { return nil },
 			tlsConfig:  nil,
+			wantErr:    false,
+		},
+		{
+			name:       "Malformed CA reference",
+			setupCache: func(_ *ResourceCache) error { return nil },
+			tlsConfig: &pomonitoringv1.SafeTLSConfig{
+				CA: pomonitoringv1.SecretOrConfigMap{
+					ConfigMap: &corev1.ConfigMapKeySelector{Key: "ca.crt"},
+				},
+			},
+			wantErr: true,
 		},
 	}
 
@@ -320,12 +459,18 @@ func TestConvertSafeTLSConfig(t *testing.T) {
 				t.Fatalf("failed to setup cache: %v", err)
 			}
 
-			gmpTLS := ctx.convertSafeTLSConfig(tc.tlsConfig)
+			gmpTLS, err := ctx.convertSafeTLSConfig(tc.tlsConfig)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("convertSafeTLSConfig() error = %v, wantErr %v", err, tc.wantErr)
+			}
 
 			if tc.tlsConfig == nil {
 				if gmpTLS != nil {
 					t.Errorf("expected nil result for nil TLS config, got %+v", gmpTLS)
 				}
+				return
+			}
+			if tc.wantErr {
 				return
 			}
 
@@ -358,13 +503,19 @@ func TestConvertConfigMapToSecretSelectorDeduplication(t *testing.T) {
 	}
 
 	// Call first time.
-	gmpSel1 := ctx.convertConfigMapToSecretSelector(selector)
+	gmpSel1, err := ctx.convertConfigMapToSecretSelector(selector)
+	if err != nil {
+		t.Fatalf("first call failed with error: %v", err)
+	}
 	if gmpSel1 == nil || gmpSel1.Secret.Name != "secret-tls-cm" {
 		t.Fatal("first call failed to translate selector")
 	}
 
 	// Call second time.
-	gmpSel2 := ctx.convertConfigMapToSecretSelector(selector)
+	gmpSel2, err := ctx.convertConfigMapToSecretSelector(selector)
+	if err != nil {
+		t.Fatalf("second call failed with error: %v", err)
+	}
 	if gmpSel2 == nil || gmpSel2.Secret.Name != "secret-tls-cm" {
 		t.Fatal("second call failed to translate selector")
 	}
@@ -372,6 +523,6 @@ func TestConvertConfigMapToSecretSelectorDeduplication(t *testing.T) {
 	// Ensure only one secret was generated in total.
 	genSecrets := ctx.getGeneratedSecrets()
 	if len(genSecrets) != 1 {
-		t.Fatalf("expected exactly 1 generated secret due to deduplication, got %d", len(genSecrets))
+		t.Fatalf("expected exactly 1 generated secret due to duplication, got %d", len(genSecrets))
 	}
 }

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -360,13 +360,13 @@ func TestConvertConfigMapToSecretSelectorDeduplication(t *testing.T) {
 	// Call first time.
 	gmpSel1 := convertConfigMapToSecretSelector(ctx, selector)
 	if gmpSel1 == nil || gmpSel1.Secret.Name != "secret-tls-cm" {
-		t.Fatalf("first call failed to translate selector")
+		t.Fatal("first call failed to translate selector")
 	}
 
 	// Call second time.
 	gmpSel2 := convertConfigMapToSecretSelector(ctx, selector)
 	if gmpSel2 == nil || gmpSel2.Secret.Name != "secret-tls-cm" {
-		t.Fatalf("second call failed to translate selector")
+		t.Fatal("second call failed to translate selector")
 	}
 
 	// Ensure only one secret was generated in total.

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -75,7 +75,7 @@ func TestExtractSecretKey(t *testing.T) {
 	}{
 		{
 			name:        "Missing secret",
-			setupCache:  func(_ *ResourceCache) error { return nil }, // Empty cache
+			setupCache:  func(_ *ResourceCache) error { return nil }, // Empty cache.
 			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "missing"}, Key: "user"},
 			expectedVal: "<MISSING_SECRET_missing_KEY_user>",
 		},
@@ -121,7 +121,7 @@ func TestExtractConfigMapKey(t *testing.T) {
 	}{
 		{
 			name:        "Missing configmap",
-			setupCache:  func(_ *ResourceCache) error { return nil }, // Empty cache
+			setupCache:  func(_ *ResourceCache) error { return nil }, // Empty cache.
 			selector:    corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "missing"}, Key: "user"},
 			expectedVal: "<MISSING_CONFIGMAP_missing_KEY_user>",
 		},

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -203,10 +203,11 @@ func TestConvertConfigMapToSecretSelector(t *testing.T) {
 			}
 
 			if tc.expectGeneratedSecret {
-				if len(ctx.generatedSecrets) != 1 {
-					t.Fatalf("expected 1 generated secret, got %d", len(ctx.generatedSecrets))
+				genSecrets := ctx.getGeneratedSecrets()
+				if len(genSecrets) != 1 {
+					t.Fatalf("expected 1 generated secret, got %d", len(genSecrets))
 				}
-				gen := ctx.generatedSecrets[0]
+				gen := genSecrets[0]
 				if gen.GetName() != tc.expectedSecretName {
 					t.Errorf("expected generated secret name %s, got %s", tc.expectedSecretName, gen.GetName())
 				}
@@ -341,5 +342,36 @@ func TestConvertSafeTLSConfig(t *testing.T) {
 				t.Errorf("expected server name %s, got %s", tc.expectedServerName, gmpTLS.ServerName)
 			}
 		})
+	}
+}
+
+func TestConvertConfigMapToSecretSelectorDeduplication(t *testing.T) {
+	ctx := newTestConversionContext()
+	err := addConfigMapToCache(ctx.cache, "default", "tls-cm", "ca.crt", "cert-data")
+	if err != nil {
+		t.Fatalf("failed to setup cache: %v", err)
+	}
+
+	selector := &corev1.ConfigMapKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{Name: "tls-cm"},
+		Key:                  "ca.crt",
+	}
+
+	// Call first time.
+	gmpSel1 := convertConfigMapToSecretSelector(ctx, selector)
+	if gmpSel1 == nil || gmpSel1.Secret.Name != "secret-tls-cm" {
+		t.Fatalf("first call failed to translate selector")
+	}
+
+	// Call second time.
+	gmpSel2 := convertConfigMapToSecretSelector(ctx, selector)
+	if gmpSel2 == nil || gmpSel2.Secret.Name != "secret-tls-cm" {
+		t.Fatalf("second call failed to translate selector")
+	}
+
+	// Ensure only one secret was generated in total.
+	genSecrets := ctx.getGeneratedSecrets()
+	if len(genSecrets) != 1 {
+		t.Fatalf("expected exactly 1 generated secret due to deduplication, got %d", len(genSecrets))
 	}
 }

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -1,0 +1,335 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	pomonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func newTestConversionContext() *conversionContext {
+	return &conversionContext{
+		logger:    slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		cache:     NewResourceCache(),
+		namespace: "default",
+	}
+}
+
+func addSecretToCache(cache *ResourceCache, namespace, name, key, value string, isStringData bool) {
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if isStringData {
+		secret.StringData = map[string]string{key: value}
+	} else {
+		secret.Data = map[string][]byte{key: []byte(value)}
+	}
+
+	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
+	cache.Add(&unstructured.Unstructured{Object: u})
+}
+
+func addConfigMapToCache(cache *ResourceCache, namespace, name, key, value string) {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{key: value},
+	}
+
+	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+	cache.Add(&unstructured.Unstructured{Object: u})
+}
+
+func TestExtractSecretKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupCache  func(cache *ResourceCache)
+		selector    corev1.SecretKeySelector
+		expectedVal string
+	}{
+		{
+			name:        "Missing secret",
+			setupCache:  func(cache *ResourceCache) {}, // Empty cache
+			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "missing"}, Key: "user"},
+			expectedVal: "<MISSING_SECRET_missing_KEY_user>",
+		},
+		{
+			name: "Secret with StringData",
+			setupCache: func(cache *ResourceCache) {
+				addSecretToCache(cache, "default", "my-secret", "user", "admin", true)
+			},
+			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"}, Key: "user"},
+			expectedVal: "admin",
+		},
+		{
+			name: "Secret with Base64 Data",
+			setupCache: func(cache *ResourceCache) {
+				addSecretToCache(cache, "default", "my-secret-2", "pass", "supersecret", false)
+			},
+			selector:    corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret-2"}, Key: "pass"},
+			expectedVal: "supersecret",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newTestConversionContext()
+			tc.setupCache(ctx.cache)
+
+			val := extractSecretKey(ctx, tc.selector)
+			if val != tc.expectedVal {
+				t.Errorf("expected %s, got %s", tc.expectedVal, val)
+			}
+		})
+	}
+}
+
+func TestExtractConfigMapKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupCache  func(cache *ResourceCache)
+		selector    corev1.ConfigMapKeySelector
+		expectedVal string
+	}{
+		{
+			name:        "Missing configmap",
+			setupCache:  func(cache *ResourceCache) {}, // Empty cache
+			selector:    corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "missing"}, Key: "user"},
+			expectedVal: "<MISSING_CONFIGMAP_missing_KEY_user>",
+		},
+		{
+			name: "Found configmap",
+			setupCache: func(cache *ResourceCache) {
+				addConfigMapToCache(cache, "default", "my-cm", "id", "client-123")
+			},
+			selector:    corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "my-cm"}, Key: "id"},
+			expectedVal: "client-123",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newTestConversionContext()
+			tc.setupCache(ctx.cache)
+
+			val := extractConfigMapKey(ctx, tc.selector)
+			if val != tc.expectedVal {
+				t.Errorf("expected %s, got %s", tc.expectedVal, val)
+			}
+		})
+	}
+}
+
+func TestConvertConfigMapToSecretSelector(t *testing.T) {
+	tests := []struct {
+		name                  string
+		setupCache            func(cache *ResourceCache)
+		selector              *corev1.ConfigMapKeySelector
+		expectedSecretName    string
+		expectedSecretKey     string
+		expectGeneratedSecret bool
+	}{
+		{
+			name: "Convert ConfigMap to Secret",
+			setupCache: func(cache *ResourceCache) {
+				addConfigMapToCache(cache, "default", "tls-cm", "ca.crt", "cert-data")
+			},
+			selector: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "tls-cm"},
+				Key:                  "ca.crt",
+			},
+			expectedSecretName:    "secret-tls-cm",
+			expectedSecretKey:     "ca.crt",
+			expectGeneratedSecret: true,
+		},
+		{
+			name:                  "Nil selector",
+			setupCache:            func(cache *ResourceCache) {},
+			selector:              nil,
+			expectedSecretName:    "",
+			expectedSecretKey:     "",
+			expectGeneratedSecret: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newTestConversionContext()
+			tc.setupCache(ctx.cache)
+
+			gmpSel := convertConfigMapToSecretSelector(ctx, tc.selector)
+
+			if tc.selector == nil {
+				if gmpSel != nil {
+					t.Errorf("expected nil result for nil selector, got %+v", gmpSel)
+				}
+				return
+			}
+
+			if gmpSel == nil || gmpSel.Secret == nil || gmpSel.Secret.Name != tc.expectedSecretName || gmpSel.Secret.Key != tc.expectedSecretKey {
+				t.Errorf("unexpected secret selector: %+v", gmpSel)
+			}
+
+			if tc.expectGeneratedSecret {
+				if len(ctx.generatedSecrets) != 1 {
+					t.Fatalf("expected 1 generated secret, got %d", len(ctx.generatedSecrets))
+				}
+				gen := ctx.generatedSecrets[0]
+				if gen.GetName() != tc.expectedSecretName {
+					t.Errorf("expected generated secret name %s, got %s", tc.expectedSecretName, gen.GetName())
+				}
+			}
+		})
+	}
+}
+
+func TestConvertBasicAuth(t *testing.T) {
+	tests := []struct {
+		name             string
+		setupCache       func(cache *ResourceCache)
+		basicAuth        *pomonitoringv1.BasicAuth
+		expectedUser     string
+		expectedPassName string
+		expectedPassKey  string
+	}{
+		{
+			name: "Valid BasicAuth conversion",
+			setupCache: func(cache *ResourceCache) {
+				addSecretToCache(cache, "default", "auth-secret", "user", "myuser", true)
+			},
+			basicAuth: &pomonitoringv1.BasicAuth{
+				Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "auth-secret"}, Key: "user"},
+				Password: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "auth-secret"}, Key: "pass"},
+			},
+			expectedUser:     "myuser",
+			expectedPassName: "auth-secret",
+			expectedPassKey:  "pass",
+		},
+		{
+			name:       "Nil BasicAuth",
+			setupCache: func(cache *ResourceCache) {},
+			basicAuth:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newTestConversionContext()
+			tc.setupCache(ctx.cache)
+
+			gmpBA := convertBasicAuth(ctx, tc.basicAuth)
+
+			if tc.basicAuth == nil {
+				if gmpBA != nil {
+					t.Errorf("expected nil result for nil BasicAuth, got %+v", gmpBA)
+				}
+				return
+			}
+
+			if gmpBA.Username != tc.expectedUser {
+				t.Errorf("expected username %s, got %s", tc.expectedUser, gmpBA.Username)
+			}
+			if gmpBA.Password.Secret.Name != tc.expectedPassName || gmpBA.Password.Secret.Key != tc.expectedPassKey {
+				t.Errorf("unexpected password selector: %+v", gmpBA.Password)
+			}
+		})
+	}
+}
+
+func TestConvertSafeTLSConfig(t *testing.T) {
+	trueVal := true
+	tests := []struct {
+		name               string
+		setupCache         func(cache *ResourceCache)
+		tlsConfig          *pomonitoringv1.SafeTLSConfig
+		expectedCAName     string
+		expectedCAKey      string
+		expectedCertName   string
+		expectedCertKey    string
+		expectedSkipVerify bool
+		expectedServerName string
+	}{
+		{
+			name: "Full TLS Config Conversion",
+			setupCache: func(cache *ResourceCache) {
+				addConfigMapToCache(cache, "default", "ca-cm", "ca.crt", "ca-data")
+			},
+			tlsConfig: &pomonitoringv1.SafeTLSConfig{
+				CA: pomonitoringv1.SecretOrConfigMap{
+					ConfigMap: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "ca-cm"}, Key: "ca.crt"},
+				},
+				Cert: pomonitoringv1.SecretOrConfigMap{
+					Secret: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "cert-sec"}, Key: "tls.crt"},
+				},
+				InsecureSkipVerify: &trueVal,
+				ServerName:         &[]string{"my-server"}[0],
+			},
+			expectedCAName:     "secret-ca-cm",
+			expectedCAKey:      "ca.crt",
+			expectedCertName:   "cert-sec",
+			expectedCertKey:    "tls.crt",
+			expectedSkipVerify: true,
+			expectedServerName: "my-server",
+		},
+		{
+			name:       "Nil TLS Config",
+			setupCache: func(cache *ResourceCache) {},
+			tlsConfig:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newTestConversionContext()
+			tc.setupCache(ctx.cache)
+
+			gmpTLS := convertSafeTLSConfig(ctx, tc.tlsConfig)
+
+			if tc.tlsConfig == nil {
+				if gmpTLS != nil {
+					t.Errorf("expected nil result for nil TLS config, got %+v", gmpTLS)
+				}
+				return
+			}
+
+			if gmpTLS.CA.Secret.Name != tc.expectedCAName || gmpTLS.CA.Secret.Key != tc.expectedCAKey {
+				t.Errorf("unexpected CA selector: %+v", gmpTLS.CA)
+			}
+			if gmpTLS.Cert.Secret.Name != tc.expectedCertName || gmpTLS.Cert.Secret.Key != tc.expectedCertKey {
+				t.Errorf("unexpected Cert selector: %+v", gmpTLS.Cert)
+			}
+			if gmpTLS.InsecureSkipVerify != tc.expectedSkipVerify {
+				t.Errorf("expected InsecureSkipVerify %v, got %v", tc.expectedSkipVerify, gmpTLS.InsecureSkipVerify)
+			}
+			if gmpTLS.ServerName != tc.expectedServerName {
+				t.Errorf("expected server name %s, got %s", tc.expectedServerName, gmpTLS.ServerName)
+			}
+		})
+	}
+}

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -395,7 +395,9 @@ func (m *Migrator) accumulateOutputs(logger *slog.Logger, outputsMap map[string]
 					continue
 				}
 				// Warn and keep the existing secret on content conflict.
-				logger.Warn(fmt.Sprintf("Secret %q in namespace %q already exists with different contents. Keeping original Secret and skipping conflicting definition.", out.GetName(), out.GetNamespace()))
+				logger.Warn("Secret already exists with different contents. Keeping original Secret and skipping conflicting definition.",
+					slog.String("secret", out.GetName()),
+					slog.String("namespace", out.GetNamespace()))
 				continue
 			}
 			srcKey := fmt.Sprintf("%s/%s/%s", srcKind, srcNamespace, srcName)

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -53,6 +54,13 @@ type Migrator struct {
 	Stdout io.Writer
 	Stderr io.Writer
 	logger *slog.Logger
+}
+
+type generatedResource struct {
+	res          *unstructured.Unstructured
+	srcKind      string
+	srcNamespace string
+	srcName      string
 }
 
 // NewMigrator creates a new Migrator.
@@ -315,11 +323,10 @@ func (m *Migrator) processUnstructured(u *unstructured.Unstructured) error {
 }
 
 func (m *Migrator) convertResources() []*unstructured.Unstructured {
-	var allOutputs []*unstructured.Unstructured
 	ctx := context.Background()
 
-	// Track generated outputs to detect name collisions.
-	seenOutputs := make(map[string]string)
+	// Track generated outputs by unique key to deduplicate identical secrets and detect name collisions.
+	outputsMap := make(map[string]generatedResource)
 
 	kinds := slices.AppendSeq(make([]string, 0, len(m.cache.resources)), maps.Keys(m.cache.resources))
 	slices.Sort(kinds)
@@ -351,26 +358,27 @@ func (m *Migrator) convertResources() []*unstructured.Unstructured {
 				continue
 			}
 
-			if err := m.checkCollisions(outputs, seenOutputs, kind, res.GetNamespace(), res.GetName()); err != nil {
+			if err := m.accumulateOutputs(resourceLogger, outputsMap, outputs, kind, res.GetNamespace(), res.GetName()); err != nil {
 				resourceLogger.Error(err.Error())
 				continue
 			}
 
-			allOutputs = append(allOutputs, outputs...)
-
 			resourceLogger.Info("Converted successfully", slog.String("migration_status", "success"))
 		}
+	}
+
+	outputKeys := slices.AppendSeq(make([]string, 0, len(outputsMap)), maps.Keys(outputsMap))
+	slices.Sort(outputKeys)
+
+	allOutputs := make([]*unstructured.Unstructured, 0, len(outputKeys))
+	for _, k := range outputKeys {
+		allOutputs = append(allOutputs, outputsMap[k].res)
 	}
 	return allOutputs
 }
 
-// checkCollisions verifies that none of the generated outputs conflict with previously generated outputs.
-func (m *Migrator) checkCollisions(outputs []*unstructured.Unstructured, seen map[string]string, srcKind, srcNamespace, srcName string) error {
-	srcKey := fmt.Sprintf("%s/%s/%s", srcKind, srcNamespace, srcName)
-
-	// Store verified keys.
-	verifiedKeys := make([]string, 0, len(outputs))
-	// Verify and collect keys.
+// accumulateOutputs adds generated resources to outputsMap, deduplicating identical Secrets and erroring on collisions.
+func (m *Migrator) accumulateOutputs(logger *slog.Logger, outputsMap map[string]generatedResource, outputs []*unstructured.Unstructured, srcKind, srcNamespace, srcName string) error {
 	for _, out := range outputs {
 		if out == nil {
 			continue
@@ -378,15 +386,28 @@ func (m *Migrator) checkCollisions(outputs []*unstructured.Unstructured, seen ma
 		gvk := out.GroupVersionKind()
 		key := fmt.Sprintf("%s/%s/%s", gvk.String(), out.GetNamespace(), out.GetName())
 
-		if originalSrc, exists := seen[key]; exists {
-			return fmt.Errorf("conflict detected: both %s and %s generate the same target resource %q",
-				srcKey, originalSrc, key)
+		existing, exists := outputsMap[key]
+		if exists {
+			if out.GetKind() == KindSecret {
+				// If object contents are identical, silently deduplicate.
+				// (two monitors referencing same ConfigMap generate duplicate Secrets).
+				if reflect.DeepEqual(existing.res.Object, out.Object) {
+					continue
+				}
+				// Warn and keep the existing secret on content conflict.
+				logger.Warn(fmt.Sprintf("Secret %q in namespace %q already exists with different contents. Keeping original Secret and skipping conflicting definition.", out.GetName(), out.GetNamespace()))
+				continue
+			}
+			srcKey := fmt.Sprintf("%s/%s/%s", srcKind, srcNamespace, srcName)
+			existingSrcKey := fmt.Sprintf("%s/%s/%s", existing.srcKind, existing.srcNamespace, existing.srcName)
+			return fmt.Errorf("conflict detected: both %s and %s generate the same target resource %q", existingSrcKey, srcKey, key)
 		}
-		verifiedKeys = append(verifiedKeys, key)
-	}
-	// Add verified keys.
-	for _, key := range verifiedKeys {
-		seen[key] = srcKey
+		outputsMap[key] = generatedResource{
+			res:          out,
+			srcKind:      srcKind,
+			srcNamespace: srcNamespace,
+			srcName:      srcName,
+		}
 	}
 	return nil
 }

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -184,16 +184,16 @@ func (c *PodMonitorConverter) convertEndpoints(
 
 		// Auth & TLS mappings.
 		if ep.BasicAuth != nil {
-			gmpEp.BasicAuth = convertBasicAuth(convCtx, ep.BasicAuth)
+			gmpEp.BasicAuth = convCtx.convertBasicAuth(ep.BasicAuth)
 		}
 		if ep.OAuth2 != nil {
-			gmpEp.OAuth2 = convertOAuth2(convCtx, ep.OAuth2)
+			gmpEp.OAuth2 = convCtx.convertOAuth2(ep.OAuth2)
 		}
 		if ep.TLSConfig != nil {
-			gmpEp.TLS = convertSafeTLSConfig(convCtx, ep.TLSConfig)
+			gmpEp.TLS = convCtx.convertSafeTLSConfig(ep.TLSConfig)
 		}
 		if ep.Authorization != nil {
-			gmpEp.Authorization = convertAuthorization(convCtx, ep.Authorization)
+			gmpEp.Authorization = convCtx.convertAuthorization(ep.Authorization)
 		}
 
 		// Handle deprecated BearerTokenSecret -> Authorization.
@@ -202,7 +202,7 @@ func (c *PodMonitorConverter) convertEndpoints(
 				convCtx.logger.Warn(fmt.Sprintf("Endpoint [%d] has both 'bearerTokenSecret' and 'authorization' defined. Dropping 'bearerTokenSecret'.", i))
 			} else {
 				tokenSecret := ep.BearerTokenSecret // nolint:staticcheck // Map deprecated BearerTokenSecret for backwards compatibility.
-				gmpEp.Authorization = convertAuthorization(convCtx, &pomonitoringv1.SafeAuthorization{Credentials: &tokenSecret})
+				gmpEp.Authorization = convCtx.convertAuthorization(&pomonitoringv1.SafeAuthorization{Credentials: &tokenSecret})
 			}
 		}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -155,8 +155,9 @@ func (c *PodMonitorConverter) convertEndpoints(
 				return nil, fmt.Errorf("endpoint [%d]: invalid scrapeTimeout %q: %w", i, gmpEp.Timeout, err)
 			}
 			if toDur > intDur {
-				convCtx.logger.Warn(fmt.Sprintf("Scrape timeout %q is larger than scrape interval %q. Capping timeout to %q.",
-					gmpEp.Timeout, gmpEp.Interval, gmpEp.Interval))
+				convCtx.logger.Warn("Scrape timeout is larger than scrape interval. Capping timeout to interval.",
+					slog.String("timeout", gmpEp.Timeout),
+					slog.String("interval", gmpEp.Interval))
 				gmpEp.Timeout = gmpEp.Interval
 			}
 		}
@@ -199,7 +200,8 @@ func (c *PodMonitorConverter) convertEndpoints(
 		// Handle deprecated BearerTokenSecret -> Authorization.
 		if ep.BearerTokenSecret.Name != "" { // nolint:staticcheck // Map deprecated BearerTokenSecret for backwards compatibility.
 			if gmpEp.Authorization != nil {
-				convCtx.logger.Warn(fmt.Sprintf("Endpoint [%d] has both 'bearerTokenSecret' and 'authorization' defined. Dropping 'bearerTokenSecret'.", i))
+				convCtx.logger.Warn("Endpoint has both 'bearerTokenSecret' and 'authorization' defined. Dropping 'bearerTokenSecret'.",
+					slog.Int("endpoint_index", i))
 			} else {
 				tokenSecret := ep.BearerTokenSecret // nolint:staticcheck // Map deprecated BearerTokenSecret for backwards compatibility.
 				gmpEp.Authorization = convCtx.convertAuthorization(&pomonitoringv1.SafeAuthorization{Credentials: &tokenSecret})

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -96,13 +96,8 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 			uClone := baseU.DeepCopy()
 			uClone.SetNamespace(ns)
 			outputs = append(outputs, uClone)
-			// Secrets needed per namespace.
-			for _, g := range generatedSecrets {
-				gClone := g.DeepCopy()
-				gClone.SetNamespace(ns)
-				outputs = append(outputs, gClone)
-			}
 		}
+		outputs = append(outputs, generatedSecrets...)
 		return outputs, nil
 	}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -29,6 +29,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// conversionContext groups common parameters passed down to conversion helper functions.
+type conversionContext struct {
+	// logger is used to log warnings when dropping unsupported features.
+	logger *slog.Logger
+	// cache provides access to dependent resources.
+	cache *ResourceCache
+	// namespace is the source namespace of the primary resource.
+	namespace string
+	// generatedSecrets accumulates created Secrets when migrating ConfigMaps.
+	generatedSecrets []*unstructured.Unstructured
+}
+
 // PodMonitorConverter implements ResourceConverter for PodMonitor resources.
 type PodMonitorConverter struct{}
 
@@ -38,7 +50,7 @@ func (c *PodMonitorConverter) ImportKey() string {
 }
 
 // Convert translates a Prometheus Operator PodMonitor into GMP resources.
-func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, unstruct *unstructured.Unstructured, _ *ResourceCache) ([]*unstructured.Unstructured, error) {
+func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, unstruct *unstructured.Unstructured, cache *ResourceCache) ([]*unstructured.Unstructured, error) {
 	if unstruct == nil || unstruct.Object == nil {
 		return nil, errors.New("cannot convert nil or uninitialized unstructured resource")
 	}
@@ -60,11 +72,13 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 	if nsSel.Any {
 		// Case A: namespaceSelector.any = true -> Single ClusterPodMonitoring.
 		logger.Info("namespaceSelector selects 'any: true'. Translated to 'ClusterPodMonitoring'")
-		u, err := c.convertToClusterPodMonitoring(&podMonitor, logger)
+		u, generatedSecrets, err := c.convertToClusterPodMonitoring(&podMonitor, logger, cache)
 		if err != nil {
 			return nil, err
 		}
-		return []*unstructured.Unstructured{u}, nil
+		outputs := []*unstructured.Unstructured{u}
+		outputs = append(outputs, generatedSecrets...)
+		return outputs, nil
 	}
 
 	if len(nsSel.MatchNames) > 0 {
@@ -83,7 +97,7 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 		}
 
 		// 2.2 Convert to a base namespaced PodMonitoring.
-		baseU, err := c.convertToPodMonitoring(&podMonitor, logger)
+		baseU, generatedSecrets, err := c.convertToPodMonitoring(&podMonitor, logger, cache)
 		if err != nil {
 			return nil, err
 		}
@@ -94,16 +108,24 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 			uClone := baseU.DeepCopy()
 			uClone.SetNamespace(ns)
 			outputs = append(outputs, uClone)
+			// Secrets needed per namespace.
+			for _, g := range generatedSecrets {
+				gClone := g.DeepCopy()
+				gClone.SetNamespace(ns)
+				outputs = append(outputs, gClone)
+			}
 		}
 		return outputs, nil
 	}
 
 	// Case C: namespaceSelector is empty/omitted -> Single PodMonitoring in local namespace.
-	u, err := c.convertToPodMonitoring(&podMonitor, logger)
+	u, generatedSecrets, err := c.convertToPodMonitoring(&podMonitor, logger, cache)
 	if err != nil {
 		return nil, err
 	}
-	return []*unstructured.Unstructured{u}, nil
+	outputs := []*unstructured.Unstructured{u}
+	outputs = append(outputs, generatedSecrets...)
+	return outputs, nil
 }
 
 func (c *PodMonitorConverter) convertFromPodLabels(logger *slog.Logger, pm *pomonitoringv1.PodMonitor) []monitoringv1.LabelMapping {
@@ -150,7 +172,7 @@ func (c *PodMonitorConverter) convertFromPodLabels(logger *slog.Logger, pm *pomo
 }
 
 func (c *PodMonitorConverter) convertEndpoints(
-	logger *slog.Logger,
+	convCtx *conversionContext,
 	endpoints []pomonitoringv1.PodMetricsEndpoint,
 ) ([]monitoringv1.ScrapeEndpoint, error) {
 	var gmpEndpoints []monitoringv1.ScrapeEndpoint
@@ -178,7 +200,7 @@ func (c *PodMonitorConverter) convertEndpoints(
 
 		// TODO(M2): Inherit global scrape interval from Prometheus CR if empty.
 		if gmpEp.Interval == "" {
-			logger.Warn("Scrape interval is empty. Defaulting to '30s' as GMP requires this field.")
+			convCtx.logger.Warn("Scrape interval is empty. Defaulting to '30s' as GMP requires this field.")
 			gmpEp.Interval = "30s"
 		}
 
@@ -193,7 +215,7 @@ func (c *PodMonitorConverter) convertEndpoints(
 				return nil, fmt.Errorf("endpoint [%d]: invalid scrapeTimeout %q: %w", i, gmpEp.Timeout, err)
 			}
 			if toDur > intDur {
-				logger.Warn(fmt.Sprintf("Scrape timeout %q is larger than scrape interval %q. Capping timeout to %q.",
+				convCtx.logger.Warn(fmt.Sprintf("Scrape timeout %q is larger than scrape interval %q. Capping timeout to %q.",
 					gmpEp.Timeout, gmpEp.Interval, gmpEp.Interval))
 				gmpEp.Timeout = gmpEp.Interval
 			}
@@ -202,22 +224,33 @@ func (c *PodMonitorConverter) convertEndpoints(
 
 		// 4. Relabeling Rules (MetricRelabelings).
 		if len(ep.MetricRelabelConfigs) > 0 {
-			rules, err := c.convertMetricRelabelings(logger, ep.MetricRelabelConfigs)
+			rules, err := c.convertMetricRelabelings(convCtx.logger, ep.MetricRelabelConfigs)
 			if err != nil {
 				return nil, fmt.Errorf("endpoint [%d]: %w", i, err)
 			}
 			gmpEp.MetricRelabeling = rules
 		}
 
+		// Proxy Settings.
+		if ep.ProxyURL != nil {
+			if strings.Contains(*ep.ProxyURL, "@") {
+				return nil, fmt.Errorf("endpoint [%d]: proxyUrl contains credentials (matches '@'), which is blocked by GMP API validation", i)
+			}
+			gmpEp.ProxyURL = *ep.ProxyURL
+		}
+
+		// noProxy, proxyConnectHeader, and proxyFromEnvironment fields are silently dropped.
+		// The pinned Prometheus Operator version lacks these fields, and GMP does not support them anyway.
+
 		// 5. Warnings for Unsupported Fields in Endpoint.
 		if ep.HonorLabels {
-			logger.Warn("Field 'honorLabels: true' is unsupported and dropped. GMP always overrides conflicting labels. Clashing metric labels will be renamed with the 'exported_' prefix.")
+			convCtx.logger.Warn("Field 'honorLabels: true' is unsupported and dropped. GMP always overrides conflicting labels. Clashing metric labels will be renamed with the 'exported_' prefix.")
 		}
 		if ep.HonorTimestamps != nil && *ep.HonorTimestamps {
-			logger.Warn("Field 'honorTimestamps: true' is unsupported and dropped. GMP always uses the scrape ingestion timestamp. Target metric timestamps will be ignored.")
+			convCtx.logger.Warn("Field 'honorTimestamps: true' is unsupported and dropped. GMP always uses the scrape ingestion timestamp. Target metric timestamps will be ignored.")
 		}
 		if ep.TrackTimestampsStaleness != nil {
-			logger.Warn("Field 'trackTimestampsStaleness' is unsupported in GMP and has been dropped.")
+			convCtx.logger.Warn("Field 'trackTimestampsStaleness' is unsupported in GMP and has been dropped.")
 		}
 
 		gmpEndpoints = append(gmpEndpoints, gmpEp)
@@ -279,10 +312,15 @@ func (c *PodMonitorConverter) convertMetricRelabelings(
 	return rules, nil
 }
 
-func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonitor, logger *slog.Logger) (*unstructured.Unstructured, error) {
-	endpoints, err := c.convertEndpoints(logger, pm.Spec.PodMetricsEndpoints)
+func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonitor, logger *slog.Logger, cache *ResourceCache) (*unstructured.Unstructured, []*unstructured.Unstructured, error) {
+	convCtx := &conversionContext{
+		logger:    logger,
+		cache:     cache,
+		namespace: pm.Namespace,
+	}
+	endpoints, err := c.convertEndpoints(convCtx, pm.Spec.PodMetricsEndpoints)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	gmpPM := &monitoringv1.PodMonitoring{
@@ -299,20 +337,25 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 
 	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(gmpPM)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal PodMonitoring: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal PodMonitoring: %w", err)
 	}
 
 	u := &unstructured.Unstructured{Object: unstructuredMap}
 	u.SetAPIVersion(GMPAPIVersion)
 	u.SetKind(KindPodMonitoring)
 
-	return u, nil
+	return u, convCtx.generatedSecrets, nil
 }
 
-func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.PodMonitor, logger *slog.Logger) (*unstructured.Unstructured, error) {
-	endpoints, err := c.convertEndpoints(logger, pm.Spec.PodMetricsEndpoints)
+func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.PodMonitor, logger *slog.Logger, cache *ResourceCache) (*unstructured.Unstructured, []*unstructured.Unstructured, error) {
+	convCtx := &conversionContext{
+		logger:    logger,
+		cache:     cache,
+		namespace: pm.Namespace,
+	}
+	endpoints, err := c.convertEndpoints(convCtx, pm.Spec.PodMetricsEndpoints)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	gmpCPM := &monitoringv1.ClusterPodMonitoring{
@@ -329,12 +372,12 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 
 	unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(gmpCPM)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal ClusterPodMonitoring: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal ClusterPodMonitoring: %w", err)
 	}
 
 	u := &unstructured.Unstructured{Object: unstructuredMap}
 	u.SetAPIVersion(GMPAPIVersion)
 	u.SetKind(KindClusterPodMonitoring)
 
-	return u, nil
+	return u, convCtx.generatedSecrets, nil
 }

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -201,7 +201,8 @@ func (c *PodMonitorConverter) convertEndpoints(
 			if gmpEp.Authorization != nil {
 				convCtx.logger.Warn(fmt.Sprintf("Endpoint [%d] has both 'bearerTokenSecret' and 'authorization' defined. Dropping 'bearerTokenSecret'.", i))
 			} else {
-				gmpEp.Authorization = convertAuthorization(convCtx, &pomonitoringv1.SafeAuthorization{Credentials: &ep.BearerTokenSecret}) // nolint:staticcheck // Map deprecated BearerTokenSecret for backwards compatibility.
+				tokenSecret := ep.BearerTokenSecret // nolint:staticcheck // Map deprecated BearerTokenSecret for backwards compatibility.
+				gmpEp.Authorization = convertAuthorization(convCtx, &pomonitoringv1.SafeAuthorization{Credentials: &tokenSecret})
 			}
 		}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -254,7 +254,7 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 	u.SetAPIVersion(GMPAPIVersion)
 	u.SetKind(KindPodMonitoring)
 
-	return u, convCtx.generatedSecrets, nil
+	return u, convCtx.getGeneratedSecrets(), nil
 }
 
 func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.PodMonitor, logger *slog.Logger, cache *ResourceCache) (*unstructured.Unstructured, []*unstructured.Unstructured, error) {
@@ -289,5 +289,5 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 	u.SetAPIVersion(GMPAPIVersion)
 	u.SetKind(KindClusterPodMonitoring)
 
-	return u, convCtx.generatedSecrets, nil
+	return u, convCtx.getGeneratedSecrets(), nil
 }

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -185,16 +185,32 @@ func (c *PodMonitorConverter) convertEndpoints(
 
 		// Auth & TLS mappings.
 		if ep.BasicAuth != nil {
-			gmpEp.BasicAuth = convCtx.convertBasicAuth(ep.BasicAuth)
+			ba, err := convCtx.convertBasicAuth(ep.BasicAuth)
+			if err != nil {
+				return nil, fmt.Errorf("endpoint [%d]: basicAuth: %w", i, err)
+			}
+			gmpEp.BasicAuth = ba
 		}
 		if ep.OAuth2 != nil {
-			gmpEp.OAuth2 = convCtx.convertOAuth2(ep.OAuth2)
+			oa, err := convCtx.convertOAuth2(ep.OAuth2)
+			if err != nil {
+				return nil, fmt.Errorf("endpoint [%d]: oAuth2: %w", i, err)
+			}
+			gmpEp.OAuth2 = oa
 		}
 		if ep.TLSConfig != nil {
-			gmpEp.TLS = convCtx.convertSafeTLSConfig(ep.TLSConfig)
+			tls, err := convCtx.convertSafeTLSConfig(ep.TLSConfig)
+			if err != nil {
+				return nil, fmt.Errorf("endpoint [%d]: tlsConfig: %w", i, err)
+			}
+			gmpEp.TLS = tls
 		}
 		if ep.Authorization != nil {
-			gmpEp.Authorization = convCtx.convertAuthorization(ep.Authorization)
+			auth, err := convCtx.convertAuthorization(ep.Authorization)
+			if err != nil {
+				return nil, fmt.Errorf("endpoint [%d]: authorization: %w", i, err)
+			}
+			gmpEp.Authorization = auth
 		}
 
 		// Handle deprecated BearerTokenSecret -> Authorization.
@@ -204,7 +220,11 @@ func (c *PodMonitorConverter) convertEndpoints(
 					slog.Int("endpoint_index", i))
 			} else {
 				tokenSecret := ep.BearerTokenSecret // nolint:staticcheck // Map deprecated BearerTokenSecret for backwards compatibility.
-				gmpEp.Authorization = convCtx.convertAuthorization(&pomonitoringv1.SafeAuthorization{Credentials: &tokenSecret})
+				auth, err := convCtx.convertAuthorization(&pomonitoringv1.SafeAuthorization{Credentials: &tokenSecret})
+				if err != nil {
+					return nil, fmt.Errorf("endpoint [%d]: bearerTokenSecret: %w", i, err)
+				}
+				gmpEp.Authorization = auth
 			}
 		}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -206,7 +206,7 @@ func (c *PodMonitorConverter) convertEndpoints(
 			if gmpEp.Authorization != nil {
 				convCtx.logger.Warn(fmt.Sprintf("Endpoint [%d] has both 'bearerTokenSecret' and 'authorization' defined. Dropping 'bearerTokenSecret'.", i))
 			} else {
-				gmpEp.Authorization = convertAuthorization(convCtx, &pomonitoringv1.SafeAuthorization{Credentials: &ep.BearerTokenSecret})
+				gmpEp.Authorization = convertAuthorization(convCtx, &pomonitoringv1.SafeAuthorization{Credentials: &ep.BearerTokenSecret}) // nolint:staticcheck // Map deprecated BearerTokenSecret for backwards compatibility.
 			}
 		}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -29,18 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// conversionContext groups common parameters passed down to conversion helper functions.
-type conversionContext struct {
-	// logger is used to log warnings when dropping unsupported features.
-	logger *slog.Logger
-	// cache provides access to dependent resources.
-	cache *ResourceCache
-	// namespace is the source namespace of the primary resource.
-	namespace string
-	// generatedSecrets accumulates created Secrets when migrating ConfigMaps.
-	generatedSecrets []*unstructured.Unstructured
-}
-
 // PodMonitorConverter implements ResourceConverter for PodMonitor resources.
 type PodMonitorConverter struct{}
 
@@ -128,49 +116,6 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 	return outputs, nil
 }
 
-func (c *PodMonitorConverter) convertFromPodLabels(logger *slog.Logger, pm *pomonitoringv1.PodMonitor) []monitoringv1.LabelMapping {
-	var fromPod []monitoringv1.LabelMapping
-	seenTargets := make(map[string]bool)
-
-	for _, l := range pm.Spec.PodTargetLabels {
-		target := l
-		if protectedLabels[l] {
-			target = "exported_" + l
-		}
-
-		if seenTargets[target] {
-			logger.Warn(fmt.Sprintf("Pod target label %q maps to target label %q which is already taken. Skipping.", l, target))
-			continue
-		}
-
-		seenTargets[target] = true
-		mapping := monitoringv1.LabelMapping{From: l}
-
-		if target != l {
-			mapping.To = target
-			logger.Warn(fmt.Sprintf("Pod target label %q is protected in GMP. Renamed target to %q.", l, target))
-		}
-
-		fromPod = append(fromPod, mapping)
-	}
-
-	if pm.Spec.JobLabel != "" {
-		target := "exported_job"
-		if !seenTargets[target] {
-			logger.Warn(fmt.Sprintf("GMP does not support overriding the protected 'job' label. Value on label %q has been copied into the target label 'exported_job'.", pm.Spec.JobLabel))
-			fromPod = append(fromPod, monitoringv1.LabelMapping{
-				From: pm.Spec.JobLabel,
-				To:   target,
-			})
-			seenTargets[target] = true
-		} else {
-			logger.Warn(fmt.Sprintf("Job label %q could not be mapped to 'exported_job' because 'exported_job' is already taken by another target label mapping.", pm.Spec.JobLabel))
-		}
-	}
-
-	return fromPod
-}
-
 func (c *PodMonitorConverter) convertEndpoints(
 	convCtx *conversionContext,
 	endpoints []pomonitoringv1.PodMetricsEndpoint,
@@ -224,7 +169,7 @@ func (c *PodMonitorConverter) convertEndpoints(
 
 		// 4. Relabeling Rules (MetricRelabelings).
 		if len(ep.MetricRelabelConfigs) > 0 {
-			rules, err := c.convertMetricRelabelings(convCtx.logger, ep.MetricRelabelConfigs)
+			rules, err := convertMetricRelabelings(convCtx.logger, ep.MetricRelabelConfigs)
 			if err != nil {
 				return nil, fmt.Errorf("endpoint [%d]: %w", i, err)
 			}
@@ -242,6 +187,29 @@ func (c *PodMonitorConverter) convertEndpoints(
 		// noProxy, proxyConnectHeader, and proxyFromEnvironment fields are silently dropped.
 		// The pinned Prometheus Operator version lacks these fields, and GMP does not support them anyway.
 
+		// Auth & TLS mappings.
+		if ep.BasicAuth != nil {
+			gmpEp.BasicAuth = convertBasicAuth(convCtx, ep.BasicAuth)
+		}
+		if ep.OAuth2 != nil {
+			gmpEp.OAuth2 = convertOAuth2(convCtx, ep.OAuth2)
+		}
+		if ep.TLSConfig != nil {
+			gmpEp.TLS = convertSafeTLSConfig(convCtx, ep.TLSConfig)
+		}
+		if ep.Authorization != nil {
+			gmpEp.Authorization = convertAuthorization(convCtx, ep.Authorization)
+		}
+
+		// Handle deprecated BearerTokenSecret -> Authorization.
+		if ep.BearerTokenSecret.Name != "" { // nolint:staticcheck // Map deprecated BearerTokenSecret for backwards compatibility.
+			if gmpEp.Authorization != nil {
+				convCtx.logger.Warn(fmt.Sprintf("Endpoint [%d] has both 'bearerTokenSecret' and 'authorization' defined. Dropping 'bearerTokenSecret'.", i))
+			} else {
+				gmpEp.Authorization = convertAuthorization(convCtx, &pomonitoringv1.SafeAuthorization{Credentials: &ep.BearerTokenSecret})
+			}
+		}
+
 		// 5. Warnings for Unsupported Fields in Endpoint.
 		if ep.HonorLabels {
 			convCtx.logger.Warn("Field 'honorLabels: true' is unsupported and dropped. GMP always overrides conflicting labels. Clashing metric labels will be renamed with the 'exported_' prefix.")
@@ -257,59 +225,6 @@ func (c *PodMonitorConverter) convertEndpoints(
 	}
 
 	return gmpEndpoints, nil
-}
-
-func (c *PodMonitorConverter) convertMetricRelabelings(
-	logger *slog.Logger,
-	configs []pomonitoringv1.RelabelConfig,
-) ([]monitoringv1.RelabelingRule, error) {
-	var rules []monitoringv1.RelabelingRule
-
-	for _, config := range configs {
-		action := strings.ToLower(config.Action)
-		if action == "" {
-			action = "replace"
-		}
-
-		if action == "labelmap" {
-			logger.Warn("metricRelabelings rule uses 'action: labelmap' which is not supported by GMP and has been dropped.")
-			continue
-		}
-
-		targetLabel := config.TargetLabel
-		if action == "replace" || action == "hashmod" || action == "lowercase" || action == "uppercase" {
-			if protectedLabels[config.TargetLabel] {
-				targetLabel = "exported_" + config.TargetLabel
-				logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.",
-					config.TargetLabel, targetLabel))
-			}
-		}
-
-		rule := monitoringv1.RelabelingRule{
-			TargetLabel: targetLabel,
-			Regex:       config.Regex,
-			Modulus:     config.Modulus,
-			Action:      action,
-		}
-
-		if len(config.SourceLabels) > 0 {
-			rule.SourceLabels = make([]string, len(config.SourceLabels))
-			for i, sl := range config.SourceLabels {
-				rule.SourceLabels[i] = string(sl)
-			}
-		}
-
-		if config.Separator != nil {
-			rule.Separator = *config.Separator
-		}
-		if config.Replacement != nil {
-			rule.Replacement = *config.Replacement
-		}
-
-		rules = append(rules, rule)
-	}
-
-	return rules, nil
 }
 
 func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonitor, logger *slog.Logger, cache *ResourceCache) (*unstructured.Unstructured, []*unstructured.Unstructured, error) {
@@ -330,7 +245,7 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 			Selector:  pm.Spec.Selector,
 			Endpoints: endpoints,
 			TargetLabels: monitoringv1.TargetLabels{
-				FromPod: c.convertFromPodLabels(logger, pm),
+				FromPod: convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"),
 			},
 		},
 	}
@@ -365,7 +280,7 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 			Selector:  pm.Spec.Selector,
 			Endpoints: endpoints,
 			TargetLabels: monitoringv1.ClusterTargetLabels{
-				FromPod: c.convertFromPodLabels(logger, pm),
+				FromPod: convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"),
 			},
 		},
 	}

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -517,18 +517,18 @@ func TestPodMonitorConversion(t *testing.T) {
 								Interval: "30s",
 								HTTPClientConfig: monitoringv1.HTTPClientConfig{
 									Authorization: &monitoringv1.Auth{
-										Credentials: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "token-secret", Key: "token"}},
+										Credentials: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "token-secret", Key: "token", Namespace: "frontend"}},
 									},
 									BasicAuth: &monitoringv1.BasicAuth{
 										Username: "<MISSING_SECRET_auth-secret_KEY_user>",
-										Password: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "auth-secret", Key: "pass"}},
+										Password: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "auth-secret", Key: "pass", Namespace: "frontend"}},
 									},
 									TLS: &monitoringv1.TLS{
-										CA: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "secret-ca-cm", Key: "ca.crt"}},
+										CA: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "secret-ca-cm", Key: "ca.crt", Namespace: "frontend"}},
 									},
 									OAuth2: &monitoringv1.OAuth2{
 										ClientID:     "<MISSING_CONFIGMAP_oauth-cm_KEY_id>",
-										ClientSecret: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "oauth-secret", Key: "secret"}},
+										ClientSecret: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "oauth-secret", Key: "secret", Namespace: "frontend"}},
 										TokenURL:     "https://auth.example.com/token",
 									},
 								},

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -23,6 +23,7 @@ import (
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
 	"github.com/google/go-cmp/cmp"
 	pomonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -455,6 +456,88 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Authorization and TLS Mapping",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "auth-monitor",
+					Namespace: "frontend",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "auth-app"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							BasicAuth: &pomonitoringv1.BasicAuth{
+								Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "auth-secret"}, Key: "user"},
+								Password: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "auth-secret"}, Key: "pass"},
+							},
+							BearerTokenSecret: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "token-secret"}, Key: "token"},
+							TLSConfig: &pomonitoringv1.SafeTLSConfig{
+								CA: pomonitoringv1.SecretOrConfigMap{
+									ConfigMap: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "ca-cm"}, Key: "ca.crt"},
+								},
+							},
+							OAuth2: &pomonitoringv1.OAuth2{
+								ClientID: pomonitoringv1.SecretOrConfigMap{
+									ConfigMap: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "oauth-cm"}, Key: "id"},
+								},
+								ClientSecret: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "oauth-secret"}, Key: "secret"},
+								TokenURL:     "https://auth.example.com/token",
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "monitoring.googleapis.com/v1",
+						Kind:       KindPodMonitoring,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "auth-monitor",
+						Namespace: "frontend",
+					},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app": "auth-app",
+							},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+								HTTPClientConfig: monitoringv1.HTTPClientConfig{
+									Authorization: &monitoringv1.Auth{
+										Credentials: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "token-secret", Key: "token"}},
+									},
+									BasicAuth: &monitoringv1.BasicAuth{
+										Username: "<MISSING_SECRET_auth-secret_KEY_user>",
+										Password: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "auth-secret", Key: "pass"}},
+									},
+									TLS: &monitoringv1.TLS{
+										CA: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "secret-ca-cm", Key: "ca.crt"}},
+									},
+									OAuth2: &monitoringv1.OAuth2{
+										ClientID:     "<MISSING_CONFIGMAP_oauth-cm_KEY_id>",
+										ClientSecret: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "oauth-secret", Key: "secret"}},
+										TokenURL:     "https://auth.example.com/token",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}
@@ -466,7 +549,7 @@ func TestPodMonitorConversion(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			uInput := toUnstructured(t, tc.input)
 
-			actual, err := converter.Convert(context.Background(), logger, uInput, nil)
+			actual, err := converter.Convert(context.Background(), logger, uInput, NewResourceCache())
 
 			if tc.wantErr != "" {
 				if err == nil {


### PR DESCRIPTION
Adds migration logic to map Authentication, TLS, and Proxy configurations from Prometheus Operator `PodMonitor` endpoints into GMP `PodMonitoring` equivalents.

This change introduces the core extraction helpers required to consolidate nested Kubernetes `corev1.SecretKeySelector` and `corev1.ConfigMapKeySelector` references into GMP's `monitoringv1.SecretKeySelector` struct. 

**Key Changes:**
* Added translation mapping for `BasicAuth`, `BearerTokenSecret`, `TLSConfig`, and `OAuth2` fields within endpoint configurations.
* Added functions (`extractSecretKey`, `extractConfigMapKey`) that inject clear `<MISSING_...>` placeholders and emit warnings if a referenced resource is missing from the input files.
* Added `convertConfigMapToSecretSelector` to automatically migrate TLS ConfigMap references into generated Secrets, adhering to GMP's strict Secret-only TLS requirements.
* Added comprehensive, table-driven unit tests for all edge cases (cache hits vs misses, empty inputs) in `helpers_test.go`.
* Added a test case to `podmonitor_test.go`.