### PR TITLE
PO to GMP Migration Tool: Podmonitor Relabeling Migration

### DIFF
--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -193,6 +193,12 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			continue
 		}
 
+		// Pre-scrape hashmod is used for target sharding, which GMP automatically handles.
+		if action == relabel.HashMod {
+			logger.Warn("Pre-scrape relabeling rule uses 'action: hashmod'. GMP automatically handles target sharding; this rule has been dropped.")
+			continue
+		}
+
 		// Resolve all source labels upfront and intercept unsupported internal discovery labels.
 		podSources, metaSources, rewrittenSources, unsupported := resolveSourceLabels(config.SourceLabels)
 		if unsupported {
@@ -281,7 +287,7 @@ func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1
 // mergeLabelSelector combines base selector requirements with extracted pre-scrape filtering rules.
 func mergeLabelSelector(base metav1.LabelSelector, extraLabels map[string]string, extraExprs []metav1.LabelSelectorRequirement) (metav1.LabelSelector, error) {
 	if len(extraLabels) == 0 && len(extraExprs) == 0 {
-		return base, nil
+		return *base.DeepCopy(), nil
 	}
 	res := base.DeepCopy()
 	if len(extraLabels) > 0 && res.MatchLabels == nil {
@@ -820,8 +826,12 @@ func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSi
 
 // convertRelabelingToSimpleCopy attempts to convert simple label copy rules to targetLabels (fromPod or metadata).
 func convertRelabelingToSimpleCopy(logger *slog.Logger, data *relabelingData, res *preScrapeRelabelingResult, rawMetadata *[]string) bool {
+	isDefaultRegex := data.config.Regex == "" ||
+		data.config.Regex == "(.*)" ||
+		data.config.Regex == "^(.*)$" ||
+		data.config.Regex == "^.*$"
 	isSimpleCopy := len(data.config.SourceLabels) == 1 &&
-		(data.config.Regex == "" || data.config.Regex == "(.*)") &&
+		isDefaultRegex &&
 		(data.config.Replacement == nil || *data.config.Replacement == "$1") &&
 		data.action == relabel.Replace
 

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -278,6 +278,9 @@ func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1
 
 // mergeLabelSelector combines base selector requirements with extracted pre-scrape filtering rules.
 func mergeLabelSelector(logger *slog.Logger, base metav1.LabelSelector, extraLabels map[string]string, extraExprs []metav1.LabelSelectorRequirement) metav1.LabelSelector {
+	if len(extraLabels) == 0 && len(extraExprs) == 0 {
+		return base
+	}
 	res := base.DeepCopy()
 	if len(extraLabels) > 0 && res.MatchLabels == nil {
 		res.MatchLabels = make(map[string]string)
@@ -295,6 +298,9 @@ func mergeLabelSelector(logger *slog.Logger, base metav1.LabelSelector, extraLab
 
 // mergeFromPod merges target label mappings and deduplicates by target label name.
 func mergeFromPod(logger *slog.Logger, base []monitoringv1.LabelMapping, extra []monitoringv1.LabelMapping) []monitoringv1.LabelMapping {
+	if len(extra) == 0 {
+		return base
+	}
 	seenTargets := make(map[string]string)
 	var res []monitoringv1.LabelMapping
 

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -311,10 +311,12 @@ func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1
 			if r.Metadata != nil {
 				rawMetadata = append(rawMetadata, *r.Metadata...)
 			}
-			if len(r.MatchLabels) > 0 && combined.MatchLabels == nil {
-				combined.MatchLabels = make(map[string]string)
+			if len(r.MatchLabels) > 0 {
+				if combined.MatchLabels == nil {
+					combined.MatchLabels = make(map[string]string)
+				}
+				maps.Copy(combined.MatchLabels, r.MatchLabels)
 			}
-			maps.Copy(combined.MatchLabels, r.MatchLabels)
 			combined.MatchExpressions = append(combined.MatchExpressions, r.MatchExpressions...)
 		}
 		epResults = append(epResults, r)

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -205,7 +205,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			source := string(config.SourceLabels[0])
 			labelName := podSources[0]
 			// Strip optional regex start (^) and end ($) anchors (ex. "^production$" -> "production").
-			clean := strings.Trim(strings.TrimSpace(config.Regex), "^$")
+			clean := strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(config.Regex), "$"), "^")
 			// Strip outer grouping parentheses around literal lists (ex. "(test|staging)" -> "test|staging").
 			if strings.HasPrefix(clean, "(") && strings.HasSuffix(clean, ")") {
 				clean = clean[1 : len(clean)-1]
@@ -262,7 +262,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			}
 
 			// Simple metadata label transfer.
-			if len(metaSources) == 1 {
+			if len(metaSources) == 1 && target == metaSources[0] {
 				rawMetadata = append(rawMetadata, metaSources[0])
 				logger.Info(fmt.Sprintf("Translated metadata label copy (%q) to 'targetLabels.metadata' (as label: %q).", source, metaSources[0]))
 				continue

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -780,12 +780,6 @@ func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSi
 	source := string(data.config.SourceLabels[0])
 	labelName := data.podSources[0]
 
-	// If the label contains an underscore, it might have been sanitized from '.', '/', or '-'.
-	// Since we cannot recover the original key, we skip selector conversion to avoid mismatch.
-	if strings.Contains(labelName, "_") {
-		return false, nil
-	}
-
 	if errs := validation.IsQualifiedName(labelName); len(errs) > 0 {
 		return false, nil
 	}

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -108,6 +108,40 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 	return secrets
 }
 
+// convertPreScrapeRelabelings evaluates pre-scrape relabelings and drops unsupported rules with warnings.
+func convertPreScrapeRelabelings(convCtx *conversionContext, configs []pomonitoringv1.RelabelConfig) {
+	for i, config := range configs {
+		action := strings.ToLower(config.Action)
+		if action == "" {
+			action = "replace"
+		}
+
+		if action == "labelmap" || action == "labelkeep" || action == "labeldrop" {
+			convCtx.logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' which is not supported by GMP and has been dropped.", action))
+			continue
+		}
+
+		// Relabeling rules on annotations cannot be migrated.
+		var anno string
+		for _, sl := range config.SourceLabels {
+			if strings.HasPrefix(string(sl), "__meta_kubernetes_pod_annotation_") {
+				anno = string(sl)
+				break
+			}
+		}
+		if anno != "" {
+			convCtx.logger.Warn(fmt.Sprintf("Relabeling rule referencing pod annotation %q is unsupported in GMP. The rule has been dropped.", anno))
+			continue
+		}
+
+		if protectedLabels[config.TargetLabel] {
+			oldTarget := config.TargetLabel
+			configs[i].TargetLabel = "exported_" + oldTarget
+			convCtx.logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.", oldTarget, configs[i].TargetLabel))
+		}
+	}
+}
+
 // extractResourceKey is a consolidated helper that fetches a key from a ConfigMap or Secret.
 // It returns an error if the reference is malformed or if data is corrupt.
 // It returns a placeholder and logs a warning if the resource itself is not found in the cache.

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -18,7 +18,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
-	"maps"
 	"slices"
 	"strings"
 
@@ -230,37 +229,33 @@ func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1
 		combined    preScrapeRelabelingResult
 		rawMetadata []string
 	)
+	isSingleEndpoint := len(endpoints) == 1
+
 	for _, ep := range endpoints {
 		var r preScrapeRelabelingResult
 		if len(ep.RelabelConfigs) > 0 {
-			r = convertPreScrapeRelabelings(logger, ep.RelabelConfigs, len(endpoints) == 1)
+			r = convertPreScrapeRelabelings(logger, ep.RelabelConfigs, isSingleEndpoint)
 			combined.FromPod = append(combined.FromPod, r.FromPod...)
 			if r.Metadata != nil {
 				rawMetadata = append(rawMetadata, *r.Metadata...)
 			}
-			if len(r.MatchLabels) > 0 {
-				if combined.MatchLabels == nil {
-					combined.MatchLabels = make(map[string]string)
-				}
-				maps.Copy(combined.MatchLabels, r.MatchLabels)
-			}
-			combined.MatchExpressions = append(combined.MatchExpressions, r.MatchExpressions...)
 		}
 		epResults = append(epResults, r)
 	}
 
 	if len(rawMetadata) > 0 {
-		unique := make(map[string]bool)
-		var sortedMd []string
-		for _, m := range rawMetadata {
-			if !unique[m] {
-				unique[m] = true
-				sortedMd = append(sortedMd, m)
-			}
-		}
-		slices.Sort(sortedMd)
-		combined.Metadata = &sortedMd
+		slices.Sort(rawMetadata)
+		rawMetadata = slices.Compact(rawMetadata)
+		combined.Metadata = &rawMetadata
 	}
+
+	// Since we only convert selectors for single-endpoint resources,
+	// the combined selector is simply the selector from the first (and only) endpoint.
+	if isSingleEndpoint && len(epResults) == 1 {
+		combined.MatchLabels = epResults[0].MatchLabels
+		combined.MatchExpressions = epResults[0].MatchExpressions
+	}
+
 	return extractedPreScrapeRules{
 		PerEndpoint:      epResults,
 		ResourceCombined: combined,

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -147,7 +147,8 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			action = "replace"
 		}
 
-		if action == "labelmap" || action == "labelkeep" || action == "labeldrop" {
+		switch action {
+		case "labelmap", "labelkeep", "labeldrop":
 			logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' which is not supported by GMP and has been dropped.", action))
 			continue
 		}

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -171,7 +171,7 @@ func isValidLabelValues(parts []string) bool {
 }
 
 // convertPreScrapeRelabelings evaluates pre-scrape relabelings on a single endpoint and extracts target label and selector rules.
-func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig, isSingleEndpoint bool) preScrapeRelabelingResult {
+func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig, isSingleEndpoint bool) (preScrapeRelabelingResult, error) {
 	var (
 		res         preScrapeRelabelingResult
 		rawMetadata []string
@@ -184,6 +184,13 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		if shouldSkipRelabelConfig(logger, config, action) {
+			continue
+		}
+
+		// Pre-scrape labeldrop and labelkeep filter service-discovery meta labels; there is
+		// no post-scrape equivalent, so they cannot be promoted.
+		if action == relabel.LabelDrop || action == relabel.LabelKeep {
+			logger.Warn(fmt.Sprintf("Pre-scrape relabeling rule uses 'action: %s', which filters service discovery labels and has no GMP equivalent. The rule has been dropped.", action))
 			continue
 		}
 
@@ -207,7 +214,9 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		// Convert target filtering ("keep" and "drop") rules on pod labels to Kubernetes label selectors.
-		if convertRelabelingToSelector(logger, data, isSingleEndpoint, &res) {
+		if converted, err := convertRelabelingToSelector(logger, data, isSingleEndpoint, &res); err != nil {
+			return preScrapeRelabelingResult{}, err
+		} else if converted {
 			continue
 		}
 
@@ -217,17 +226,17 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		// Convert complex or value-changing rules to post-scrape metricRelabeling.
-		convertRelabelingToMetricRelabeling(logger, data, isSingleEndpoint, &res, &rawMetadata)
+		convertRelabelingToMetricRelabeling(logger, data, &res, &rawMetadata)
 	}
 
 	if len(rawMetadata) > 0 {
 		res.Metadata = &rawMetadata
 	}
-	return res
+	return res, nil
 }
 
 // extractPreScrapeRelabelings evaluates pre-scrape rules once per endpoint, returning consolidated endpoint and resource-level results.
-func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1.PodMetricsEndpoint) extractedPreScrapeRules {
+func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1.PodMetricsEndpoint) (extractedPreScrapeRules, error) {
 	var (
 		epResults   []preScrapeRelabelingResult
 		combined    preScrapeRelabelingResult
@@ -238,7 +247,11 @@ func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1
 	for _, ep := range endpoints {
 		var r preScrapeRelabelingResult
 		if len(ep.RelabelConfigs) > 0 {
-			r = convertPreScrapeRelabelings(logger, ep.RelabelConfigs, isSingleEndpoint)
+			var err error
+			r, err = convertPreScrapeRelabelings(logger, ep.RelabelConfigs, isSingleEndpoint)
+			if err != nil {
+				return extractedPreScrapeRules{}, err
+			}
 			combined.FromPod = append(combined.FromPod, r.FromPod...)
 			if r.Metadata != nil {
 				rawMetadata = append(rawMetadata, *r.Metadata...)
@@ -263,7 +276,7 @@ func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1
 	return extractedPreScrapeRules{
 		PerEndpoint:      epResults,
 		ResourceCombined: combined,
-	}
+	}, nil
 }
 
 // mergeLabelSelector combines base selector requirements with extracted pre-scrape filtering rules.
@@ -298,13 +311,6 @@ func mergeFromPod(logger *slog.Logger, base []monitoringv1.LabelMapping, extra [
 		target := m.From
 		if m.To != "" {
 			target = m.To
-		}
-		if existingFrom, exists := seenTargets[target]; exists {
-			if existingFrom == m.From {
-				continue
-			}
-			logger.Warn(fmt.Sprintf("Conflict in relabel configs: target label %q is already mapped from %q. Skipping conflicting mapping from %q.", target, existingFrom, m.From))
-			continue
 		}
 		seenTargets[target] = m.From
 		res = append(res, m)
@@ -746,6 +752,9 @@ func resolveSourceLabels(sourceLabels []pomonitoringv1.LabelName) (podSources []
 		s := string(sl)
 		if labelName, found := strings.CutPrefix(s, "__meta_kubernetes_pod_label_"); found {
 			podSources = append(podSources, labelName)
+			if protectedLabels[labelName] {
+				labelName = "exported_" + labelName
+			}
 			rewrittenSources = append(rewrittenSources, labelName)
 			continue
 		}
@@ -764,9 +773,9 @@ func resolveSourceLabels(sourceLabels []pomonitoringv1.LabelName) (podSources []
 }
 
 // convertRelabelingToSelector attempts to convert target filtering (keep/drop) rules to pod selectors.
-func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSingleEndpoint bool, res *preScrapeRelabelingResult) bool {
+func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSingleEndpoint bool, res *preScrapeRelabelingResult) (bool, error) {
 	if !isSingleEndpoint || data.action != relabel.Keep || len(data.podSources) != 1 || len(data.config.SourceLabels) != 1 {
-		return false
+		return false, nil
 	}
 	source := string(data.config.SourceLabels[0])
 	labelName := data.podSources[0]
@@ -774,11 +783,11 @@ func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSi
 	// If the label contains an underscore, it might have been sanitized from '.', '/', or '-'.
 	// Since we cannot recover the original key, we skip selector conversion to avoid mismatch.
 	if strings.Contains(labelName, "_") {
-		return false
+		return false, nil
 	}
 
 	if errs := validation.IsQualifiedName(labelName); len(errs) > 0 {
-		return false
+		return false, nil
 	}
 
 	clean := strings.TrimPrefix(strings.TrimSuffix(data.config.Regex, "$"), "^")
@@ -787,16 +796,19 @@ func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSi
 	}
 	parts := strings.Split(clean, "|")
 	if strings.ContainsAny(clean, "*+?[]{}()\\^$.") || slices.Contains(parts, "") || !isValidLabelValues(parts) {
-		return false
+		return false, nil
 	}
 
 	if len(parts) == 1 {
 		if res.MatchLabels == nil {
 			res.MatchLabels = make(map[string]string)
 		}
+		if existing, exists := res.MatchLabels[labelName]; exists && existing != parts[0] {
+			return false, fmt.Errorf("conflicting keep rules for label %q: cannot require both %q and %q simultaneously", labelName, existing, parts[0])
+		}
 		res.MatchLabels[labelName] = parts[0]
 		logger.Info(fmt.Sprintf("Converted target filtering relabeling rule (%q -> %q) to Pod Selector (matchLabels).", source, parts[0]))
-		return true
+		return true, nil
 	}
 
 	res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
@@ -805,7 +817,7 @@ func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSi
 		Values:   parts,
 	})
 	logger.Info(fmt.Sprintf("Converted target filtering relabeling rule (%q -> In) to Pod Selector (matchExpressions).", source))
-	return true
+	return true, nil
 }
 
 // convertRelabelingToSimpleCopy attempts to convert simple label copy rules to targetLabels (fromPod or metadata).
@@ -851,22 +863,22 @@ func convertRelabelingToSimpleCopy(logger *slog.Logger, data *relabelingData, re
 }
 
 // convertRelabelingToMetricRelabeling converts a rule to post-scrape metricRelabeling.
-func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingData, isSingleEndpoint bool, res *preScrapeRelabelingResult, rawMetadata *[]string) {
+func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingData, res *preScrapeRelabelingResult, rawMetadata *[]string) {
 	if data.action == relabel.Keep || data.action == relabel.Drop {
 		logger.Warn(fmt.Sprintf("Target filtering rule (action %q on %v) promoted to post-scrape metricRelabeling; target is still scraped but metrics are dropped. Use labelSelector instead to avoid scraping overhead.", data.action, data.config.SourceLabels))
 	}
 
 	for _, p := range data.podSources {
-		res.FromPod = append(res.FromPod, monitoringv1.LabelMapping{From: p})
-		if !isSingleEndpoint {
-			logger.Warn(fmt.Sprintf("Promoted relabeling rule requires pod label %q, which is added to 'targetLabels.fromPod'. Because this resource has multiple endpoints, this label will also be attached to metrics scraped from all other endpoints.", p))
+		mapping := monitoringv1.LabelMapping{From: p}
+		if protectedLabels[p] {
+			mapping.To = "exported_" + p
 		}
+		res.FromPod = append(res.FromPod, mapping)
+		logger.Warn(fmt.Sprintf("Promoted relabeling rule requires pod label %q, which is added to 'targetLabels.fromPod'. This label will be attached to all metrics scraped by this resource across all endpoints.", p))
 	}
 	for _, m := range data.metaSources {
 		*rawMetadata = append(*rawMetadata, m)
-		if !isSingleEndpoint {
-			logger.Warn(fmt.Sprintf("Promoted relabeling rule requires metadata label %q, which is added to 'targetLabels.metadata'. Because this resource has multiple endpoints, this label will also be attached to metrics scraped from all other endpoints.", m))
-		}
+		logger.Warn(fmt.Sprintf("Promoted relabeling rule requires metadata label %q, which is added to 'targetLabels.metadata'. This label will be attached to all metrics scraped by this resource across all endpoints.", m))
 	}
 
 	targetLabel := data.targetLabel

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 
@@ -314,9 +315,7 @@ func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1
 			if len(r.MatchLabels) > 0 && combined.MatchLabels == nil {
 				combined.MatchLabels = make(map[string]string)
 			}
-			for k, v := range r.MatchLabels {
-				combined.MatchLabels[k] = v
-			}
+			maps.Copy(combined.MatchLabels, r.MatchLabels)
 			combined.MatchExpressions = append(combined.MatchExpressions, r.MatchExpressions...)
 		}
 		epResults = append(epResults, r)

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -52,6 +52,14 @@ var metadataLabelMap = map[string]string{
 	"__meta_kubernetes_pod_controller_kind": "top_level_controller_type",
 }
 
+// PreScrapeRelabelingResult holds the label mappings and selector rules extracted from pre-scrape relabelings.
+type PreScrapeRelabelingResult struct {
+	FromPod          []monitoringv1.LabelMapping
+	Metadata         *[]string
+	MatchLabels      map[string]string
+	MatchExpressions []metav1.LabelSelectorRequirement
+}
+
 // BuildTypeMeta constructs standard TypeMeta for a GMP resource Kind.
 func BuildTypeMeta(kind string) metav1.TypeMeta {
 	return metav1.TypeMeta{
@@ -118,10 +126,10 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 	return secrets
 }
 
-// convertPreScrapeRelabelings evaluates pre-scrape relabelings and extracts pod and metadata label mappings.
-func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig) ([]monitoringv1.LabelMapping, []string) {
-	var fromPod []monitoringv1.LabelMapping
-	var metadata []string
+// convertPreScrapeRelabelings evaluates pre-scrape relabelings on a single endpoint and extracts target label and selector rules.
+func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig) PreScrapeRelabelingResult {
+	var res PreScrapeRelabelingResult
+	var rawMetadata []string
 
 	for i, config := range configs {
 		action := strings.ToLower(config.Action)
@@ -147,10 +155,51 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			continue
 		}
 
+		// Change protected labels to exported_<label>.
 		if protectedLabels[config.TargetLabel] {
 			oldTarget := config.TargetLabel
 			configs[i].TargetLabel = "exported_" + oldTarget
 			logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.", oldTarget, configs[i].TargetLabel))
+		}
+
+		// Translate target filtering ("keep" and "drop") rules on pod labels to Kubernetes label selectors.
+		if (action == "keep" || action == "drop") && len(config.SourceLabels) == 1 {
+			source := string(config.SourceLabels[0])
+			if labelName, found := strings.CutPrefix(source, "__meta_kubernetes_pod_label_"); found {
+				// Strip optional regex start (^) and end ($) anchors (ex. "^production$" -> "production").
+				clean := strings.Trim(strings.TrimSpace(config.Regex), "^$")
+				// Strip outer grouping parentheses around literal lists (ex. "(test|staging)" -> "test|staging").
+				if strings.HasPrefix(clean, "(") && strings.HasSuffix(clean, ")") {
+					clean = clean[1 : len(clean)-1]
+				}
+				// Verify that the remaining string contains no regex metacharacters (*, +, ?, [, ], etc.).
+				// TODO: Defer to post-scrape metricRelabeling in that case.
+				if clean != "" && !strings.ContainsAny(clean, "*+?[]{}()\\^$.") {
+					parts := strings.Split(clean, "|")
+					// A single value with "action: keep" translates to matchLabels.
+					if action == "keep" && len(parts) == 1 {
+						if res.MatchLabels == nil {
+							res.MatchLabels = make(map[string]string)
+						}
+						res.MatchLabels[labelName] = parts[0]
+						logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %q) to Pod Selector (matchLabels).", source, parts[0]))
+						continue
+					}
+
+					// Multiple values (or any "action: drop" set) translate to matchExpressions (In / NotIn).
+					op := metav1.LabelSelectorOpIn
+					if action == "drop" {
+						op = metav1.LabelSelectorOpNotIn
+					}
+					res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
+						Key:      labelName,
+						Operator: op,
+						Values:   parts,
+					})
+					logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %s) to Pod Selector (matchExpressions).", source, op))
+					continue
+				}
+			}
 		}
 
 		// Relabeling rule equivalent of simply copying over a label.
@@ -169,49 +218,77 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 				if target != fromLabel {
 					mapping.To = target
 				}
-				fromPod = append(fromPod, mapping)
+				res.FromPod = append(res.FromPod, mapping)
 				logger.Info(fmt.Sprintf("Translated simple label copy relabeling rule (%q -> %q) to 'targetLabels.fromPod'.", source, target))
 				continue
 			}
 
 			// Simple metadata label transfer.
 			if gmpMeta, ok := metadataLabelMap[source]; ok {
-				metadata = append(metadata, gmpMeta)
+				rawMetadata = append(rawMetadata, gmpMeta)
 				logger.Info(fmt.Sprintf("Translated metadata label copy (%q) to 'targetLabels.metadata' (as label: %q).", source, gmpMeta))
 				continue
 			}
 		}
 	}
-	return fromPod, metadata
+
+	if len(rawMetadata) > 0 {
+		res.Metadata = &rawMetadata
+	}
+	return res
 }
 
-// extractPreScrapeTargetLabels loops through endpoints to extract all pre-scrape target label mappings.
-func extractPreScrapeTargetLabels(logger *slog.Logger, endpoints []pomonitoringv1.PodMetricsEndpoint) ([]monitoringv1.LabelMapping, *[]string) {
-	var allFromPod []monitoringv1.LabelMapping
-	var allMetadata []string
+// extractPreScrapeRelabelings loops through endpoints to extract all pre-scrape target label and selector rules.
+func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1.PodMetricsEndpoint) PreScrapeRelabelingResult {
+	var res PreScrapeRelabelingResult
+	var rawMetadata []string
 	for _, ep := range endpoints {
 		if len(ep.RelabelConfigs) > 0 {
-			fp, md := convertPreScrapeRelabelings(logger, ep.RelabelConfigs)
-			allFromPod = append(allFromPod, fp...)
-			allMetadata = append(allMetadata, md...)
+			r := convertPreScrapeRelabelings(logger, ep.RelabelConfigs)
+			res.FromPod = append(res.FromPod, r.FromPod...)
+			if r.Metadata != nil {
+				rawMetadata = append(rawMetadata, *r.Metadata...)
+			}
+			if len(r.MatchLabels) > 0 && res.MatchLabels == nil {
+				res.MatchLabels = make(map[string]string)
+			}
+			for k, v := range r.MatchLabels {
+				res.MatchLabels[k] = v
+			}
+			res.MatchExpressions = append(res.MatchExpressions, r.MatchExpressions...)
 		}
 	}
 
-	if len(allMetadata) == 0 {
-		return allFromPod, nil
-	}
-
-	// Deduplicate metadata labels (multiple endpoints transferring same metadata).
-	unique := make(map[string]bool)
-	var sortedMd []string
-	for _, m := range allMetadata {
-		if !unique[m] {
-			unique[m] = true
-			sortedMd = append(sortedMd, m)
+	if len(rawMetadata) > 0 {
+		unique := make(map[string]bool)
+		var sortedMd []string
+		for _, m := range rawMetadata {
+			if !unique[m] {
+				unique[m] = true
+				sortedMd = append(sortedMd, m)
+			}
 		}
+		slices.Sort(sortedMd)
+		res.Metadata = &sortedMd
 	}
-	slices.Sort(sortedMd)
-	return allFromPod, &sortedMd
+	return res
+}
+
+// mergeLabelSelector combines base selector requirements with extracted pre-scrape filtering rules.
+func mergeLabelSelector(logger *slog.Logger, base metav1.LabelSelector, extraLabels map[string]string, extraExprs []metav1.LabelSelectorRequirement) metav1.LabelSelector {
+	res := base.DeepCopy()
+	if len(extraLabels) > 0 && res.MatchLabels == nil {
+		res.MatchLabels = make(map[string]string)
+	}
+	for k, v := range extraLabels {
+		if existing, exists := res.MatchLabels[k]; exists && existing != v {
+			logger.Warn(fmt.Sprintf("Relabeling rule target filter for label %q (%q) conflicts with existing selector matchLabel (%q). Skipping rule.", k, v, existing))
+			continue
+		}
+		res.MatchLabels[k] = v
+	}
+	res.MatchExpressions = append(res.MatchExpressions, extraExprs...)
+	return *res
 }
 
 // mergeFromPod merges target label mappings and deduplicates by target label name.

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -188,8 +188,12 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		// Resolve all source labels upfront and intercept unsupported internal discovery labels.
-		podSources, metaSources, rewrittenSources, unsupported := resolveSourceLabels(logger, config.SourceLabels)
+		podSources, metaSources, rewrittenSources, unsupported := resolveSourceLabels(config.SourceLabels)
 		if unsupported {
+			logger.Warn(fmt.Sprintf("Relabeling rule (action %q on %v) dropped due to unsupported internal labels (e.g. annotations).", action, config.SourceLabels))
+			if action == relabel.Keep || action == relabel.Drop {
+				logger.Warn("Scraping scope expanded: targets previously excluded by this rule will now be scraped. Adjust pod selectors to compensate.")
+			}
 			continue
 		}
 
@@ -213,7 +217,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		// Convert complex or value-changing rules to post-scrape metricRelabeling.
-		convertRelabelingToMetricRelabeling(logger, data, &res, &rawMetadata)
+		convertRelabelingToMetricRelabeling(logger, data, isSingleEndpoint, &res, &rawMetadata)
 	}
 
 	if len(rawMetadata) > 0 {
@@ -737,7 +741,7 @@ func shouldSkipRelabelConfig(logger *slog.Logger, config pomonitoringv1.RelabelC
 
 // resolveSourceLabels resolves source labels to pod labels, metadata labels, and rewritten labels.
 // Returns unsupported=true if it encounters an unsupported internal label.
-func resolveSourceLabels(logger *slog.Logger, sourceLabels []pomonitoringv1.LabelName) (podSources []string, metaSources []string, rewrittenSources []string, unsupported bool) {
+func resolveSourceLabels(sourceLabels []pomonitoringv1.LabelName) (podSources []string, metaSources []string, rewrittenSources []string, unsupported bool) {
 	for _, sl := range sourceLabels {
 		s := string(sl)
 		if labelName, found := strings.CutPrefix(s, "__meta_kubernetes_pod_label_"); found {
@@ -752,7 +756,6 @@ func resolveSourceLabels(logger *slog.Logger, sourceLabels []pomonitoringv1.Labe
 		}
 		// TODO(kunnikrishnan): Support __meta_kubernetes_pod_labelpresent_<labelname> in the future.
 		if strings.HasPrefix(s, "__") {
-			logger.Warn(fmt.Sprintf("Relabeling rule referencing internal label %q is unsupported in GMP. The rule has been dropped.", s))
 			return nil, nil, nil, true
 		}
 		rewrittenSources = append(rewrittenSources, s)
@@ -848,15 +851,23 @@ func convertRelabelingToSimpleCopy(logger *slog.Logger, data *relabelingData, re
 }
 
 // convertRelabelingToMetricRelabeling converts a rule to post-scrape metricRelabeling.
-func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingData, res *preScrapeRelabelingResult, rawMetadata *[]string) {
+func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingData, isSingleEndpoint bool, res *preScrapeRelabelingResult, rawMetadata *[]string) {
 	if data.action == relabel.Keep || data.action == relabel.Drop {
 		logger.Warn(fmt.Sprintf("Target filtering rule (action %q on %v) promoted to post-scrape metricRelabeling; target is still scraped but metrics are dropped. Use labelSelector instead to avoid scraping overhead.", data.action, data.config.SourceLabels))
 	}
 
 	for _, p := range data.podSources {
 		res.FromPod = append(res.FromPod, monitoringv1.LabelMapping{From: p})
+		if !isSingleEndpoint {
+			logger.Warn(fmt.Sprintf("Promoted relabeling rule requires pod label %q, which is added to 'targetLabels.fromPod'. Because this resource has multiple endpoints, this label will also be attached to metrics scraped from all other endpoints.", p))
+		}
 	}
-	*rawMetadata = append(*rawMetadata, data.metaSources...)
+	for _, m := range data.metaSources {
+		*rawMetadata = append(*rawMetadata, m)
+		if !isSingleEndpoint {
+			logger.Warn(fmt.Sprintf("Promoted relabeling rule requires metadata label %q, which is added to 'targetLabels.metadata'. Because this resource has multiple endpoints, this label will also be attached to metrics scraped from all other endpoints.", m))
+		}
+	}
 
 	targetLabel := data.targetLabel
 	if protectedLabels[targetLabel] {

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -24,6 +24,7 @@ import (
 
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
 	pomonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/prometheus/google/export"
 	"github.com/prometheus/prometheus/model/relabel"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,12 +33,6 @@ import (
 )
 
 const (
-	labelCluster                = "cluster"
-	labelLocation               = "location"
-	labelProjectID              = "project_id"
-	labelNamespace              = "namespace"
-	labelJob                    = "job"
-	labelInstance               = "instance"
 	labelContainer              = "container"
 	labelNode                   = "node"
 	labelPod                    = "pod"
@@ -51,12 +46,12 @@ var (
 	// protectedLabels contains the list of labels that are protected by GMP and cannot
 	// be overwritten by targetLabels or relabeling rules.
 	protectedLabels = map[string]bool{
-		labelProjectID:              true,
-		labelLocation:               true,
-		labelCluster:                true,
-		labelNamespace:              true,
-		labelJob:                    true,
-		labelInstance:               true,
+		export.KeyProjectID:         true,
+		export.KeyLocation:          true,
+		export.KeyCluster:           true,
+		export.KeyNamespace:         true,
+		export.KeyJob:               true,
+		export.KeyInstance:          true,
 		labelTopLevelController:     true,
 		labelTopLevelControllerName: true,
 		labelTopLevelControllerType: true,
@@ -68,7 +63,7 @@ var (
 		"__meta_kubernetes_pod_name":            labelPod,
 		"__meta_kubernetes_pod_container_name":  labelContainer,
 		"__meta_kubernetes_pod_node_name":       labelNode,
-		"__meta_kubernetes_namespace":           labelNamespace,
+		"__meta_kubernetes_namespace":           export.KeyNamespace,
 		"__meta_kubernetes_pod_controller_name": labelTopLevelControllerName,
 		"__meta_kubernetes_pod_controller_kind": labelTopLevelControllerType,
 	}

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -42,6 +42,16 @@ var protectedLabels = map[string]bool{
 	"__address__":               true,
 }
 
+// metadataLabelMap contains the list of PO metadata labels and their GMP equivalent.
+var metadataLabelMap = map[string]string{
+	"__meta_kubernetes_pod_name":            "pod",
+	"__meta_kubernetes_pod_container_name":  "container",
+	"__meta_kubernetes_pod_node_name":       "node",
+	"__meta_kubernetes_namespace":           "namespace",
+	"__meta_kubernetes_pod_controller_name": "top_level_controller_name",
+	"__meta_kubernetes_pod_controller_kind": "top_level_controller_type",
+}
+
 // BuildTypeMeta constructs standard TypeMeta for a GMP resource Kind.
 func BuildTypeMeta(kind string) metav1.TypeMeta {
 	return metav1.TypeMeta{
@@ -108,8 +118,11 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 	return secrets
 }
 
-// convertPreScrapeRelabelings evaluates pre-scrape relabelings and drops unsupported rules with warnings.
-func convertPreScrapeRelabelings(convCtx *conversionContext, configs []pomonitoringv1.RelabelConfig) {
+// convertPreScrapeRelabelings evaluates pre-scrape relabelings and extracts pod and metadata label mappings.
+func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig) ([]monitoringv1.LabelMapping, []string) {
+	var fromPod []monitoringv1.LabelMapping
+	var metadata []string
+
 	for i, config := range configs {
 		action := strings.ToLower(config.Action)
 		if action == "" {
@@ -117,7 +130,7 @@ func convertPreScrapeRelabelings(convCtx *conversionContext, configs []pomonitor
 		}
 
 		if action == "labelmap" || action == "labelkeep" || action == "labeldrop" {
-			convCtx.logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' which is not supported by GMP and has been dropped.", action))
+			logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' which is not supported by GMP and has been dropped.", action))
 			continue
 		}
 
@@ -130,16 +143,107 @@ func convertPreScrapeRelabelings(convCtx *conversionContext, configs []pomonitor
 			}
 		}
 		if anno != "" {
-			convCtx.logger.Warn(fmt.Sprintf("Relabeling rule referencing pod annotation %q is unsupported in GMP. The rule has been dropped.", anno))
+			logger.Warn(fmt.Sprintf("Relabeling rule referencing pod annotation %q is unsupported in GMP. The rule has been dropped.", anno))
 			continue
 		}
 
 		if protectedLabels[config.TargetLabel] {
 			oldTarget := config.TargetLabel
 			configs[i].TargetLabel = "exported_" + oldTarget
-			convCtx.logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.", oldTarget, configs[i].TargetLabel))
+			logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.", oldTarget, configs[i].TargetLabel))
+		}
+
+		// Relabeling rule equivalent of simply copying over a label.
+		isSimpleCopy := len(config.SourceLabels) == 1 &&
+			(config.Regex == "" || config.Regex == "(.*)") &&
+			(config.Replacement == nil || *config.Replacement == "" || *config.Replacement == "$1") &&
+			action == "replace"
+
+		if isSimpleCopy {
+			source := string(config.SourceLabels[0])
+			target := configs[i].TargetLabel
+
+			// Simple pod target label transfer.
+			if fromLabel, found := strings.CutPrefix(source, "__meta_kubernetes_pod_label_"); found {
+				mapping := monitoringv1.LabelMapping{From: fromLabel}
+				if target != fromLabel {
+					mapping.To = target
+				}
+				fromPod = append(fromPod, mapping)
+				logger.Info(fmt.Sprintf("Translated simple label copy relabeling rule (%q -> %q) to 'targetLabels.fromPod'.", source, target))
+				continue
+			}
+
+			// Simple metadata label transfer.
+			if gmpMeta, ok := metadataLabelMap[source]; ok {
+				metadata = append(metadata, gmpMeta)
+				logger.Info(fmt.Sprintf("Translated metadata label copy (%q) to 'targetLabels.metadata' (as label: %q).", source, gmpMeta))
+				continue
+			}
 		}
 	}
+	return fromPod, metadata
+}
+
+// extractPreScrapeTargetLabels loops through endpoints to extract all pre-scrape target label mappings.
+func extractPreScrapeTargetLabels(logger *slog.Logger, endpoints []pomonitoringv1.PodMetricsEndpoint) ([]monitoringv1.LabelMapping, *[]string) {
+	var allFromPod []monitoringv1.LabelMapping
+	var allMetadata []string
+	for _, ep := range endpoints {
+		if len(ep.RelabelConfigs) > 0 {
+			fp, md := convertPreScrapeRelabelings(logger, ep.RelabelConfigs)
+			allFromPod = append(allFromPod, fp...)
+			allMetadata = append(allMetadata, md...)
+		}
+	}
+
+	if len(allMetadata) == 0 {
+		return allFromPod, nil
+	}
+
+	// Deduplicate metadata labels (multiple endpoints transferring same metadata).
+	unique := make(map[string]bool)
+	var sortedMd []string
+	for _, m := range allMetadata {
+		if !unique[m] {
+			unique[m] = true
+			sortedMd = append(sortedMd, m)
+		}
+	}
+	slices.Sort(sortedMd)
+	return allFromPod, &sortedMd
+}
+
+// mergeFromPod merges target label mappings and deduplicates by target label name.
+func mergeFromPod(logger *slog.Logger, base []monitoringv1.LabelMapping, extra []monitoringv1.LabelMapping) []monitoringv1.LabelMapping {
+	seenTargets := make(map[string]string)
+	var res []monitoringv1.LabelMapping
+
+	for _, m := range base {
+		target := m.From
+		if m.To != "" {
+			target = m.To
+		}
+		seenTargets[target] = m.From
+		res = append(res, m)
+	}
+
+	for _, m := range extra {
+		target := m.From
+		if m.To != "" {
+			target = m.To
+		}
+		if existingFrom, exists := seenTargets[target]; exists {
+			if existingFrom == m.From {
+				continue
+			}
+			logger.Warn(fmt.Sprintf("Target label %q is already mapped from %q. Skipping conflicting mapping from %q.", target, existingFrom, m.From))
+			continue
+		}
+		seenTargets[target] = m.From
+		res = append(res, m)
+	}
+	return res
 }
 
 // extractResourceKey is a consolidated helper that fetches a key from a ConfigMap or Secret.

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -78,8 +78,8 @@ type relabelingData struct {
 	rewrittenSources []string
 }
 
-// PreScrapeRelabelingResult holds the label mappings and selector rules extracted from pre-scrape relabelings.
-type PreScrapeRelabelingResult struct {
+// preScrapeRelabelingResult holds the label mappings and selector rules extracted from pre-scrape relabelings.
+type preScrapeRelabelingResult struct {
 	FromPod          []monitoringv1.LabelMapping
 	Metadata         *[]string
 	MatchLabels      map[string]string
@@ -87,12 +87,12 @@ type PreScrapeRelabelingResult struct {
 	PromotedRules    []monitoringv1.RelabelingRule
 }
 
-// ExtractedPreScrapeRules holds all translated rules, separated by where they belong in GMP.
-type ExtractedPreScrapeRules struct {
+// extractedPreScrapeRules holds all translated rules, separated by where they belong in GMP.
+type extractedPreScrapeRules struct {
 	// PerEndpoint contains the rules (like promoted metric relabelings) specific to each scrape endpoint.
-	PerEndpoint []PreScrapeRelabelingResult
+	PerEndpoint []preScrapeRelabelingResult
 	// ResourceCombined contains target labels and selectors merged across all endpoints.
-	ResourceCombined PreScrapeRelabelingResult
+	ResourceCombined preScrapeRelabelingResult
 }
 
 // BuildTypeMeta constructs standard TypeMeta for a GMP resource Kind.
@@ -172,13 +172,12 @@ func isValidLabelValues(parts []string) bool {
 }
 
 // convertPreScrapeRelabelings evaluates pre-scrape relabelings on a single endpoint and extracts target label and selector rules.
-func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig, isSingleEndpoint bool) PreScrapeRelabelingResult {
+func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig, isSingleEndpoint bool) preScrapeRelabelingResult {
 	var (
-		res         PreScrapeRelabelingResult
+		res         preScrapeRelabelingResult
 		rawMetadata []string
 	)
 
-relabelLoop:
 	for _, config := range configs {
 		action := relabel.Action(strings.ToLower(config.Action))
 		if action == "" {
@@ -186,13 +185,13 @@ relabelLoop:
 		}
 
 		if shouldSkipRelabelConfig(logger, config, action) {
-			continue relabelLoop
+			continue
 		}
 
 		// Resolve all source labels upfront and intercept unsupported internal discovery labels.
 		podSources, metaSources, rewrittenSources, unsupported := resolveSourceLabels(logger, config.SourceLabels)
 		if unsupported {
-			continue relabelLoop
+			continue
 		}
 
 		data := &relabelingData{
@@ -206,12 +205,12 @@ relabelLoop:
 
 		// Convert target filtering ("keep" and "drop") rules on pod labels to Kubernetes label selectors.
 		if convertRelabelingToSelector(logger, data, isSingleEndpoint, &res) {
-			continue relabelLoop
+			continue
 		}
 
 		// Convert simple label copy rules to targetLabels (fromPod or metadata).
 		if convertRelabelingToSimpleCopy(logger, data, &res, &rawMetadata) {
-			continue relabelLoop
+			continue
 		}
 
 		// Convert complex or value-changing rules to post-scrape metricRelabeling.
@@ -225,14 +224,14 @@ relabelLoop:
 }
 
 // extractPreScrapeRelabelings evaluates pre-scrape rules once per endpoint, returning consolidated endpoint and resource-level results.
-func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1.PodMetricsEndpoint) ExtractedPreScrapeRules {
+func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1.PodMetricsEndpoint) extractedPreScrapeRules {
 	var (
-		epResults   []PreScrapeRelabelingResult
-		combined    PreScrapeRelabelingResult
+		epResults   []preScrapeRelabelingResult
+		combined    preScrapeRelabelingResult
 		rawMetadata []string
 	)
 	for _, ep := range endpoints {
-		var r PreScrapeRelabelingResult
+		var r preScrapeRelabelingResult
 		if len(ep.RelabelConfigs) > 0 {
 			r = convertPreScrapeRelabelings(logger, ep.RelabelConfigs, len(endpoints) == 1)
 			combined.FromPod = append(combined.FromPod, r.FromPod...)
@@ -262,16 +261,16 @@ func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1
 		slices.Sort(sortedMd)
 		combined.Metadata = &sortedMd
 	}
-	return ExtractedPreScrapeRules{
+	return extractedPreScrapeRules{
 		PerEndpoint:      epResults,
 		ResourceCombined: combined,
 	}
 }
 
 // mergeLabelSelector combines base selector requirements with extracted pre-scrape filtering rules.
-func mergeLabelSelector(logger *slog.Logger, base metav1.LabelSelector, extraLabels map[string]string, extraExprs []metav1.LabelSelectorRequirement) metav1.LabelSelector {
+func mergeLabelSelector(base metav1.LabelSelector, extraLabels map[string]string, extraExprs []metav1.LabelSelectorRequirement) (metav1.LabelSelector, error) {
 	if len(extraLabels) == 0 && len(extraExprs) == 0 {
-		return base
+		return base, nil
 	}
 	res := base.DeepCopy()
 	if len(extraLabels) > 0 && res.MatchLabels == nil {
@@ -279,13 +278,12 @@ func mergeLabelSelector(logger *slog.Logger, base metav1.LabelSelector, extraLab
 	}
 	for k, v := range extraLabels {
 		if existing, exists := res.MatchLabels[k]; exists && existing != v {
-			logger.Warn(fmt.Sprintf("Relabeling rule target filter for label %q (%q) conflicts with existing selector matchLabel (%q). Skipping rule.", k, v, existing))
-			continue
+			return metav1.LabelSelector{}, fmt.Errorf("selector conflict: label %q has conflicting values %q (base selector) and %q (relabeling rule)", k, existing, v)
 		}
 		res.MatchLabels[k] = v
 	}
 	res.MatchExpressions = append(res.MatchExpressions, extraExprs...)
-	return *res
+	return *res, nil
 }
 
 // mergeFromPod merges target label mappings and deduplicates by target label name.
@@ -768,7 +766,7 @@ func resolveSourceLabels(logger *slog.Logger, sourceLabels []pomonitoringv1.Labe
 }
 
 // convertRelabelingToSelector attempts to convert target filtering (keep/drop) rules to pod selectors.
-func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSingleEndpoint bool, res *PreScrapeRelabelingResult) bool {
+func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSingleEndpoint bool, res *preScrapeRelabelingResult) bool {
 	if !isSingleEndpoint || data.action != relabel.Keep || len(data.podSources) != 1 || len(data.config.SourceLabels) != 1 {
 		return false
 	}
@@ -781,7 +779,11 @@ func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSi
 		return false
 	}
 
-	clean := strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(data.config.Regex), "$"), "^")
+	if errs := validation.IsQualifiedName(labelName); len(errs) > 0 {
+		return false
+	}
+
+	clean := strings.TrimPrefix(strings.TrimSuffix(data.config.Regex, "$"), "^")
 	if strings.HasPrefix(clean, "(") && strings.HasSuffix(clean, ")") {
 		clean = clean[1 : len(clean)-1]
 	}
@@ -809,7 +811,7 @@ func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSi
 }
 
 // convertRelabelingToSimpleCopy attempts to convert simple label copy rules to targetLabels (fromPod or metadata).
-func convertRelabelingToSimpleCopy(logger *slog.Logger, data *relabelingData, res *PreScrapeRelabelingResult, rawMetadata *[]string) bool {
+func convertRelabelingToSimpleCopy(logger *slog.Logger, data *relabelingData, res *preScrapeRelabelingResult, rawMetadata *[]string) bool {
 	isSimpleCopy := len(data.config.SourceLabels) == 1 &&
 		(data.config.Regex == "" || data.config.Regex == "(.*)") &&
 		(data.config.Replacement == nil || *data.config.Replacement == "$1") &&
@@ -851,7 +853,11 @@ func convertRelabelingToSimpleCopy(logger *slog.Logger, data *relabelingData, re
 }
 
 // convertRelabelingToMetricRelabeling converts a rule to post-scrape metricRelabeling.
-func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingData, res *PreScrapeRelabelingResult, rawMetadata *[]string) {
+func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingData, res *preScrapeRelabelingResult, rawMetadata *[]string) {
+	if data.action == relabel.Keep || data.action == relabel.Drop {
+		logger.Warn(fmt.Sprintf("Target filtering rule (action %q on %v) promoted to post-scrape metricRelabeling; target is still scraped but metrics are dropped. Use labelSelector instead to avoid scraping overhead.", data.action, data.config.SourceLabels))
+	}
+
 	for _, p := range data.podSources {
 		res.FromPod = append(res.FromPod, monitoringv1.LabelMapping{From: p})
 	}

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -635,12 +635,13 @@ func convertMetricRelabelings(
 			action = relabel.Replace
 		}
 
+		if shouldSkipRelabelConfig(logger, config, action) {
+			continue
+		}
+
 		targetLabel := config.TargetLabel
 		switch action {
-		case relabel.LabelMap:
-			logger.Warn("metricRelabelings rule uses 'action: labelmap' which is not supported by GMP and has been dropped.")
-			continue
-		case relabel.Replace, relabel.HashMod, relabel.Lowercase, relabel.Uppercase:
+		case relabel.Replace, relabel.HashMod:
 			if protectedLabels[config.TargetLabel] {
 				targetLabel = "exported_" + config.TargetLabel
 				logger.Warn("Relabeling rule attempts to write to protected target label. Renamed target.",
@@ -730,8 +731,13 @@ func convertTargetLabels(logger *slog.Logger, sourceLabels []string, jobLabel st
 // shouldSkipRelabelConfig checks if the relabel config uses unsupported actions or references annotations.
 func shouldSkipRelabelConfig(logger *slog.Logger, config pomonitoringv1.RelabelConfig, action relabel.Action) bool {
 	switch action {
-	case relabel.LabelMap, relabel.LabelKeep, relabel.LabelDrop:
+	case relabel.Replace, relabel.Keep, relabel.Drop, relabel.HashMod, relabel.LabelDrop, relabel.LabelKeep, "":
+		// Supported actions.
+	case relabel.LabelMap, relabel.Lowercase, relabel.Uppercase, relabel.KeepEqual, relabel.DropEqual:
 		logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' which is not supported by GMP and has been dropped.", action))
+		return true
+	default:
+		logger.Warn(fmt.Sprintf("Relabeling rule uses unknown 'action: %s' which is not supported by GMP and has been dropped.", action))
 		return true
 	}
 
@@ -771,11 +777,18 @@ func resolveSourceLabels(logger *slog.Logger, sourceLabels []pomonitoringv1.Labe
 
 // convertRelabelingToSelector attempts to convert target filtering (keep/drop) rules to pod selectors.
 func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSingleEndpoint bool, res *PreScrapeRelabelingResult) bool {
-	if !isSingleEndpoint || (data.action != relabel.Keep && data.action != relabel.Drop) || len(data.podSources) != 1 || len(data.config.SourceLabels) != 1 {
+	if !isSingleEndpoint || data.action != relabel.Keep || len(data.podSources) != 1 || len(data.config.SourceLabels) != 1 {
 		return false
 	}
 	source := string(data.config.SourceLabels[0])
 	labelName := data.podSources[0]
+
+	// If the label contains an underscore, it might have been sanitized from '.', '/', or '-'.
+	// Since we cannot recover the original key, we skip selector conversion to avoid mismatch.
+	if strings.Contains(labelName, "_") {
+		return false
+	}
+
 	clean := strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(data.config.Regex), "$"), "^")
 	if strings.HasPrefix(clean, "(") && strings.HasSuffix(clean, ")") {
 		clean = clean[1 : len(clean)-1]
@@ -785,7 +798,7 @@ func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSi
 		return false
 	}
 
-	if data.action == relabel.Keep && len(parts) == 1 {
+	if len(parts) == 1 {
 		if res.MatchLabels == nil {
 			res.MatchLabels = make(map[string]string)
 		}
@@ -794,16 +807,12 @@ func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSi
 		return true
 	}
 
-	op := metav1.LabelSelectorOpIn
-	if data.action == relabel.Drop {
-		op = metav1.LabelSelectorOpNotIn
-	}
 	res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
 		Key:      labelName,
-		Operator: op,
+		Operator: metav1.LabelSelectorOpIn,
 		Values:   parts,
 	})
-	logger.Info(fmt.Sprintf("Converted target filtering relabeling rule (%q -> %s) to Pod Selector (matchExpressions).", source, op))
+	logger.Info(fmt.Sprintf("Converted target filtering relabeling rule (%q -> In) to Pod Selector (matchExpressions).", source))
 	return true
 }
 

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -24,6 +24,7 @@ import (
 
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
 	pomonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/prometheus/model/relabel"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -31,15 +32,6 @@ import (
 )
 
 const (
-	actionReplace   = "replace"
-	actionKeep      = "keep"
-	actionDrop      = "drop"
-	actionLabelMap  = "labelmap"
-	actionLabelKeep = "labelkeep"
-	actionLabelDrop = "labeldrop"
-	actionHashMod   = "hashmod"
-	actionLowercase = "lowercase"
-	actionUppercase = "uppercase"
 
 	labelCluster                = "cluster"
 	labelLocation               = "location"
@@ -178,17 +170,19 @@ func isValidLabelValues(parts []string) bool {
 
 // convertPreScrapeRelabelings evaluates pre-scrape relabelings on a single endpoint and extracts target label and selector rules.
 func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig, isSingleEndpoint bool) PreScrapeRelabelingResult {
-	var res PreScrapeRelabelingResult
-	var rawMetadata []string
+	var (
+		res         PreScrapeRelabelingResult
+		rawMetadata []string
+	)
 
 	for _, config := range configs {
-		action := strings.ToLower(config.Action)
+		action := relabel.Action(strings.ToLower(config.Action))
 		if action == "" {
-			action = actionReplace
+			action = relabel.Replace
 		}
 
 		switch action {
-		case actionLabelMap, actionLabelKeep, actionLabelDrop:
+		case relabel.LabelMap, relabel.LabelKeep, relabel.LabelDrop:
 			logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' which is not supported by GMP and has been dropped.", action))
 			continue
 		}
@@ -215,10 +209,12 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		// Resolve all source labels upfront and intercept unsupported internal discovery labels.
-		var podSources []string
-		var metaSources []string
-		var rewrittenSources []string
-		var unsupportedInternal bool
+		var (
+			podSources          []string
+			metaSources         []string
+			rewrittenSources    []string
+			unsupportedInternal bool
+		)
 
 		for _, sl := range config.SourceLabels {
 			s := string(sl)
@@ -241,7 +237,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		// Translate target filtering ("keep" and "drop") rules on pod labels to Kubernetes label selectors.
-		if isSingleEndpoint && (action == actionKeep || action == actionDrop) && len(podSources) == 1 && len(config.SourceLabels) == 1 {
+		if isSingleEndpoint && (action == relabel.Keep || action == relabel.Drop) && len(podSources) == 1 && len(config.SourceLabels) == 1 {
 			source := string(config.SourceLabels[0])
 			labelName := podSources[0]
 			// Strip optional regex start (^) and end ($) anchors (ex. "^production$" -> "production").
@@ -254,7 +250,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			// Verify that the remaining string contains no regex metacharacters (*, +, ?, [, ], etc.) and valid K8s label values.
 			if !strings.ContainsAny(clean, "*+?[]{}()\\^$.") && !slices.Contains(parts, "") && isValidLabelValues(parts) {
 				// A single value with "action: keep" translates to matchLabels.
-				if action == actionKeep && len(parts) == 1 {
+				if action == relabel.Keep && len(parts) == 1 {
 					if res.MatchLabels == nil {
 						res.MatchLabels = make(map[string]string)
 					}
@@ -265,7 +261,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 
 				// Multiple values (or any "action: drop" set) translate to matchExpressions (In / NotIn).
 				op := metav1.LabelSelectorOpIn
-				if action == actionDrop {
+				if action == relabel.Drop {
 					op = metav1.LabelSelectorOpNotIn
 				}
 				res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
@@ -282,7 +278,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		isSimpleCopy := len(config.SourceLabels) == 1 &&
 			(config.Regex == "" || config.Regex == "(.*)") &&
 			(config.Replacement == nil || *config.Replacement == "$1") &&
-			action == actionReplace
+			action == relabel.Replace
 
 		if isSimpleCopy {
 			source := string(config.SourceLabels[0])
@@ -318,7 +314,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			TargetLabel:  targetLabel,
 			Regex:        config.Regex,
 			Modulus:      config.Modulus,
-			Action:       action,
+			Action:       string(action),
 		}
 		if config.Separator != nil {
 			promoted.Separator = *config.Separator
@@ -338,9 +334,11 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 
 // extractPreScrapeRelabelings evaluates pre-scrape rules once per endpoint, returning consolidated endpoint and resource-level results.
 func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1.PodMetricsEndpoint) ExtractedPreScrapeRules {
-	var epResults []PreScrapeRelabelingResult
-	var combined PreScrapeRelabelingResult
-	var rawMetadata []string
+	var (
+		epResults   []PreScrapeRelabelingResult
+		combined    PreScrapeRelabelingResult
+		rawMetadata []string
+	)
 	for _, ep := range endpoints {
 		var r PreScrapeRelabelingResult
 		if len(ep.RelabelConfigs) > 0 {
@@ -694,8 +692,10 @@ func (c *conversionContext) convertAuthorization(auth *pomonitoringv1.SafeAuthor
 	if auth == nil {
 		return nil, nil
 	}
-	var credentials *monitoringv1.SecretSelector
-	var err error
+	var (
+		credentials *monitoringv1.SecretSelector
+		err         error
+	)
 	if auth.Credentials != nil {
 		credentials, err = c.convertSecretSelector(auth.Credentials)
 		if err != nil {
@@ -715,17 +715,17 @@ func convertMetricRelabelings(
 	var rules []monitoringv1.RelabelingRule
 
 	for _, config := range configs {
-		action := strings.ToLower(config.Action)
+		action := relabel.Action(strings.ToLower(config.Action))
 		if action == "" {
-			action = actionReplace
+			action = relabel.Replace
 		}
 
 		targetLabel := config.TargetLabel
 		switch action {
-		case actionLabelMap:
+		case relabel.LabelMap:
 			logger.Warn("metricRelabelings rule uses 'action: labelmap' which is not supported by GMP and has been dropped.")
 			continue
-		case actionReplace, actionHashMod, actionLowercase, actionUppercase:
+		case relabel.Replace, relabel.HashMod, relabel.Lowercase, relabel.Uppercase:
 			if protectedLabels[config.TargetLabel] {
 				targetLabel = "exported_" + config.TargetLabel
 				logger.Warn("Relabeling rule attempts to write to protected target label. Renamed target.",
@@ -738,7 +738,7 @@ func convertMetricRelabelings(
 			TargetLabel: targetLabel,
 			Regex:       config.Regex,
 			Modulus:     config.Modulus,
-			Action:      action,
+			Action:      string(action),
 		}
 
 		if len(config.SourceLabels) > 0 {

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -162,43 +162,63 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.", oldTarget, configs[i].TargetLabel))
 		}
 
-		// Translate target filtering ("keep" and "drop") rules on pod labels to Kubernetes label selectors.
-		if (action == "keep" || action == "drop") && len(config.SourceLabels) == 1 {
-			source := string(config.SourceLabels[0])
-			if labelName, found := strings.CutPrefix(source, "__meta_kubernetes_pod_label_"); found {
-				// Strip optional regex start (^) and end ($) anchors (ex. "^production$" -> "production").
-				clean := strings.Trim(strings.TrimSpace(config.Regex), "^$")
-				// Strip outer grouping parentheses around literal lists (ex. "(test|staging)" -> "test|staging").
-				if strings.HasPrefix(clean, "(") && strings.HasSuffix(clean, ")") {
-					clean = clean[1 : len(clean)-1]
-				}
-				// Verify that the remaining string contains no regex metacharacters (*, +, ?, [, ], etc.).
-				// TODO: Defer to post-scrape metricRelabeling in that case.
-				if clean != "" && !strings.ContainsAny(clean, "*+?[]{}()\\^$.") {
-					parts := strings.Split(clean, "|")
-					// A single value with "action: keep" translates to matchLabels.
-					if action == "keep" && len(parts) == 1 {
-						if res.MatchLabels == nil {
-							res.MatchLabels = make(map[string]string)
-						}
-						res.MatchLabels[labelName] = parts[0]
-						logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %q) to Pod Selector (matchLabels).", source, parts[0]))
-						continue
-					}
+		// Resolve all source labels upfront and intercept unsupported internal discovery labels.
+		var podSources []string
+		var metaSources []string
+		var unsupportedInternal bool
 
-					// Multiple values (or any "action: drop" set) translate to matchExpressions (In / NotIn).
-					op := metav1.LabelSelectorOpIn
-					if action == "drop" {
-						op = metav1.LabelSelectorOpNotIn
+		for _, sl := range config.SourceLabels {
+			s := string(sl)
+			if labelName, found := strings.CutPrefix(s, "__meta_kubernetes_pod_label_"); found {
+				podSources = append(podSources, labelName)
+			} else if gmpMeta, ok := metadataLabelMap[s]; ok {
+				metaSources = append(metaSources, gmpMeta)
+			} else if strings.HasPrefix(s, "__") {
+				logger.Warn(fmt.Sprintf("Relabeling rule references internal label %q which is not available in post-scrape metricRelabeling. The rule cannot be migrated and has been dropped.", s))
+				unsupportedInternal = true
+				break
+			}
+		}
+		if unsupportedInternal {
+			continue
+		}
+
+		// Translate target filtering ("keep" and "drop") rules on pod labels to Kubernetes label selectors.
+		if (action == "keep" || action == "drop") && len(podSources) == 1 && len(config.SourceLabels) == 1 {
+			source := string(config.SourceLabels[0])
+			labelName := podSources[0]
+			// Strip optional regex start (^) and end ($) anchors (ex. "^production$" -> "production").
+			clean := strings.Trim(strings.TrimSpace(config.Regex), "^$")
+			// Strip outer grouping parentheses around literal lists (ex. "(test|staging)" -> "test|staging").
+			if strings.HasPrefix(clean, "(") && strings.HasSuffix(clean, ")") {
+				clean = clean[1 : len(clean)-1]
+			}
+			// Verify that the remaining string contains no regex metacharacters (*, +, ?, [, ], etc.).
+			// TODO: Defer to post-scrape metricRelabeling in that case.
+			if clean != "" && !strings.ContainsAny(clean, "*+?[]{}()\\^$.") {
+				parts := strings.Split(clean, "|")
+				// A single value with "action: keep" translates to matchLabels.
+				if action == "keep" && len(parts) == 1 {
+					if res.MatchLabels == nil {
+						res.MatchLabels = make(map[string]string)
 					}
-					res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
-						Key:      labelName,
-						Operator: op,
-						Values:   parts,
-					})
-					logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %s) to Pod Selector (matchExpressions).", source, op))
+					res.MatchLabels[labelName] = parts[0]
+					logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %q) to Pod Selector (matchLabels).", source, parts[0]))
 					continue
 				}
+
+				// Multiple values (or any "action: drop" set) translate to matchExpressions (In / NotIn).
+				op := metav1.LabelSelectorOpIn
+				if action == "drop" {
+					op = metav1.LabelSelectorOpNotIn
+				}
+				res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
+					Key:      labelName,
+					Operator: op,
+					Values:   parts,
+				})
+				logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %s) to Pod Selector (matchExpressions).", source, op))
+				continue
 			}
 		}
 
@@ -213,9 +233,9 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			target := configs[i].TargetLabel
 
 			// Simple pod target label transfer.
-			if fromLabel, found := strings.CutPrefix(source, "__meta_kubernetes_pod_label_"); found {
-				mapping := monitoringv1.LabelMapping{From: fromLabel}
-				if target != fromLabel {
+			if len(podSources) == 1 {
+				mapping := monitoringv1.LabelMapping{From: podSources[0]}
+				if target != podSources[0] {
 					mapping.To = target
 				}
 				res.FromPod = append(res.FromPod, mapping)
@@ -224,9 +244,9 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			}
 
 			// Simple metadata label transfer.
-			if gmpMeta, ok := metadataLabelMap[source]; ok {
-				rawMetadata = append(rawMetadata, gmpMeta)
-				logger.Info(fmt.Sprintf("Translated metadata label copy (%q) to 'targetLabels.metadata' (as label: %q).", source, gmpMeta))
+			if len(metaSources) == 1 {
+				rawMetadata = append(rawMetadata, metaSources[0])
+				logger.Info(fmt.Sprintf("Translated metadata label copy (%q) to 'targetLabels.metadata' (as label: %q).", source, metaSources[0]))
 				continue
 			}
 		}

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -304,15 +304,7 @@ func mergeFromPod(logger *slog.Logger, base []monitoringv1.LabelMapping, extra [
 	seenTargets := make(map[string]string)
 	var res []monitoringv1.LabelMapping
 
-	for _, m := range base {
-		target := m.From
-		if m.To != "" {
-			target = m.To
-		}
-		seenTargets[target] = m.From
-		res = append(res, m)
-	}
-
+	// Process custom relabel configs first (higher precedence).
 	for _, m := range extra {
 		target := m.From
 		if m.To != "" {
@@ -322,7 +314,24 @@ func mergeFromPod(logger *slog.Logger, base []monitoringv1.LabelMapping, extra [
 			if existingFrom == m.From {
 				continue
 			}
-			logger.Warn(fmt.Sprintf("Target label %q is already mapped from %q. Skipping conflicting mapping from %q.", target, existingFrom, m.From))
+			logger.Warn(fmt.Sprintf("Conflict in relabel configs: target label %q is already mapped from %q. Skipping conflicting mapping from %q.", target, existingFrom, m.From))
+			continue
+		}
+		seenTargets[target] = m.From
+		res = append(res, m)
+	}
+
+	// Process static podTargetLabels second (lower precedence, overridden by extra).
+	for _, m := range base {
+		target := m.From
+		if m.To != "" {
+			target = m.To
+		}
+		if existingFrom, exists := seenTargets[target]; exists {
+			if existingFrom == m.From {
+				continue
+			}
+			logger.Info(fmt.Sprintf("Static podTargetLabels mapping for target %q (from %q) is overridden by custom relabel config (from %q).", target, m.From, existingFrom))
 			continue
 		}
 		seenTargets[target] = m.From

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -52,7 +52,6 @@ var (
 		export.KeyJob:               true,
 		export.KeyInstance:          true,
 		labelTopLevelController:     true,
-		labelTopLevelControllerName: true,
 		labelTopLevelControllerType: true,
 		labelAddress:                true,
 	}
@@ -726,8 +725,13 @@ func convertTargetLabels(logger *slog.Logger, sourceLabels []string, jobLabel st
 // shouldSkipRelabelConfig checks if the relabel config uses unsupported actions or references annotations.
 func shouldSkipRelabelConfig(logger *slog.Logger, config pomonitoringv1.RelabelConfig, action relabel.Action) bool {
 	switch action {
-	case relabel.Replace, relabel.Keep, relabel.Drop, relabel.HashMod, relabel.LabelDrop, relabel.LabelKeep, "":
-		// Supported actions.
+	case relabel.Replace, relabel.HashMod, "":
+		if config.TargetLabel == "" {
+			logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' with an empty 'targetLabel', which is invalid in Prometheus and has been dropped.", action))
+			return true
+		}
+	case relabel.Keep, relabel.Drop, relabel.LabelDrop, relabel.LabelKeep:
+		// Supported actions that do not require targetLabel.
 	case relabel.LabelMap, relabel.Lowercase, relabel.Uppercase, relabel.KeepEqual, relabel.DropEqual:
 		logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' which is not supported by GMP and has been dropped.", action))
 		return true
@@ -825,12 +829,10 @@ func convertRelabelingToSimpleCopy(logger *slog.Logger, data *relabelingData, re
 		return false
 	}
 
-	source := string(data.config.SourceLabels[0])
 	target := data.targetLabel
 
 	if len(data.podSources) == 1 {
 		source := data.podSources[0]
-		target := data.targetLabel
 
 		if protectedLabels[target] {
 			oldTarget := target
@@ -848,6 +850,7 @@ func convertRelabelingToSimpleCopy(logger *slog.Logger, data *relabelingData, re
 	}
 
 	if len(data.metaSources) == 1 && target == data.metaSources[0] {
+		source := string(data.config.SourceLabels[0])
 		*rawMetadata = append(*rawMetadata, data.metaSources[0])
 		logger.Info(fmt.Sprintf("Converted metadata label copy (%q) to 'targetLabels.metadata' (as label: %q).", source, data.metaSources[0]))
 		return true

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -137,11 +137,11 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 }
 
 // convertPreScrapeRelabelings evaluates pre-scrape relabelings on a single endpoint and extracts target label and selector rules.
-func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig) PreScrapeRelabelingResult {
+func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig, isSingleEndpoint bool) PreScrapeRelabelingResult {
 	var res PreScrapeRelabelingResult
 	var rawMetadata []string
 
-	for i, config := range configs {
+	for _, config := range configs {
 		action := strings.ToLower(config.Action)
 		if action == "" {
 			action = "replace"
@@ -166,10 +166,11 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		// Change protected labels to exported_<label>.
-		if protectedLabels[config.TargetLabel] {
-			oldTarget := config.TargetLabel
-			configs[i].TargetLabel = "exported_" + oldTarget
-			logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.", oldTarget, configs[i].TargetLabel))
+		targetLabel := config.TargetLabel
+		if protectedLabels[targetLabel] {
+			oldTarget := targetLabel
+			targetLabel = "exported_" + oldTarget
+			logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.", oldTarget, targetLabel))
 		}
 
 		// Resolve all source labels upfront and intercept unsupported internal discovery labels.
@@ -199,7 +200,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		// Translate target filtering ("keep" and "drop") rules on pod labels to Kubernetes label selectors.
-		if (action == "keep" || action == "drop") && len(podSources) == 1 && len(config.SourceLabels) == 1 {
+		if isSingleEndpoint && (action == "keep" || action == "drop") && len(podSources) == 1 && len(config.SourceLabels) == 1 {
 			source := string(config.SourceLabels[0])
 			labelName := podSources[0]
 			// Strip optional regex start (^) and end ($) anchors (ex. "^production$" -> "production").
@@ -211,28 +212,30 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			// Verify that the remaining string contains no regex metacharacters (*, +, ?, [, ], etc.).
 			if clean != "" && !strings.ContainsAny(clean, "*+?[]{}()\\^$.") {
 				parts := strings.Split(clean, "|")
-				// A single value with "action: keep" translates to matchLabels.
-				if action == "keep" && len(parts) == 1 {
-					if res.MatchLabels == nil {
-						res.MatchLabels = make(map[string]string)
+				if !slices.Contains(parts, "") {
+					// A single value with "action: keep" translates to matchLabels.
+					if action == "keep" && len(parts) == 1 {
+						if res.MatchLabels == nil {
+							res.MatchLabels = make(map[string]string)
+						}
+						res.MatchLabels[labelName] = parts[0]
+						logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %q) to Pod Selector (matchLabels).", source, parts[0]))
+						continue
 					}
-					res.MatchLabels[labelName] = parts[0]
-					logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %q) to Pod Selector (matchLabels).", source, parts[0]))
+
+					// Multiple values (or any "action: drop" set) translate to matchExpressions (In / NotIn).
+					op := metav1.LabelSelectorOpIn
+					if action == "drop" {
+						op = metav1.LabelSelectorOpNotIn
+					}
+					res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
+						Key:      labelName,
+						Operator: op,
+						Values:   parts,
+					})
+					logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %s) to Pod Selector (matchExpressions).", source, op))
 					continue
 				}
-
-				// Multiple values (or any "action: drop" set) translate to matchExpressions (In / NotIn).
-				op := metav1.LabelSelectorOpIn
-				if action == "drop" {
-					op = metav1.LabelSelectorOpNotIn
-				}
-				res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
-					Key:      labelName,
-					Operator: op,
-					Values:   parts,
-				})
-				logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %s) to Pod Selector (matchExpressions).", source, op))
-				continue
 			}
 		}
 
@@ -244,7 +247,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 
 		if isSimpleCopy {
 			source := string(config.SourceLabels[0])
-			target := configs[i].TargetLabel
+			target := targetLabel
 
 			// Simple pod target label transfer.
 			if len(podSources) == 1 {
@@ -270,11 +273,6 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			res.FromPod = append(res.FromPod, monitoringv1.LabelMapping{From: p})
 		}
 		rawMetadata = append(rawMetadata, metaSources...)
-
-		targetLabel := config.TargetLabel
-		if protectedLabels[targetLabel] {
-			targetLabel = "exported_" + targetLabel
-		}
 
 		promoted := monitoringv1.RelabelingRule{
 			SourceLabels: rewrittenSources,
@@ -307,7 +305,7 @@ func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1
 	for _, ep := range endpoints {
 		var r PreScrapeRelabelingResult
 		if len(ep.RelabelConfigs) > 0 {
-			r = convertPreScrapeRelabelings(logger, ep.RelabelConfigs)
+			r = convertPreScrapeRelabelings(logger, ep.RelabelConfigs, len(endpoints) == 1)
 			combined.FromPod = append(combined.FromPod, r.FromPod...)
 			if r.Metadata != nil {
 				rawMetadata = append(rawMetadata, *r.Metadata...)

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -189,14 +189,6 @@ relabelLoop:
 			continue relabelLoop
 		}
 
-		// Change protected labels to exported_<label>.
-		targetLabel := config.TargetLabel
-		if protectedLabels[targetLabel] {
-			oldTarget := targetLabel
-			targetLabel = "exported_" + oldTarget
-			logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.", oldTarget, targetLabel))
-		}
-
 		// Resolve all source labels upfront and intercept unsupported internal discovery labels.
 		podSources, metaSources, rewrittenSources, unsupported := resolveSourceLabels(logger, config.SourceLabels)
 		if unsupported {
@@ -206,7 +198,7 @@ relabelLoop:
 		data := &relabelingData{
 			config:           config,
 			action:           action,
-			targetLabel:      targetLabel,
+			targetLabel:      config.TargetLabel,
 			podSources:       podSources,
 			metaSources:      metaSources,
 			rewrittenSources: rewrittenSources,
@@ -831,8 +823,17 @@ func convertRelabelingToSimpleCopy(logger *slog.Logger, data *relabelingData, re
 	target := data.targetLabel
 
 	if len(data.podSources) == 1 {
-		mapping := monitoringv1.LabelMapping{From: data.podSources[0]}
-		if target != data.podSources[0] {
+		source := data.podSources[0]
+		target := data.targetLabel
+
+		if protectedLabels[target] {
+			oldTarget := target
+			target = "exported_" + oldTarget
+			logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.", oldTarget, target))
+		}
+
+		mapping := monitoringv1.LabelMapping{From: source}
+		if target != source {
 			mapping.To = target
 		}
 		res.FromPod = append(res.FromPod, mapping)
@@ -856,9 +857,16 @@ func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingDa
 	}
 	*rawMetadata = append(*rawMetadata, data.metaSources...)
 
+	targetLabel := data.targetLabel
+	if protectedLabels[targetLabel] {
+		oldTarget := targetLabel
+		targetLabel = "exported_" + oldTarget
+		logger.Warn(fmt.Sprintf("Relabeling rule attempts to write to protected target label %q. Renamed target to %q.", oldTarget, targetLabel))
+	}
+
 	promoted := monitoringv1.RelabelingRule{
 		SourceLabels: data.rewrittenSources,
-		TargetLabel:  data.targetLabel,
+		TargetLabel:  targetLabel,
 		Regex:        data.config.Regex,
 		Modulus:      data.config.Modulus,
 		Action:       string(data.action),

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -58,6 +58,15 @@ type PreScrapeRelabelingResult struct {
 	Metadata         *[]string
 	MatchLabels      map[string]string
 	MatchExpressions []metav1.LabelSelectorRequirement
+	PromotedRules    []monitoringv1.RelabelingRule
+}
+
+// ExtractedPreScrapeRules holds all translated rules, separated by where they belong in GMP.
+type ExtractedPreScrapeRules struct {
+	// PerEndpoint contains the rules (like promoted metric relabelings) specific to each scrape endpoint.
+	PerEndpoint []PreScrapeRelabelingResult
+	// ResourceCombined contains target labels and selectors merged across all endpoints.
+	ResourceCombined PreScrapeRelabelingResult
 }
 
 // BuildTypeMeta constructs standard TypeMeta for a GMP resource Kind.
@@ -165,18 +174,23 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		// Resolve all source labels upfront and intercept unsupported internal discovery labels.
 		var podSources []string
 		var metaSources []string
+		var rewrittenSources []string
 		var unsupportedInternal bool
 
 		for _, sl := range config.SourceLabels {
 			s := string(sl)
 			if labelName, found := strings.CutPrefix(s, "__meta_kubernetes_pod_label_"); found {
 				podSources = append(podSources, labelName)
+				rewrittenSources = append(rewrittenSources, labelName)
 			} else if gmpMeta, ok := metadataLabelMap[s]; ok {
 				metaSources = append(metaSources, gmpMeta)
+				rewrittenSources = append(rewrittenSources, gmpMeta)
 			} else if strings.HasPrefix(s, "__") {
 				logger.Warn(fmt.Sprintf("Relabeling rule references internal label %q which is not available in post-scrape metricRelabeling. The rule cannot be migrated and has been dropped.", s))
 				unsupportedInternal = true
 				break
+			} else {
+				rewrittenSources = append(rewrittenSources, s)
 			}
 		}
 		if unsupportedInternal {
@@ -194,7 +208,6 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 				clean = clean[1 : len(clean)-1]
 			}
 			// Verify that the remaining string contains no regex metacharacters (*, +, ?, [, ], etc.).
-			// TODO: Defer to post-scrape metricRelabeling in that case.
 			if clean != "" && !strings.ContainsAny(clean, "*+?[]{}()\\^$.") {
 				parts := strings.Split(clean, "|")
 				// A single value with "action: keep" translates to matchLabels.
@@ -250,6 +263,33 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 				continue
 			}
 		}
+
+		// Phase 3: Promote complex or value-changing rules to post-scrape metricRelabeling.
+		for _, p := range podSources {
+			res.FromPod = append(res.FromPod, monitoringv1.LabelMapping{From: p})
+		}
+		rawMetadata = append(rawMetadata, metaSources...)
+
+		targetLabel := config.TargetLabel
+		if protectedLabels[targetLabel] {
+			targetLabel = "exported_" + targetLabel
+		}
+
+		promoted := monitoringv1.RelabelingRule{
+			SourceLabels: rewrittenSources,
+			TargetLabel:  targetLabel,
+			Regex:        config.Regex,
+			Modulus:      config.Modulus,
+			Action:       action,
+		}
+		if config.Separator != nil {
+			promoted.Separator = *config.Separator
+		}
+		if config.Replacement != nil {
+			promoted.Replacement = *config.Replacement
+		}
+		res.PromotedRules = append(res.PromotedRules, promoted)
+		logger.Info(fmt.Sprintf("Complex relabeling rule (target: %q) promoted from pre-scrape 'relabelings' to post-scrape 'metricRelabeling'.", targetLabel))
 	}
 
 	if len(rawMetadata) > 0 {
@@ -258,25 +298,28 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 	return res
 }
 
-// extractPreScrapeRelabelings loops through endpoints to extract all pre-scrape target label and selector rules.
-func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1.PodMetricsEndpoint) PreScrapeRelabelingResult {
-	var res PreScrapeRelabelingResult
+// extractPreScrapeRelabelings evaluates pre-scrape rules once per endpoint, returning consolidated endpoint and resource-level results.
+func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1.PodMetricsEndpoint) ExtractedPreScrapeRules {
+	var epResults []PreScrapeRelabelingResult
+	var combined PreScrapeRelabelingResult
 	var rawMetadata []string
 	for _, ep := range endpoints {
+		var r PreScrapeRelabelingResult
 		if len(ep.RelabelConfigs) > 0 {
-			r := convertPreScrapeRelabelings(logger, ep.RelabelConfigs)
-			res.FromPod = append(res.FromPod, r.FromPod...)
+			r = convertPreScrapeRelabelings(logger, ep.RelabelConfigs)
+			combined.FromPod = append(combined.FromPod, r.FromPod...)
 			if r.Metadata != nil {
 				rawMetadata = append(rawMetadata, *r.Metadata...)
 			}
-			if len(r.MatchLabels) > 0 && res.MatchLabels == nil {
-				res.MatchLabels = make(map[string]string)
+			if len(r.MatchLabels) > 0 && combined.MatchLabels == nil {
+				combined.MatchLabels = make(map[string]string)
 			}
 			for k, v := range r.MatchLabels {
-				res.MatchLabels[k] = v
+				combined.MatchLabels[k] = v
 			}
-			res.MatchExpressions = append(res.MatchExpressions, r.MatchExpressions...)
+			combined.MatchExpressions = append(combined.MatchExpressions, r.MatchExpressions...)
 		}
+		epResults = append(epResults, r)
 	}
 
 	if len(rawMetadata) > 0 {
@@ -289,9 +332,12 @@ func extractPreScrapeRelabelings(logger *slog.Logger, endpoints []pomonitoringv1
 			}
 		}
 		slices.Sort(sortedMd)
-		res.Metadata = &sortedMd
+		combined.Metadata = &sortedMd
 	}
-	return res
+	return ExtractedPreScrapeRules{
+		PerEndpoint:      epResults,
+		ResourceCombined: combined,
+	}
 }
 
 // mergeLabelSelector combines base selector requirements with extracted pre-scrape filtering rules.

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -27,6 +27,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	actionReplace   = "replace"
+	actionKeep      = "keep"
+	actionDrop      = "drop"
+	actionLabelMap  = "labelmap"
+	actionLabelKeep = "labelkeep"
+	actionLabelDrop = "labeldrop"
+	actionHashMod   = "hashmod"
+	actionLowercase = "lowercase"
+	actionUppercase = "uppercase"
 )
 
 // protectedLabels contains the list of labels that are protected by GMP and cannot
@@ -136,6 +149,16 @@ func (c *conversionContext) getGeneratedSecrets() []*unstructured.Unstructured {
 	return secrets
 }
 
+// isValidLabelValues checks whether all strings in parts satisfy Kubernetes label value validation.
+func isValidLabelValues(parts []string) bool {
+	for _, p := range parts {
+		if errs := validation.IsValidLabelValue(p); len(errs) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // convertPreScrapeRelabelings evaluates pre-scrape relabelings on a single endpoint and extracts target label and selector rules.
 func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.RelabelConfig, isSingleEndpoint bool) PreScrapeRelabelingResult {
 	var res PreScrapeRelabelingResult
@@ -144,11 +167,11 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 	for _, config := range configs {
 		action := strings.ToLower(config.Action)
 		if action == "" {
-			action = "replace"
+			action = actionReplace
 		}
 
 		switch action {
-		case "labelmap", "labelkeep", "labeldrop":
+		case actionLabelMap, actionLabelKeep, actionLabelDrop:
 			logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' which is not supported by GMP and has been dropped.", action))
 			continue
 		}
@@ -201,7 +224,7 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		// Translate target filtering ("keep" and "drop") rules on pod labels to Kubernetes label selectors.
-		if isSingleEndpoint && (action == "keep" || action == "drop") && len(podSources) == 1 && len(config.SourceLabels) == 1 {
+		if isSingleEndpoint && (action == actionKeep || action == actionDrop) && len(podSources) == 1 && len(config.SourceLabels) == 1 {
 			source := string(config.SourceLabels[0])
 			labelName := podSources[0]
 			// Strip optional regex start (^) and end ($) anchors (ex. "^production$" -> "production").
@@ -210,41 +233,39 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 			if strings.HasPrefix(clean, "(") && strings.HasSuffix(clean, ")") {
 				clean = clean[1 : len(clean)-1]
 			}
-			// Verify that the remaining string contains no regex metacharacters (*, +, ?, [, ], etc.).
-			if clean != "" && !strings.ContainsAny(clean, "*+?[]{}()\\^$.") {
-				parts := strings.Split(clean, "|")
-				if !slices.Contains(parts, "") {
-					// A single value with "action: keep" translates to matchLabels.
-					if action == "keep" && len(parts) == 1 {
-						if res.MatchLabels == nil {
-							res.MatchLabels = make(map[string]string)
-						}
-						res.MatchLabels[labelName] = parts[0]
-						logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %q) to Pod Selector (matchLabels).", source, parts[0]))
-						continue
+			parts := strings.Split(clean, "|")
+			// Verify that the remaining string contains no regex metacharacters (*, +, ?, [, ], etc.) and valid K8s label values.
+			if !strings.ContainsAny(clean, "*+?[]{}()\\^$.") && !slices.Contains(parts, "") && isValidLabelValues(parts) {
+				// A single value with "action: keep" translates to matchLabels.
+				if action == actionKeep && len(parts) == 1 {
+					if res.MatchLabels == nil {
+						res.MatchLabels = make(map[string]string)
 					}
-
-					// Multiple values (or any "action: drop" set) translate to matchExpressions (In / NotIn).
-					op := metav1.LabelSelectorOpIn
-					if action == "drop" {
-						op = metav1.LabelSelectorOpNotIn
-					}
-					res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
-						Key:      labelName,
-						Operator: op,
-						Values:   parts,
-					})
-					logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %s) to Pod Selector (matchExpressions).", source, op))
+					res.MatchLabels[labelName] = parts[0]
+					logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %q) to Pod Selector (matchLabels).", source, parts[0]))
 					continue
 				}
+
+				// Multiple values (or any "action: drop" set) translate to matchExpressions (In / NotIn).
+				op := metav1.LabelSelectorOpIn
+				if action == actionDrop {
+					op = metav1.LabelSelectorOpNotIn
+				}
+				res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
+					Key:      labelName,
+					Operator: op,
+					Values:   parts,
+				})
+				logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %s) to Pod Selector (matchExpressions).", source, op))
+				continue
 			}
 		}
 
 		// Relabeling rule equivalent of simply copying over a label.
 		isSimpleCopy := len(config.SourceLabels) == 1 &&
 			(config.Regex == "" || config.Regex == "(.*)") &&
-			(config.Replacement == nil || *config.Replacement == "" || *config.Replacement == "$1") &&
-			action == "replace"
+			(config.Replacement == nil || *config.Replacement == "$1") &&
+			action == actionReplace
 
 		if isSimpleCopy {
 			source := string(config.SourceLabels[0])
@@ -679,15 +700,15 @@ func convertMetricRelabelings(
 	for _, config := range configs {
 		action := strings.ToLower(config.Action)
 		if action == "" {
-			action = "replace"
+			action = actionReplace
 		}
 
 		targetLabel := config.TargetLabel
 		switch action {
-		case "labelmap":
+		case actionLabelMap:
 			logger.Warn("metricRelabelings rule uses 'action: labelmap' which is not supported by GMP and has been dropped.")
 			continue
-		case "replace", "hashmod", "lowercase", "uppercase":
+		case actionReplace, actionHashMod, actionLowercase, actionUppercase:
 			if protectedLabels[config.TargetLabel] {
 				targetLabel = "exported_" + config.TargetLabel
 				logger.Warn("Relabeling rule attempts to write to protected target label. Renamed target.",

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -40,31 +40,48 @@ const (
 	actionHashMod   = "hashmod"
 	actionLowercase = "lowercase"
 	actionUppercase = "uppercase"
+
+	labelCluster                = "cluster"
+	labelLocation               = "location"
+	labelProjectID              = "project_id"
+	labelNamespace              = "namespace"
+	labelJob                    = "job"
+	labelInstance               = "instance"
+	labelContainer              = "container"
+	labelNode                   = "node"
+	labelPod                    = "pod"
+	labelTopLevelController     = "top_level_controller"
+	labelTopLevelControllerName = "top_level_controller_name"
+	labelTopLevelControllerType = "top_level_controller_type"
+	labelAddress                = "__address__"
 )
 
-// protectedLabels contains the list of labels that are protected by GMP and cannot
-// be overwritten by targetLabels or relabeling rules.
-var protectedLabels = map[string]bool{
-	"project_id":                true,
-	"location":                  true,
-	"cluster":                   true,
-	"namespace":                 true,
-	"job":                       true,
-	"instance":                  true,
-	"top_level_controller":      true,
-	"top_level_controller_type": true,
-	"__address__":               true,
-}
+var (
+	// protectedLabels contains the list of labels that are protected by GMP and cannot
+	// be overwritten by targetLabels or relabeling rules.
+	protectedLabels = map[string]bool{
+		labelProjectID:              true,
+		labelLocation:               true,
+		labelCluster:                true,
+		labelNamespace:              true,
+		labelJob:                    true,
+		labelInstance:               true,
+		labelTopLevelController:     true,
+		labelTopLevelControllerName: true,
+		labelTopLevelControllerType: true,
+		labelAddress:                true,
+	}
 
-// metadataLabelMap contains the list of PO metadata labels and their GMP equivalent.
-var metadataLabelMap = map[string]string{
-	"__meta_kubernetes_pod_name":            "pod",
-	"__meta_kubernetes_pod_container_name":  "container",
-	"__meta_kubernetes_pod_node_name":       "node",
-	"__meta_kubernetes_namespace":           "namespace",
-	"__meta_kubernetes_pod_controller_name": "top_level_controller_name",
-	"__meta_kubernetes_pod_controller_kind": "top_level_controller_type",
-}
+	// metadataLabelMap contains the list of PO metadata labels and their GMP equivalent.
+	metadataLabelMap = map[string]string{
+		"__meta_kubernetes_pod_name":            labelPod,
+		"__meta_kubernetes_pod_container_name":  labelContainer,
+		"__meta_kubernetes_pod_node_name":       labelNode,
+		"__meta_kubernetes_namespace":           labelNamespace,
+		"__meta_kubernetes_pod_controller_name": labelTopLevelControllerName,
+		"__meta_kubernetes_pod_controller_kind": labelTopLevelControllerType,
+	}
+)
 
 // PreScrapeRelabelingResult holds the label mappings and selector rules extracted from pre-scrape relabelings.
 type PreScrapeRelabelingResult struct {

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -32,7 +32,6 @@ import (
 )
 
 const (
-
 	labelCluster                = "cluster"
 	labelLocation               = "location"
 	labelProjectID              = "project_id"
@@ -74,6 +73,15 @@ var (
 		"__meta_kubernetes_pod_controller_kind": labelTopLevelControllerType,
 	}
 )
+
+type relabelingData struct {
+	config           pomonitoringv1.RelabelConfig
+	action           relabel.Action
+	targetLabel      string
+	podSources       []string
+	metaSources      []string
+	rewrittenSources []string
+}
 
 // PreScrapeRelabelingResult holds the label mappings and selector rules extracted from pre-scrape relabelings.
 type PreScrapeRelabelingResult struct {
@@ -175,29 +183,15 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		rawMetadata []string
 	)
 
+relabelLoop:
 	for _, config := range configs {
 		action := relabel.Action(strings.ToLower(config.Action))
 		if action == "" {
 			action = relabel.Replace
 		}
 
-		switch action {
-		case relabel.LabelMap, relabel.LabelKeep, relabel.LabelDrop:
-			logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' which is not supported by GMP and has been dropped.", action))
-			continue
-		}
-
-		// Relabeling rules on annotations cannot be migrated.
-		var anno string
-		for _, sl := range config.SourceLabels {
-			if strings.HasPrefix(string(sl), "__meta_kubernetes_pod_annotation_") {
-				anno = string(sl)
-				break
-			}
-		}
-		if anno != "" {
-			logger.Warn(fmt.Sprintf("Relabeling rule referencing pod annotation %q is unsupported in GMP. The rule has been dropped.", anno))
-			continue
+		if shouldSkipRelabelConfig(logger, config, action) {
+			continue relabelLoop
 		}
 
 		// Change protected labels to exported_<label>.
@@ -209,121 +203,32 @@ func convertPreScrapeRelabelings(logger *slog.Logger, configs []pomonitoringv1.R
 		}
 
 		// Resolve all source labels upfront and intercept unsupported internal discovery labels.
-		var (
-			podSources          []string
-			metaSources         []string
-			rewrittenSources    []string
-			unsupportedInternal bool
-		)
-
-		for _, sl := range config.SourceLabels {
-			s := string(sl)
-			if labelName, found := strings.CutPrefix(s, "__meta_kubernetes_pod_label_"); found {
-				podSources = append(podSources, labelName)
-				rewrittenSources = append(rewrittenSources, labelName)
-			} else if gmpMeta, ok := metadataLabelMap[s]; ok {
-				metaSources = append(metaSources, gmpMeta)
-				rewrittenSources = append(rewrittenSources, gmpMeta)
-			} else if strings.HasPrefix(s, "__") {
-				logger.Warn(fmt.Sprintf("Relabeling rule references internal label %q which is not available in post-scrape metricRelabeling. The rule cannot be migrated and has been dropped.", s))
-				unsupportedInternal = true
-				break
-			} else {
-				rewrittenSources = append(rewrittenSources, s)
-			}
-		}
-		if unsupportedInternal {
-			continue
+		podSources, metaSources, rewrittenSources, unsupported := resolveSourceLabels(logger, config.SourceLabels)
+		if unsupported {
+			continue relabelLoop
 		}
 
-		// Translate target filtering ("keep" and "drop") rules on pod labels to Kubernetes label selectors.
-		if isSingleEndpoint && (action == relabel.Keep || action == relabel.Drop) && len(podSources) == 1 && len(config.SourceLabels) == 1 {
-			source := string(config.SourceLabels[0])
-			labelName := podSources[0]
-			// Strip optional regex start (^) and end ($) anchors (ex. "^production$" -> "production").
-			clean := strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(config.Regex), "$"), "^")
-			// Strip outer grouping parentheses around literal lists (ex. "(test|staging)" -> "test|staging").
-			if strings.HasPrefix(clean, "(") && strings.HasSuffix(clean, ")") {
-				clean = clean[1 : len(clean)-1]
-			}
-			parts := strings.Split(clean, "|")
-			// Verify that the remaining string contains no regex metacharacters (*, +, ?, [, ], etc.) and valid K8s label values.
-			if !strings.ContainsAny(clean, "*+?[]{}()\\^$.") && !slices.Contains(parts, "") && isValidLabelValues(parts) {
-				// A single value with "action: keep" translates to matchLabels.
-				if action == relabel.Keep && len(parts) == 1 {
-					if res.MatchLabels == nil {
-						res.MatchLabels = make(map[string]string)
-					}
-					res.MatchLabels[labelName] = parts[0]
-					logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %q) to Pod Selector (matchLabels).", source, parts[0]))
-					continue
-				}
-
-				// Multiple values (or any "action: drop" set) translate to matchExpressions (In / NotIn).
-				op := metav1.LabelSelectorOpIn
-				if action == relabel.Drop {
-					op = metav1.LabelSelectorOpNotIn
-				}
-				res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
-					Key:      labelName,
-					Operator: op,
-					Values:   parts,
-				})
-				logger.Info(fmt.Sprintf("Translated target filtering relabeling rule (%q -> %s) to Pod Selector (matchExpressions).", source, op))
-				continue
-			}
+		data := &relabelingData{
+			config:           config,
+			action:           action,
+			targetLabel:      targetLabel,
+			podSources:       podSources,
+			metaSources:      metaSources,
+			rewrittenSources: rewrittenSources,
 		}
 
-		// Relabeling rule equivalent of simply copying over a label.
-		isSimpleCopy := len(config.SourceLabels) == 1 &&
-			(config.Regex == "" || config.Regex == "(.*)") &&
-			(config.Replacement == nil || *config.Replacement == "$1") &&
-			action == relabel.Replace
-
-		if isSimpleCopy {
-			source := string(config.SourceLabels[0])
-			target := targetLabel
-
-			// Simple pod target label transfer.
-			if len(podSources) == 1 {
-				mapping := monitoringv1.LabelMapping{From: podSources[0]}
-				if target != podSources[0] {
-					mapping.To = target
-				}
-				res.FromPod = append(res.FromPod, mapping)
-				logger.Info(fmt.Sprintf("Translated simple label copy relabeling rule (%q -> %q) to 'targetLabels.fromPod'.", source, target))
-				continue
-			}
-
-			// Simple metadata label transfer.
-			if len(metaSources) == 1 && target == metaSources[0] {
-				rawMetadata = append(rawMetadata, metaSources[0])
-				logger.Info(fmt.Sprintf("Translated metadata label copy (%q) to 'targetLabels.metadata' (as label: %q).", source, metaSources[0]))
-				continue
-			}
+		// Convert target filtering ("keep" and "drop") rules on pod labels to Kubernetes label selectors.
+		if convertRelabelingToSelector(logger, data, isSingleEndpoint, &res) {
+			continue relabelLoop
 		}
 
-		// Phase 3: Promote complex or value-changing rules to post-scrape metricRelabeling.
-		for _, p := range podSources {
-			res.FromPod = append(res.FromPod, monitoringv1.LabelMapping{From: p})
+		// Convert simple label copy rules to targetLabels (fromPod or metadata).
+		if convertRelabelingToSimpleCopy(logger, data, &res, &rawMetadata) {
+			continue relabelLoop
 		}
-		rawMetadata = append(rawMetadata, metaSources...)
 
-		promoted := monitoringv1.RelabelingRule{
-			SourceLabels: rewrittenSources,
-			TargetLabel:  targetLabel,
-			Regex:        config.Regex,
-			Modulus:      config.Modulus,
-			Action:       string(action),
-		}
-		if config.Separator != nil {
-			promoted.Separator = *config.Separator
-		}
-		if config.Replacement != nil {
-			promoted.Replacement = *config.Replacement
-		}
-		res.PromotedRules = append(res.PromotedRules, promoted)
-		logger.Info(fmt.Sprintf("Complex relabeling rule (target: %q) promoted from pre-scrape 'relabelings' to post-scrape 'metricRelabeling'.", targetLabel))
+		// Convert complex or value-changing rules to post-scrape metricRelabeling.
+		convertRelabelingToMetricRelabeling(logger, data, &res, &rawMetadata)
 	}
 
 	if len(rawMetadata) > 0 {
@@ -810,4 +715,141 @@ func convertTargetLabels(logger *slog.Logger, sourceLabels []string, jobLabel st
 	}
 
 	return fromPod
+}
+
+// shouldSkipRelabelConfig checks if the relabel config uses unsupported actions or references annotations.
+func shouldSkipRelabelConfig(logger *slog.Logger, config pomonitoringv1.RelabelConfig, action relabel.Action) bool {
+	switch action {
+	case relabel.LabelMap, relabel.LabelKeep, relabel.LabelDrop:
+		logger.Warn(fmt.Sprintf("Relabeling rule uses 'action: %s' which is not supported by GMP and has been dropped.", action))
+		return true
+	}
+
+	for _, sl := range config.SourceLabels {
+		if strings.HasPrefix(string(sl), "__meta_kubernetes_pod_annotation_") {
+			logger.Warn(fmt.Sprintf("Relabeling rule referencing pod annotation %q is unsupported in GMP. The rule has been dropped.", string(sl)))
+			return true
+		}
+	}
+	return false
+}
+
+// resolveSourceLabels resolves source labels to pod labels, metadata labels, and rewritten labels.
+// Returns unsupported=true if it encounters an unsupported internal label.
+func resolveSourceLabels(logger *slog.Logger, sourceLabels []pomonitoringv1.LabelName) (podSources []string, metaSources []string, rewrittenSources []string, unsupported bool) {
+	for _, sl := range sourceLabels {
+		s := string(sl)
+		if labelName, found := strings.CutPrefix(s, "__meta_kubernetes_pod_label_"); found {
+			podSources = append(podSources, labelName)
+			rewrittenSources = append(rewrittenSources, labelName)
+			continue
+		}
+		if gmpMeta, ok := metadataLabelMap[s]; ok {
+			metaSources = append(metaSources, gmpMeta)
+			rewrittenSources = append(rewrittenSources, gmpMeta)
+			continue
+		}
+		// TODO(kunnikrishnan): Support __meta_kubernetes_pod_labelpresent_<labelname> in the future.
+		if strings.HasPrefix(s, "__") {
+			logger.Warn(fmt.Sprintf("Relabeling rule referencing internal label %q is unsupported in GMP. The rule has been dropped.", s))
+			return nil, nil, nil, true
+		}
+		rewrittenSources = append(rewrittenSources, s)
+	}
+	return podSources, metaSources, rewrittenSources, false
+}
+
+// convertRelabelingToSelector attempts to convert target filtering (keep/drop) rules to pod selectors.
+func convertRelabelingToSelector(logger *slog.Logger, data *relabelingData, isSingleEndpoint bool, res *PreScrapeRelabelingResult) bool {
+	if !isSingleEndpoint || (data.action != relabel.Keep && data.action != relabel.Drop) || len(data.podSources) != 1 || len(data.config.SourceLabels) != 1 {
+		return false
+	}
+	source := string(data.config.SourceLabels[0])
+	labelName := data.podSources[0]
+	clean := strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(data.config.Regex), "$"), "^")
+	if strings.HasPrefix(clean, "(") && strings.HasSuffix(clean, ")") {
+		clean = clean[1 : len(clean)-1]
+	}
+	parts := strings.Split(clean, "|")
+	if strings.ContainsAny(clean, "*+?[]{}()\\^$.") || slices.Contains(parts, "") || !isValidLabelValues(parts) {
+		return false
+	}
+
+	if data.action == relabel.Keep && len(parts) == 1 {
+		if res.MatchLabels == nil {
+			res.MatchLabels = make(map[string]string)
+		}
+		res.MatchLabels[labelName] = parts[0]
+		logger.Info(fmt.Sprintf("Converted target filtering relabeling rule (%q -> %q) to Pod Selector (matchLabels).", source, parts[0]))
+		return true
+	}
+
+	op := metav1.LabelSelectorOpIn
+	if data.action == relabel.Drop {
+		op = metav1.LabelSelectorOpNotIn
+	}
+	res.MatchExpressions = append(res.MatchExpressions, metav1.LabelSelectorRequirement{
+		Key:      labelName,
+		Operator: op,
+		Values:   parts,
+	})
+	logger.Info(fmt.Sprintf("Converted target filtering relabeling rule (%q -> %s) to Pod Selector (matchExpressions).", source, op))
+	return true
+}
+
+// convertRelabelingToSimpleCopy attempts to convert simple label copy rules to targetLabels (fromPod or metadata).
+func convertRelabelingToSimpleCopy(logger *slog.Logger, data *relabelingData, res *PreScrapeRelabelingResult, rawMetadata *[]string) bool {
+	isSimpleCopy := len(data.config.SourceLabels) == 1 &&
+		(data.config.Regex == "" || data.config.Regex == "(.*)") &&
+		(data.config.Replacement == nil || *data.config.Replacement == "$1") &&
+		data.action == relabel.Replace
+
+	if !isSimpleCopy {
+		return false
+	}
+
+	source := string(data.config.SourceLabels[0])
+	target := data.targetLabel
+
+	if len(data.podSources) == 1 {
+		mapping := monitoringv1.LabelMapping{From: data.podSources[0]}
+		if target != data.podSources[0] {
+			mapping.To = target
+		}
+		res.FromPod = append(res.FromPod, mapping)
+		logger.Info(fmt.Sprintf("Converted simple label copy relabeling rule (%q -> %q) to 'targetLabels.fromPod'.", source, target))
+		return true
+	}
+
+	if len(data.metaSources) == 1 && target == data.metaSources[0] {
+		*rawMetadata = append(*rawMetadata, data.metaSources[0])
+		logger.Info(fmt.Sprintf("Converted metadata label copy (%q) to 'targetLabels.metadata' (as label: %q).", source, data.metaSources[0]))
+		return true
+	}
+
+	return false
+}
+
+// convertRelabelingToMetricRelabeling converts a rule to post-scrape metricRelabeling.
+func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingData, res *PreScrapeRelabelingResult, rawMetadata *[]string) {
+	for _, p := range data.podSources {
+		res.FromPod = append(res.FromPod, monitoringv1.LabelMapping{From: p})
+	}
+	*rawMetadata = append(*rawMetadata, data.metaSources...)
+
+	promoted := monitoringv1.RelabelingRule{
+		SourceLabels: data.rewrittenSources,
+		TargetLabel:  data.targetLabel,
+		Regex:        data.config.Regex,
+		Modulus:      data.config.Modulus,
+		Action:       string(data.action),
+	}
+	if data.config.Separator != nil {
+		promoted.Separator = *data.config.Separator
+	}
+	if data.config.Replacement != nil {
+		promoted.Replacement = *data.config.Replacement
+	}
+	res.PromotedRules = append(res.PromotedRules, promoted)
+	logger.Info(fmt.Sprintf("Complex relabeling rule (target: %q) promoted from pre-scrape 'relabelings' to post-scrape 'metricRelabeling'.", data.targetLabel))
 }

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -545,9 +545,9 @@ func TestMergeFromPod(t *testing.T) {
 	merged := mergeFromPod(logger, staticTargetLabels, relabelFromPod)
 
 	expected := []monitoringv1.LabelMapping{
-		{From: "app", To: "application"},
 		{From: "env"},
 		{From: "tier"},
+		{From: "app", To: "application"},
 	}
 
 	if diff := cmp.Diff(expected, merged); diff != "" {

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"testing"
 
+	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
+	"github.com/google/go-cmp/cmp"
 	pomonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -524,5 +526,31 @@ func TestConvertConfigMapToSecretSelectorDeduplication(t *testing.T) {
 	genSecrets := ctx.getGeneratedSecrets()
 	if len(genSecrets) != 1 {
 		t.Fatalf("expected exactly 1 generated secret due to duplication, got %d", len(genSecrets))
+	}
+}
+
+func TestMergeFromPod(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	staticTargetLabels := []monitoringv1.LabelMapping{
+		{From: "app", To: "application"},
+		{From: "env"},
+	}
+
+	relabelFromPod := []monitoringv1.LabelMapping{
+		{From: "env"}, // Duplicate, should be deduplicated.
+		{From: "tier"},
+	}
+
+	merged := mergeFromPod(logger, staticTargetLabels, relabelFromPod)
+
+	expected := []monitoringv1.LabelMapping{
+		{From: "app", To: "application"},
+		{From: "env"},
+		{From: "tier"},
+	}
+
+	if diff := cmp.Diff(expected, merged); diff != "" {
+		t.Errorf("mergeFromPod mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -165,13 +165,18 @@ func (c *PodMonitorConverter) convertEndpoints(
 		// TODO(M2): Inherit global scrape timeout from Prometheus CR if empty.
 
 		// 4. Relabeling Rules (Promoted Pre-Scrape + MetricRelabelings).
-		allRules := epResults[i].PromotedRules
-		if len(ep.MetricRelabelConfigs) > 0 {
-			rules, err := convertMetricRelabelings(convCtx.logger, ep.MetricRelabelConfigs)
-			if err != nil {
-				return nil, fmt.Errorf("endpoint [%d]: %w", i, err)
+		totalRules := len(epResults[i].PromotedRules) + len(ep.MetricRelabelConfigs)
+		var allRules []monitoringv1.RelabelingRule
+		if totalRules > 0 {
+			allRules = make([]monitoringv1.RelabelingRule, 0, totalRules)
+			allRules = append(allRules, epResults[i].PromotedRules...)
+			if len(ep.MetricRelabelConfigs) > 0 {
+				rules, err := convertMetricRelabelings(convCtx.logger, ep.MetricRelabelConfigs)
+				if err != nil {
+					return nil, fmt.Errorf("endpoint [%d]: %w", i, err)
+				}
+				allRules = append(allRules, rules...)
 			}
-			allRules = append(allRules, rules...)
 		}
 		gmpEp.MetricRelabeling = allRules
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -296,7 +296,7 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 			if m != export.KeyNamespace {
 				md = append(md, m)
 			} else {
-				logger.Warn("Relabeling rule referencing namespace metadata is unsupported in namespaced PodMonitoring (it is only allowed in ClusterPodMonitoring). The rule has been dropped.")
+				logger.Warn("Relabeling rule referencing namespace metadata is unsupported in namespaced PodMonitoring (it is only allowed in ClusterPodMonitoring). The metadata entry has been omitted .")
 			}
 		}
 		if len(md) > 0 {

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -267,6 +267,9 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 
 	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), rules.ResourceCombined.FromPod)
 	mergedSelector := mergeLabelSelector(logger, pm.Spec.Selector, rules.ResourceCombined.MatchLabels, rules.ResourceCombined.MatchExpressions)
+	if len(mergedSelector.MatchLabels) == 0 && len(mergedSelector.MatchExpressions) == 0 {
+		logger.Warn("Resulting PodMonitoring selector is empty. It will select and scrape all pods in this namespace. Verify if this is intended.")
+	}
 
 	gmpPM := &monitoringv1.PodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindPodMonitoring),
@@ -307,6 +310,9 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 
 	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), rules.ResourceCombined.FromPod)
 	mergedSelector := mergeLabelSelector(logger, pm.Spec.Selector, rules.ResourceCombined.MatchLabels, rules.ResourceCombined.MatchExpressions)
+	if len(mergedSelector.MatchLabels) == 0 && len(mergedSelector.MatchExpressions) == 0 {
+		logger.Warn("Resulting ClusterPodMonitoring selector is empty. It will select and scrape all pods across all namespaces. Verify if this is intended.")
+	}
 
 	gmpCPM := &monitoringv1.ClusterPodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -163,6 +163,11 @@ func (c *PodMonitorConverter) convertEndpoints(
 		}
 		// TODO(M2): Inherit global scrape timeout from Prometheus CR if empty.
 
+		// Evaluate Pre-Scrape Relabeling Rules (RelabelConfigs).
+		if len(ep.RelabelConfigs) > 0 {
+			convertPreScrapeRelabelings(convCtx, ep.RelabelConfigs)
+		}
+
 		// 4. Relabeling Rules (MetricRelabelings).
 		if len(ep.MetricRelabelConfigs) > 0 {
 			rules, err := convertMetricRelabelings(convCtx.logger, ep.MetricRelabelConfigs)

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -19,14 +19,21 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
+	"github.com/prometheus/prometheus/google/export"
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
 	pomonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	prommodel "github.com/prometheus/common/model"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var (
+	namespacedMetadataDefaults = []string{labelContainer, labelPod, labelTopLevelControllerName, labelTopLevelControllerType}
+	clusterMetadataDefaults    = []string{labelContainer, export.KeyNamespace, labelPod, labelTopLevelControllerName, labelTopLevelControllerType}
 )
 
 // PodMonitorConverter implements ResourceConverter for PodMonitor resources.
@@ -271,6 +278,22 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		logger.Warn("Resulting PodMonitoring selector is empty. It will select and scrape all pods in this namespace. Verify if this is intended.")
 	}
 
+	var filteredMetadata *[]string
+	if rules.ResourceCombined.Metadata != nil {
+		union := unionMetadata(*rules.ResourceCombined.Metadata, namespacedMetadataDefaults)
+		var md []string
+		for _, m := range union {
+			if m != export.KeyNamespace {
+				md = append(md, m)
+			} else {
+				logger.Warn("Relabeling rule referencing namespace metadata is unsupported in namespaced PodMonitoring (it is only allowed in ClusterPodMonitoring). The rule has been dropped.")
+			}
+		}
+		if len(md) > 0 {
+			filteredMetadata = &md
+		}
+	}
+
 	gmpPM := &monitoringv1.PodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindPodMonitoring),
 		ObjectMeta: CopyObjectMeta(pm.ObjectMeta, pm.Namespace, logger),
@@ -279,7 +302,7 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 			Endpoints: endpoints,
 			TargetLabels: monitoringv1.TargetLabels{
 				FromPod:  mergedFromPod,
-				Metadata: rules.ResourceCombined.Metadata,
+				Metadata: filteredMetadata,
 			},
 		},
 	}
@@ -314,6 +337,12 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		logger.Warn("Resulting ClusterPodMonitoring selector is empty. It will select and scrape all pods across all namespaces. Verify if this is intended.")
 	}
 
+	var filteredMetadata *[]string
+	if rules.ResourceCombined.Metadata != nil {
+		union := unionMetadata(*rules.ResourceCombined.Metadata, clusterMetadataDefaults)
+		filteredMetadata = &union
+	}
+
 	gmpCPM := &monitoringv1.ClusterPodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
 		ObjectMeta: CopyObjectMeta(pm.ObjectMeta, "", logger),
@@ -322,7 +351,7 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 			Endpoints: endpoints,
 			TargetLabels: monitoringv1.ClusterTargetLabels{
 				FromPod:  mergedFromPod,
-				Metadata: rules.ResourceCombined.Metadata,
+				Metadata: filteredMetadata,
 			},
 		},
 	}
@@ -337,4 +366,20 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 	u.SetKind(KindClusterPodMonitoring)
 
 	return u, convCtx.getGeneratedSecrets(), nil
+}
+
+func unionMetadata(extracted []string, defaults []string) []string {
+	unique := make(map[string]bool)
+	for _, m := range defaults {
+		unique[m] = true
+	}
+	for _, m := range extracted {
+		unique[m] = true
+	}
+	var res []string
+	for k := range unique {
+		res = append(res, k)
+	}
+	slices.Sort(res)
+	return res
 }

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -270,7 +270,10 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		cache:     cache,
 		namespace: pm.Namespace,
 	}
-	rules := extractPreScrapeRelabelings(logger, pm.Spec.PodMetricsEndpoints)
+	rules, err := extractPreScrapeRelabelings(logger, pm.Spec.PodMetricsEndpoints)
+	if err != nil {
+		return nil, nil, err
+	}
 	endpoints, err := c.convertEndpoints(convCtx, pm.Spec.PodMetricsEndpoints, rules.PerEndpoint)
 	if err != nil {
 		return nil, nil, err
@@ -332,7 +335,10 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		cache:     cache,
 		namespace: pm.Namespace,
 	}
-	rules := extractPreScrapeRelabelings(logger, pm.Spec.PodMetricsEndpoints)
+	rules, err := extractPreScrapeRelabelings(logger, pm.Spec.PodMetricsEndpoints)
+	if err != nil {
+		return nil, nil, err
+	}
 	endpoints, err := c.convertEndpoints(convCtx, pm.Spec.PodMetricsEndpoints, rules.PerEndpoint)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -163,11 +163,6 @@ func (c *PodMonitorConverter) convertEndpoints(
 		}
 		// TODO(M2): Inherit global scrape timeout from Prometheus CR if empty.
 
-		// Evaluate Pre-Scrape Relabeling Rules (RelabelConfigs).
-		if len(ep.RelabelConfigs) > 0 {
-			convertPreScrapeRelabelings(convCtx, ep.RelabelConfigs)
-		}
-
 		// 4. Relabeling Rules (MetricRelabelings).
 		if len(ep.MetricRelabelConfigs) > 0 {
 			rules, err := convertMetricRelabelings(convCtx.logger, ep.MetricRelabelConfigs)
@@ -261,6 +256,9 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		return nil, nil, err
 	}
 
+	fromPod, metadata := extractPreScrapeTargetLabels(logger, pm.Spec.PodMetricsEndpoints)
+	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), fromPod)
+
 	gmpPM := &monitoringv1.PodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindPodMonitoring),
 		ObjectMeta: CopyObjectMeta(pm.ObjectMeta, pm.Namespace, logger),
@@ -268,7 +266,8 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 			Selector:  pm.Spec.Selector,
 			Endpoints: endpoints,
 			TargetLabels: monitoringv1.TargetLabels{
-				FromPod: convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"),
+				FromPod:  mergedFromPod,
+				Metadata: metadata,
 			},
 		},
 	}
@@ -296,6 +295,9 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		return nil, nil, err
 	}
 
+	fromPod, metadata := extractPreScrapeTargetLabels(logger, pm.Spec.PodMetricsEndpoints)
+	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), fromPod)
+
 	gmpCPM := &monitoringv1.ClusterPodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
 		ObjectMeta: CopyObjectMeta(pm.ObjectMeta, "", logger),
@@ -303,7 +305,8 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 			Selector:  pm.Spec.Selector,
 			Endpoints: endpoints,
 			TargetLabels: monitoringv1.ClusterTargetLabels{
-				FromPod: convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"),
+				FromPod:  mergedFromPod,
+				Metadata: metadata,
 			},
 		},
 	}

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -114,6 +114,7 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 func (c *PodMonitorConverter) convertEndpoints(
 	convCtx *conversionContext,
 	endpoints []pomonitoringv1.PodMetricsEndpoint,
+	epResults []PreScrapeRelabelingResult,
 ) ([]monitoringv1.ScrapeEndpoint, error) {
 	var gmpEndpoints []monitoringv1.ScrapeEndpoint
 
@@ -163,14 +164,16 @@ func (c *PodMonitorConverter) convertEndpoints(
 		}
 		// TODO(M2): Inherit global scrape timeout from Prometheus CR if empty.
 
-		// 4. Relabeling Rules (MetricRelabelings).
+		// 4. Relabeling Rules (Promoted Pre-Scrape + MetricRelabelings).
+		allRules := epResults[i].PromotedRules
 		if len(ep.MetricRelabelConfigs) > 0 {
 			rules, err := convertMetricRelabelings(convCtx.logger, ep.MetricRelabelConfigs)
 			if err != nil {
 				return nil, fmt.Errorf("endpoint [%d]: %w", i, err)
 			}
-			gmpEp.MetricRelabeling = rules
+			allRules = append(allRules, rules...)
 		}
+		gmpEp.MetricRelabeling = allRules
 
 		// Proxy Settings.
 		if ep.ProxyURL != nil {
@@ -251,14 +254,14 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		cache:     cache,
 		namespace: pm.Namespace,
 	}
-	endpoints, err := c.convertEndpoints(convCtx, pm.Spec.PodMetricsEndpoints)
+	rules := extractPreScrapeRelabelings(logger, pm.Spec.PodMetricsEndpoints)
+	endpoints, err := c.convertEndpoints(convCtx, pm.Spec.PodMetricsEndpoints, rules.PerEndpoint)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	extracted := extractPreScrapeRelabelings(logger, pm.Spec.PodMetricsEndpoints)
-	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), extracted.FromPod)
-	mergedSelector := mergeLabelSelector(logger, pm.Spec.Selector, extracted.MatchLabels, extracted.MatchExpressions)
+	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), rules.ResourceCombined.FromPod)
+	mergedSelector := mergeLabelSelector(logger, pm.Spec.Selector, rules.ResourceCombined.MatchLabels, rules.ResourceCombined.MatchExpressions)
 
 	gmpPM := &monitoringv1.PodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindPodMonitoring),
@@ -268,7 +271,7 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 			Endpoints: endpoints,
 			TargetLabels: monitoringv1.TargetLabels{
 				FromPod:  mergedFromPod,
-				Metadata: extracted.Metadata,
+				Metadata: rules.ResourceCombined.Metadata,
 			},
 		},
 	}
@@ -291,14 +294,14 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		cache:     cache,
 		namespace: pm.Namespace,
 	}
-	endpoints, err := c.convertEndpoints(convCtx, pm.Spec.PodMetricsEndpoints)
+	rules := extractPreScrapeRelabelings(logger, pm.Spec.PodMetricsEndpoints)
+	endpoints, err := c.convertEndpoints(convCtx, pm.Spec.PodMetricsEndpoints, rules.PerEndpoint)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	extracted := extractPreScrapeRelabelings(logger, pm.Spec.PodMetricsEndpoints)
-	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), extracted.FromPod)
-	mergedSelector := mergeLabelSelector(logger, pm.Spec.Selector, extracted.MatchLabels, extracted.MatchExpressions)
+	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), rules.ResourceCombined.FromPod)
+	mergedSelector := mergeLabelSelector(logger, pm.Spec.Selector, rules.ResourceCombined.MatchLabels, rules.ResourceCombined.MatchExpressions)
 
 	gmpCPM := &monitoringv1.ClusterPodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
@@ -308,7 +311,7 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 			Endpoints: endpoints,
 			TargetLabels: monitoringv1.ClusterTargetLabels{
 				FromPod:  mergedFromPod,
-				Metadata: extracted.Metadata,
+				Metadata: rules.ResourceCombined.Metadata,
 			},
 		},
 	}

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -22,10 +22,10 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/prometheus/prometheus/google/export"
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
 	pomonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	prommodel "github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/google/export"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -121,7 +121,7 @@ func (c *PodMonitorConverter) Convert(_ context.Context, logger *slog.Logger, un
 func (c *PodMonitorConverter) convertEndpoints(
 	convCtx *conversionContext,
 	endpoints []pomonitoringv1.PodMetricsEndpoint,
-	epResults []PreScrapeRelabelingResult,
+	epResults []preScrapeRelabelingResult,
 ) ([]monitoringv1.ScrapeEndpoint, error) {
 	var gmpEndpoints []monitoringv1.ScrapeEndpoint
 
@@ -273,7 +273,10 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 	}
 
 	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), rules.ResourceCombined.FromPod)
-	mergedSelector := mergeLabelSelector(logger, pm.Spec.Selector, rules.ResourceCombined.MatchLabels, rules.ResourceCombined.MatchExpressions)
+	mergedSelector, err := mergeLabelSelector(pm.Spec.Selector, rules.ResourceCombined.MatchLabels, rules.ResourceCombined.MatchExpressions)
+	if err != nil {
+		return nil, nil, err
+	}
 	if len(mergedSelector.MatchLabels) == 0 && len(mergedSelector.MatchExpressions) == 0 {
 		logger.Warn("Resulting PodMonitoring selector is empty. It will select and scrape all pods in this namespace. Verify if this is intended.")
 	}
@@ -332,7 +335,10 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 	}
 
 	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), rules.ResourceCombined.FromPod)
-	mergedSelector := mergeLabelSelector(logger, pm.Spec.Selector, rules.ResourceCombined.MatchLabels, rules.ResourceCombined.MatchExpressions)
+	mergedSelector, err := mergeLabelSelector(pm.Spec.Selector, rules.ResourceCombined.MatchLabels, rules.ResourceCombined.MatchExpressions)
+	if err != nil {
+		return nil, nil, err
+	}
 	if len(mergedSelector.MatchLabels) == 0 && len(mergedSelector.MatchExpressions) == 0 {
 		logger.Warn("Resulting ClusterPodMonitoring selector is empty. It will select and scrape all pods across all namespaces. Verify if this is intended.")
 	}

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -123,6 +123,10 @@ func (c *PodMonitorConverter) convertEndpoints(
 	endpoints []pomonitoringv1.PodMetricsEndpoint,
 	epResults []preScrapeRelabelingResult,
 ) ([]monitoringv1.ScrapeEndpoint, error) {
+	if len(epResults) != len(endpoints) {
+		return nil, fmt.Errorf("internal error: pre-scrape relabeling results length (%d) does not match endpoints length (%d)", len(epResults), len(endpoints))
+	}
+
 	var gmpEndpoints []monitoringv1.ScrapeEndpoint
 
 	for i, ep := range endpoints {

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -256,18 +256,19 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		return nil, nil, err
 	}
 
-	fromPod, metadata := extractPreScrapeTargetLabels(logger, pm.Spec.PodMetricsEndpoints)
-	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), fromPod)
+	extracted := extractPreScrapeRelabelings(logger, pm.Spec.PodMetricsEndpoints)
+	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), extracted.FromPod)
+	mergedSelector := mergeLabelSelector(logger, pm.Spec.Selector, extracted.MatchLabels, extracted.MatchExpressions)
 
 	gmpPM := &monitoringv1.PodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindPodMonitoring),
 		ObjectMeta: CopyObjectMeta(pm.ObjectMeta, pm.Namespace, logger),
 		Spec: monitoringv1.PodMonitoringSpec{
-			Selector:  pm.Spec.Selector,
+			Selector:  mergedSelector,
 			Endpoints: endpoints,
 			TargetLabels: monitoringv1.TargetLabels{
 				FromPod:  mergedFromPod,
-				Metadata: metadata,
+				Metadata: extracted.Metadata,
 			},
 		},
 	}
@@ -295,18 +296,19 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		return nil, nil, err
 	}
 
-	fromPod, metadata := extractPreScrapeTargetLabels(logger, pm.Spec.PodMetricsEndpoints)
-	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), fromPod)
+	extracted := extractPreScrapeRelabelings(logger, pm.Spec.PodMetricsEndpoints)
+	mergedFromPod := mergeFromPod(logger, convertTargetLabels(logger, pm.Spec.PodTargetLabels, pm.Spec.JobLabel, "Pod"), extracted.FromPod)
+	mergedSelector := mergeLabelSelector(logger, pm.Spec.Selector, extracted.MatchLabels, extracted.MatchExpressions)
 
 	gmpCPM := &monitoringv1.ClusterPodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
 		ObjectMeta: CopyObjectMeta(pm.ObjectMeta, "", logger),
 		Spec: monitoringv1.ClusterPodMonitoringSpec{
-			Selector:  pm.Spec.Selector,
+			Selector:  mergedSelector,
 			Endpoints: endpoints,
 			TargetLabels: monitoringv1.ClusterTargetLabels{
 				FromPod:  mergedFromPod,
-				Metadata: metadata,
+				Metadata: extracted.Metadata,
 			},
 		},
 	}

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -868,6 +868,49 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Unsupported annotation keep rule is dropped, selector remains empty (selecting all pods)",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "annotation-keep-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{}, // Empty selector selects all pods.
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_annotation_prometheus_io_scrape"},
+									Regex:        "true",
+									Action:       "keep",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "annotation-keep-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{}, // Remains empty, selecting all pods.
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -694,6 +694,7 @@ func TestPodMonitorConversion(t *testing.T) {
 						TargetLabels: monitoringv1.TargetLabels{
 							FromPod: []monitoringv1.LabelMapping{{From: "app_versioned"}},
 						},
+
 						Endpoints: []monitoringv1.ScrapeEndpoint{
 							{
 								Port:     intstr.FromString("metrics"),
@@ -701,6 +702,64 @@ func TestPodMonitorConversion(t *testing.T) {
 								MetricRelabeling: []monitoringv1.RelabelingRule{
 									{SourceLabels: []string{"app_versioned"}, Regex: "(.*)-v[0-9]+", Replacement: "$1", TargetLabel: "app_name", Action: "replace"},
 								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Pre-Scrape Relabelings: target filtering rules fall through to metricRelabeling in multi-endpoint resource to prevent cross-endpoint restriction",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multi-endpoint-filter-relabel",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics-alpha",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_env"},
+									Regex:        "^production$",
+									Action:       "keep",
+								},
+							},
+						},
+						{
+							Port: "metrics-beta",
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "multi-endpoint-filter-relabel", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}}, // Remains unchanged!
+						TargetLabels: monitoringv1.TargetLabels{
+							FromPod: []monitoringv1.LabelMapping{{From: "env"}},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics-alpha"),
+								Interval: "30s",
+								MetricRelabeling: []monitoringv1.RelabelingRule{
+									{SourceLabels: []string{"env"}, Regex: "^production$", TargetLabel: "", Action: "keep"},
+								},
+							},
+							{
+								Port:     intstr.FromString("metrics-beta"),
+								Interval: "30s",
 							},
 						},
 					},

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -968,7 +968,7 @@ func TestPodMonitorConversion(t *testing.T) {
 					Spec: monitoringv1.PodMonitoringSpec{
 						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
 						TargetLabels: monitoringv1.TargetLabels{
-							Metadata: &[]string{"pod"},
+							Metadata: &[]string{"container", "pod", "top_level_controller_name", "top_level_controller_type"},
 						},
 						Endpoints: []monitoringv1.ScrapeEndpoint{
 							{
@@ -1124,6 +1124,109 @@ func TestPodMonitorConversion(t *testing.T) {
 								Port:     intstr.FromString("metrics"),
 								Interval: "30s",
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Scope-aware Metadata: namespace metadata mapping dropped in namespaced PodMonitoring",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "namespaced-metadata-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_namespace"},
+									TargetLabel:  "namespace",
+									Action:       "replace",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "namespaced-metadata-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+						TargetLabels: monitoringv1.TargetLabels{
+							Metadata: &[]string{"container", "pod", "top_level_controller_name", "top_level_controller_type"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Scope-aware Metadata: namespace metadata mapping kept in ClusterPodMonitoring",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-metadata-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					NamespaceSelector: pomonitoringv1.NamespaceSelector{
+						Any: true,
+					},
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_namespace"},
+									TargetLabel:  "namespace",
+									Action:       "replace",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.ClusterPodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-metadata-monitor"},
+					Spec: monitoringv1.ClusterPodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+						TargetLabels: monitoringv1.ClusterTargetLabels{
+							Metadata: ptrTo([]string{"container", "namespace", "pod", "top_level_controller_name", "top_level_controller_type"}),
 						},
 					},
 				},

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -632,7 +632,7 @@ func TestPodMonitorConversion(t *testing.T) {
 									Regex:  "(project_id|location|cluster|namespace|job|instance|__address__|must_keep_.*)",
 								},
 								{
-									// Supported action hashmod (should be kept and promoted).
+									// Pre-scrape hashmod action is dropped with warning since GMP handles sharding.
 									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_app"},
 									TargetLabel:  "shard",
 									Modulus:      4,
@@ -666,20 +666,11 @@ func TestPodMonitorConversion(t *testing.T) {
 							{
 								Port:     intstr.FromString("metrics"),
 								Interval: "30s",
-								MetricRelabeling: []monitoringv1.RelabelingRule{
-									{
-										SourceLabels: []string{"app"},
-										TargetLabel:  "shard",
-										Modulus:      4,
-										Action:       "hashmod",
-									},
-								},
 							},
 						},
 						TargetLabels: monitoringv1.TargetLabels{
 							FromPod: []monitoringv1.LabelMapping{
 								{From: "env", To: "exported_instance"},
-								{From: "app"},
 							},
 						},
 					},
@@ -1345,7 +1336,7 @@ func TestPodMonitorConversion(t *testing.T) {
 			},
 		},
 		{
-			name: "Pre-Scrape Relabelings: hashmod action rule promoted to metricRelabelings",
+			name: "Pre-Scrape Relabelings: hashmod action rule is dropped with warning as GMP handles sharding",
 			input: &pomonitoringv1.PodMonitor{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "monitoring.coreos.com/v1",
@@ -1389,19 +1380,69 @@ func TestPodMonitorConversion(t *testing.T) {
 							{
 								Port:     intstr.FromString("metrics"),
 								Interval: "30s",
-								MetricRelabeling: []monitoringv1.RelabelingRule{
-									{
-										SourceLabels: []string{"env"},
-										TargetLabel:  "env",
-										Action:       "hashmod",
-										Modulus:      1000,
-									},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Pre-Scrape Relabelings: simple copy with anchored default regex ^(.*)$ and ^.*$ is converted to fromPod",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "anchored-regex-copy-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "frontend"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_env"},
+									Regex:        "^(.*)$",
+									TargetLabel:  "env",
+									Action:       "replace",
 								},
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_region"},
+									Regex:        "^.*$",
+									TargetLabel:  "region",
+									Action:       "replace",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta: BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "anchored-regex-copy-monitor",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "frontend"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
 							},
 						},
 						TargetLabels: monitoringv1.TargetLabels{
 							FromPod: []monitoringv1.LabelMapping{
 								{From: "env"},
+								{From: "region"},
 							},
 						},
 					},

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -745,7 +745,7 @@ func TestPodMonitorConversion(t *testing.T) {
 					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
 					ObjectMeta: metav1.ObjectMeta{Name: "multi-endpoint-filter-relabel", Namespace: "default"},
 					Spec: monitoringv1.PodMonitoringSpec{
-						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}}, // Remains unchanged!
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}}, // Remains unchanged.
 						TargetLabels: monitoringv1.TargetLabels{
 							FromPod: []monitoringv1.LabelMapping{{From: "env"}},
 						},
@@ -760,6 +760,108 @@ func TestPodMonitorConversion(t *testing.T) {
 							{
 								Port:     intstr.FromString("metrics-beta"),
 								Interval: "30s",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Pre-Scrape Relabelings: metadata label copy with renamed target falls through to metricRelabeling",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "metadata-rename-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+									TargetLabel:  "custom_pod_name",
+									Action:       "replace",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "metadata-rename-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+						TargetLabels: monitoringv1.TargetLabels{
+							Metadata: &[]string{"pod"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+								MetricRelabeling: []monitoringv1.RelabelingRule{
+									{SourceLabels: []string{"pod"}, TargetLabel: "custom_pod_name", Action: "replace"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Pre-Scrape Relabelings: target filtering rules with invalid k8s label values fall through to metricRelabeling",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-selector-value-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_env"},
+									Regex:        "^prod v1$", // Contains space - invalid for k8s label value.
+									Action:       "keep",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "invalid-selector-value-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+						TargetLabels: monitoringv1.TargetLabels{
+							FromPod: []monitoringv1.LabelMapping{{From: "env"}},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+								MetricRelabeling: []monitoringv1.RelabelingRule{
+									{SourceLabels: []string{"env"}, Regex: "^prod v1$", TargetLabel: "", Action: "keep"},
+								},
 							},
 						},
 					},

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -911,6 +911,58 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Pre-Scrape Relabelings: custom relabel rule overrides static podTargetLabels",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "override-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodTargetLabels: []string{"env"}, // Static copy env -> env.
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_custom_env"},
+									TargetLabel:  "env", // Custom rule maps custom_env -> env.
+									Action:       "replace",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "override-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+						TargetLabels: monitoringv1.TargetLabels{
+							// Only the custom one should survive because it overrides the static 'env' mapping.
+							FromPod: []monitoringv1.LabelMapping{
+								{From: "custom_env", To: "env"},
+							},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -593,6 +593,11 @@ func TestPodMonitorConversion(t *testing.T) {
 								Interval: "30s",
 							},
 						},
+						TargetLabels: monitoringv1.TargetLabels{
+							FromPod: []monitoringv1.LabelMapping{
+								{From: "env", To: "exported_instance"},
+							},
+						},
 					},
 				},
 			},

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -403,6 +403,27 @@ func TestPodMonitorConversion(t *testing.T) {
 									Regex:        "api-.*",
 									Action:       "drop",
 								},
+								{
+									// Supported action labeldrop (should be kept).
+									Action: "labeldrop",
+									Regex:  "temp_(.*)",
+								},
+								{
+									// Supported action labelkeep (should be kept).
+									Action: "labelkeep",
+									Regex:  "(project_id|location|cluster|namespace|job|instance|__address__|must_keep_.*)",
+								},
+								{
+									// Unsupported action lowercase (should be dropped).
+									SourceLabels: []pomonitoringv1.LabelName{"__name__"},
+									TargetLabel:  "instance",
+									Action:       "lowercase",
+								},
+								{
+									// Unsupported action keepequal (should be dropped).
+									SourceLabels: []pomonitoringv1.LabelName{"namespace", "job"},
+									Action:       "keepequal",
+								},
 							},
 						},
 					},
@@ -449,6 +470,14 @@ func TestPodMonitorConversion(t *testing.T) {
 										Regex:        "api-.*",
 										Action:       "drop",
 									},
+									{
+										Action: "labeldrop",
+										Regex:  "temp_(.*)",
+									},
+									{
+										Action: "labelkeep",
+										Regex:  "(project_id|location|cluster|namespace|job|instance|__address__|must_keep_.*)",
+									},
 								},
 							},
 						},
@@ -473,17 +502,23 @@ func TestPodMonitorConversion(t *testing.T) {
 					},
 					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
 						{
-							Port: "metrics",
+							Port: "metrics-basic",
 							BasicAuth: &pomonitoringv1.BasicAuth{
 								Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "auth-secret"}, Key: "user"},
 								Password: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "auth-secret"}, Key: "pass"},
 							},
-							BearerTokenSecret: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "token-secret"}, Key: "token"},
 							TLSConfig: &pomonitoringv1.SafeTLSConfig{
 								CA: pomonitoringv1.SecretOrConfigMap{
 									ConfigMap: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "ca-cm"}, Key: "ca.crt"},
 								},
 							},
+						},
+						{
+							Port:              "metrics-bearer",
+							BearerTokenSecret: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "token-secret"}, Key: "token"},
+						},
+						{
+							Port: "metrics-oauth",
 							OAuth2: &pomonitoringv1.OAuth2{
 								ClientID: pomonitoringv1.SecretOrConfigMap{
 									ConfigMap: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "oauth-cm"}, Key: "id"},
@@ -513,12 +548,9 @@ func TestPodMonitorConversion(t *testing.T) {
 						},
 						Endpoints: []monitoringv1.ScrapeEndpoint{
 							{
-								Port:     intstr.FromString("metrics"),
+								Port:     intstr.FromString("metrics-basic"),
 								Interval: "30s",
 								HTTPClientConfig: monitoringv1.HTTPClientConfig{
-									Authorization: &monitoringv1.Auth{
-										Credentials: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "token-secret", Key: "token", Namespace: "frontend"}},
-									},
 									BasicAuth: &monitoringv1.BasicAuth{
 										Username: "<MISSING_SECRET_auth-secret_KEY_user>",
 										Password: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "auth-secret", Key: "pass", Namespace: "frontend"}},
@@ -526,6 +558,21 @@ func TestPodMonitorConversion(t *testing.T) {
 									TLS: &monitoringv1.TLS{
 										CA: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "secret-ca-cm", Key: "ca.crt", Namespace: "frontend"}},
 									},
+								},
+							},
+							{
+								Port:     intstr.FromString("metrics-bearer"),
+								Interval: "30s",
+								HTTPClientConfig: monitoringv1.HTTPClientConfig{
+									Authorization: &monitoringv1.Auth{
+										Credentials: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "token-secret", Key: "token", Namespace: "frontend"}},
+									},
+								},
+							},
+							{
+								Port:     intstr.FromString("metrics-oauth"),
+								Interval: "30s",
+								HTTPClientConfig: monitoringv1.HTTPClientConfig{
 									OAuth2: &monitoringv1.OAuth2{
 										ClientID:     "<MISSING_CONFIGMAP_oauth-cm_KEY_id>",
 										ClientSecret: &monitoringv1.SecretSelector{Secret: &monitoringv1.SecretKeySelector{Name: "oauth-secret", Key: "secret", Namespace: "frontend"}},
@@ -574,6 +621,34 @@ func TestPodMonitorConversion(t *testing.T) {
 									Action: "labelmap",
 									Regex:  "app_(.*)",
 								},
+								{
+									// Supported action labeldrop (should be kept and promoted).
+									Action: "labeldrop",
+									Regex:  "temp_(.*)",
+								},
+								{
+									// Supported action labelkeep (should be kept and promoted).
+									Action: "labelkeep",
+									Regex:  "(project_id|location|cluster|namespace|job|instance|__address__|must_keep_.*)",
+								},
+								{
+									// Supported action hashmod (should be kept and promoted).
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_app"},
+									TargetLabel:  "shard",
+									Modulus:      4,
+									Action:       "hashmod",
+								},
+								{
+									// Unsupported action lowercase (should be dropped).
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_app"},
+									TargetLabel:  "app",
+									Action:       "lowercase",
+								},
+								{
+									// Unsupported action keepequal (should be dropped).
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_app", "__meta_kubernetes_pod_label_env"},
+									Action:       "keepequal",
+								},
 							},
 						},
 					},
@@ -591,11 +666,28 @@ func TestPodMonitorConversion(t *testing.T) {
 							{
 								Port:     intstr.FromString("metrics"),
 								Interval: "30s",
+								MetricRelabeling: []monitoringv1.RelabelingRule{
+									{
+										Action: "labeldrop",
+										Regex:  "temp_(.*)",
+									},
+									{
+										Action: "labelkeep",
+										Regex:  "(project_id|location|cluster|namespace|job|instance|__address__|must_keep_.*)",
+									},
+									{
+										SourceLabels: []string{"app"},
+										TargetLabel:  "shard",
+										Modulus:      4,
+										Action:       "hashmod",
+									},
+								},
 							},
 						},
 						TargetLabels: monitoringv1.TargetLabels{
 							FromPod: []monitoringv1.LabelMapping{
 								{From: "env", To: "exported_instance"},
+								{From: "app"},
 							},
 						},
 					},
@@ -645,11 +737,85 @@ func TestPodMonitorConversion(t *testing.T) {
 					Spec: monitoringv1.PodMonitoringSpec{
 						Selector: metav1.LabelSelector{
 							MatchLabels: map[string]string{"app": "test", "env": "production"},
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{Key: "tier", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"test", "staging"}},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+								MetricRelabeling: []monitoringv1.RelabelingRule{
+									{
+										SourceLabels: []string{"tier"},
+										Regex:        "(test|staging)",
+										Action:       "drop",
+									},
+								},
 							},
 						},
-						Endpoints: []monitoringv1.ScrapeEndpoint{{Port: intstr.FromString("metrics"), Interval: "30s"}},
+						TargetLabels: monitoringv1.TargetLabels{
+							FromPod: []monitoringv1.LabelMapping{
+								{From: "tier"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Pre-Scrape Relabelings: sanitized label names in keep rules not converted to selectors",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sanitized-relabel-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									// Contains underscore (potentially sanitized app.kubernetes.io/name) -> should not become selector.
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_app_kubernetes_io_name"},
+									Regex:        "^frontend$",
+									Action:       "keep",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "sanitized-relabel-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"}, // app_kubernetes_io_name is NOT here.
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+								MetricRelabeling: []monitoringv1.RelabelingRule{
+									{
+										SourceLabels: []string{"app_kubernetes_io_name"},
+										Regex:        "^frontend$",
+										Action:       "keep",
+									},
+								},
+							},
+						},
+						TargetLabels: monitoringv1.TargetLabels{
+							FromPod: []monitoringv1.LabelMapping{
+								{From: "app_kubernetes_io_name"},
+							},
+						},
 					},
 				},
 			},
@@ -1012,6 +1178,21 @@ func TestPodMonitorConversion(t *testing.T) {
 
 				if diff := cmp.Diff(tc.expected[i], gotObj); diff != "" {
 					t.Errorf("mismatch at index %d (-want +got):\n%s", i, diff)
+				}
+
+				// Verify that the generated resource compiles successfully
+				// inside the GMP Operator's own config generator.
+				switch obj := gotObj.(type) {
+				case *monitoringv1.PodMonitoring:
+					_, err = obj.ScrapeConfigs("test-project", "test-location", "test-cluster", nil)
+					if err != nil {
+						t.Errorf("Generated PodMonitoring failed operator compilation check: %v", err)
+					}
+				case *monitoringv1.ClusterPodMonitoring:
+					_, err = obj.ScrapeConfigs("test-project", "test-location", "test-cluster", nil)
+					if err != nil {
+						t.Errorf("Generated ClusterPodMonitoring failed operator compilation check: %v", err)
+					}
 				}
 			}
 		})

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -687,7 +687,7 @@ func TestPodMonitorConversion(t *testing.T) {
 			},
 		},
 		{
-			name: "Pre-Scrape Relabelings: target filtering keep and drop rules translated to Pod Selector",
+			name: "Pre-Scrape Relabelings: target filtering keep rule translated to Pod Selector, drop rule falls through to metricRelabeling",
 			input: &pomonitoringv1.PodMonitor{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "monitoring.coreos.com/v1",
@@ -712,7 +712,7 @@ func TestPodMonitorConversion(t *testing.T) {
 									Action:       "keep",
 								},
 								{
-									// Set drop -> matchExpressions NotIn.
+									// Drop rule falls through to post-scrape metricRelabeling.
 									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_tier"},
 									Regex:        "(test|staging)",
 									Action:       "drop",
@@ -753,7 +753,7 @@ func TestPodMonitorConversion(t *testing.T) {
 			},
 		},
 		{
-			name: "Pre-Scrape Relabelings: sanitized label names in keep rules not converted to selectors",
+			name: "Pre-Scrape Relabelings: label names with underscores in keep rules are converted to selectors",
 			input: &pomonitoringv1.PodMonitor{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "monitoring.coreos.com/v1",
@@ -772,7 +772,7 @@ func TestPodMonitorConversion(t *testing.T) {
 							Port: "metrics",
 							RelabelConfigs: []pomonitoringv1.RelabelConfig{
 								{
-									// Contains underscore (potentially sanitized app.kubernetes.io/name) -> should not become selector.
+									// Contains underscore (e.g. app_kubernetes_io_name) -> converted to matchLabels selector.
 									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_app_kubernetes_io_name"},
 									Regex:        "^frontend$",
 									Action:       "keep",
@@ -788,24 +788,15 @@ func TestPodMonitorConversion(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "sanitized-relabel-monitor", Namespace: "default"},
 					Spec: monitoringv1.PodMonitoringSpec{
 						Selector: metav1.LabelSelector{
-							MatchLabels: map[string]string{"app": "test"}, // app_kubernetes_io_name is NOT here.
+							MatchLabels: map[string]string{
+								"app":                    "test",
+								"app_kubernetes_io_name": "frontend",
+							},
 						},
 						Endpoints: []monitoringv1.ScrapeEndpoint{
 							{
 								Port:     intstr.FromString("metrics"),
 								Interval: "30s",
-								MetricRelabeling: []monitoringv1.RelabelingRule{
-									{
-										SourceLabels: []string{"app_kubernetes_io_name"},
-										Regex:        "^frontend$",
-										Action:       "keep",
-									},
-								},
-							},
-						},
-						TargetLabels: monitoringv1.TargetLabels{
-							FromPod: []monitoringv1.LabelMapping{
-								{From: "app_kubernetes_io_name"},
 							},
 						},
 					},

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -1263,6 +1263,132 @@ func TestPodMonitorConversion(t *testing.T) {
 			},
 			wantErr: "selector conflict: label \"app\" has conflicting values \"frontend\" (base selector) and \"backend\" (relabeling rule)",
 		},
+		{
+			name: "Pre-Scrape Relabelings: drop action rule on pod label falls through to metricRelabelings",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "drop-rule-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "frontend"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_env"},
+									Regex:        "dev",
+									Action:       "drop",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta: BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "drop-rule-monitor",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "frontend"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+								MetricRelabeling: []monitoringv1.RelabelingRule{
+									{
+										SourceLabels: []string{"env"},
+										Regex:        "dev",
+										Action:       "drop",
+									},
+								},
+							},
+						},
+						TargetLabels: monitoringv1.TargetLabels{
+							FromPod: []monitoringv1.LabelMapping{
+								{From: "env"},
+							},
+							Metadata: ptrTo([]string{"container", "pod", "top_level_controller_name", "top_level_controller_type"}),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Pre-Scrape Relabelings: lowercase action rule promoted to metricRelabelings",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "action-promotion-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "frontend"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_env"},
+									TargetLabel:  "env",
+									Action:       "lowercase",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta: BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "action-promotion-monitor",
+						Namespace: "default",
+					},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "frontend"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+								MetricRelabeling: []monitoringv1.RelabelingRule{
+									{
+										SourceLabels: []string{"env"},
+										TargetLabel:  "env",
+										Action:       "lowercase",
+									},
+								},
+							},
+						},
+						TargetLabels: monitoringv1.TargetLabels{
+							FromPod: []monitoringv1.LabelMapping{
+								{From: "env"},
+							},
+							Metadata: ptrTo([]string{"container", "pod", "top_level_controller_name", "top_level_controller_type"}),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -1320,14 +1320,13 @@ func TestPodMonitorConversion(t *testing.T) {
 							FromPod: []monitoringv1.LabelMapping{
 								{From: "env"},
 							},
-							Metadata: ptrTo([]string{"container", "pod", "top_level_controller_name", "top_level_controller_type"}),
 						},
 					},
 				},
 			},
 		},
 		{
-			name: "Pre-Scrape Relabelings: lowercase action rule promoted to metricRelabelings",
+			name: "Pre-Scrape Relabelings: hashmod action rule promoted to metricRelabelings",
 			input: &pomonitoringv1.PodMonitor{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "monitoring.coreos.com/v1",
@@ -1348,7 +1347,8 @@ func TestPodMonitorConversion(t *testing.T) {
 								{
 									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_env"},
 									TargetLabel:  "env",
-									Action:       "lowercase",
+									Action:       "hashmod",
+									Modulus:      1000,
 								},
 							},
 						},
@@ -1374,7 +1374,8 @@ func TestPodMonitorConversion(t *testing.T) {
 									{
 										SourceLabels: []string{"env"},
 										TargetLabel:  "env",
-										Action:       "lowercase",
+										Action:       "hashmod",
+										Modulus:      1000,
 									},
 								},
 							},
@@ -1383,7 +1384,6 @@ func TestPodMonitorConversion(t *testing.T) {
 							FromPod: []monitoringv1.LabelMapping{
 								{From: "env"},
 							},
-							Metadata: ptrTo([]string{"container", "pod", "top_level_controller_name", "top_level_controller_type"}),
 						},
 					},
 				},

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -1232,6 +1232,37 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Selector conflict: keep rule value conflicts with base matchLabels value",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict-selector-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "frontend"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_app"},
+									Regex:        "backend",
+									Action:       "keep",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "selector conflict: label \"app\" has conflicting values \"frontend\" (base selector) and \"backend\" (relabeling rule)",
+		},
 	}
 
 	converter := &PodMonitorConverter{}

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -538,6 +538,65 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Pre-Scrape Relabelings: drop unsupported actions and pod annotations with warning",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "warn-relabel-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									// Pod annotation reference (should be dropped with warning).
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_annotation_commit"},
+									TargetLabel:  "commit",
+									Action:       "replace",
+								},
+								{
+									// Protected target label rename (should warn and rename to exported_instance).
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_env"},
+									TargetLabel:  "instance",
+									Action:       "replace",
+								},
+								{
+									// Unsupported action labelmap (should be dropped with warning).
+									Action: "labelmap",
+									Regex:  "app_(.*)",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "warn-relabel-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -654,6 +654,59 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Pre-Scrape Relabelings: complex regex substring extraction promoted to post-scrape metricRelabeling",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "complex-relabel-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_app_versioned"},
+									Regex:        "(.*)-v[0-9]+",
+									Replacement:  ptrTo("$1"),
+									TargetLabel:  "app_name",
+									Action:       "replace",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "complex-relabel-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+						TargetLabels: monitoringv1.TargetLabels{
+							FromPod: []monitoringv1.LabelMapping{{From: "app_versioned"}},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+								MetricRelabeling: []monitoringv1.RelabelingRule{
+									{SourceLabels: []string{"app_versioned"}, Regex: "(.*)-v[0-9]+", Replacement: "$1", TargetLabel: "app_name", Action: "replace"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -622,12 +622,12 @@ func TestPodMonitorConversion(t *testing.T) {
 									Regex:  "app_(.*)",
 								},
 								{
-									// Supported action labeldrop (should be kept and promoted).
+									// Unsupported pre-scrape action labeldrop (should be dropped with warning).
 									Action: "labeldrop",
 									Regex:  "temp_(.*)",
 								},
 								{
-									// Supported action labelkeep (should be kept and promoted).
+									// Unsupported pre-scrape action labelkeep (should be dropped with warning).
 									Action: "labelkeep",
 									Regex:  "(project_id|location|cluster|namespace|job|instance|__address__|must_keep_.*)",
 								},
@@ -667,14 +667,6 @@ func TestPodMonitorConversion(t *testing.T) {
 								Port:     intstr.FromString("metrics"),
 								Interval: "30s",
 								MetricRelabeling: []monitoringv1.RelabelingRule{
-									{
-										Action: "labeldrop",
-										Regex:  "temp_(.*)",
-									},
-									{
-										Action: "labelkeep",
-										Regex:  "(project_id|location|cluster|namespace|job|instance|__address__|must_keep_.*)",
-									},
 									{
 										SourceLabels: []string{"app"},
 										TargetLabel:  "shard",
@@ -1262,6 +1254,42 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 			wantErr: "selector conflict: label \"app\" has conflicting values \"frontend\" (base selector) and \"backend\" (relabeling rule)",
+		},
+		{
+			name: "Pre-Scrape Relabelings: conflicting keep rules on same pod label return error",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflicting-keep-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_env"},
+									Regex:        "production",
+									Action:       "keep",
+								},
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_env"},
+									Regex:        "staging",
+									Action:       "keep",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "conflicting keep rules for label \"env\": cannot require both \"production\" and \"staging\" simultaneously",
 		},
 		{
 			name: "Pre-Scrape Relabelings: drop action rule on pod label falls through to metricRelabelings",

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -602,6 +602,58 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Pre-Scrape Relabelings: target filtering keep and drop rules translated to Pod Selector",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "filter-relabel-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									// Exact keep -> matchLabels.
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_env"},
+									Regex:        "^production$",
+									Action:       "keep",
+								},
+								{
+									// Set drop -> matchExpressions NotIn.
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_label_tier"},
+									Regex:        "(test|staging)",
+									Action:       "drop",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "filter-relabel-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test", "env": "production"},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{Key: "tier", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"test", "staging"}},
+							},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{{Port: intstr.FromString("metrics"), Interval: "30s"}},
+					},
+				},
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}


### PR DESCRIPTION
Adds support for migrating Prometheus Operator pre-scrape relabeling
configurations (`relabelings`) to Managed Service for Prometheus (GMP)
equivalent fields.

* Translates simple 1:1 label copies to `targetLabels.fromPod` and
   `targetLabels.metadata`.
* Translates exact equality and set-based target filtering rules
   to Kubernetes label selectors (`matchLabels` and `matchExpressions`).
* Promotes complex value-changing or regex-based rules to endpoint-level
   post-scrape `MetricRelabelings` while importing required Kubernetes
   source labels via `targetLabels.fromPod`.
* Clean warnings and drops for unsupported actions (like `labelmap`, `lowercase`, `uppercase`) and
  relabelings targeting pod annotations.