### PR TITLE
PO to GMP Migration Tool: Podmonitor Limits, ScrapeClass, Metadata. FilterRunning Migration

### DIFF
--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -43,10 +43,8 @@ const (
 
 // Constants representing the supported ScrapeProtocol enum values defined in upstream Prometheus Operator.
 const (
-	scrapeProtocolOpenMetricsText001 = pomonitoringv1.ScrapeProtocol("OpenMetricsText0.0.1")
 	scrapeProtocolOpenMetricsText100 = pomonitoringv1.ScrapeProtocol("OpenMetricsText1.0.0")
 	scrapeProtocolPrometheusProto    = pomonitoringv1.ScrapeProtocol("PrometheusProto")
-	scrapeProtocolPrometheusText004  = pomonitoringv1.ScrapeProtocol("PrometheusText0.0.4")
 )
 
 var (
@@ -958,10 +956,6 @@ func convertLimits(sampleLimit, labelLimit, labelNameLengthLimit, labelValueLeng
 	}
 	if labelValueLengthLimit != nil {
 		limits.LabelValueLength = *labelValueLengthLimit
-	}
-	// Return nil if all limit fields are zero to avoid emitting empty limits objects in YAML.
-	if *limits == (monitoringv1.ScrapeLimits{}) {
-		return nil
 	}
 	return limits
 }

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -69,6 +69,7 @@ var (
 		"__meta_kubernetes_pod_name":            labelPod,
 		"__meta_kubernetes_pod_container_name":  labelContainer,
 		"__meta_kubernetes_pod_node_name":       labelNode,
+		"__meta_kubernetes_node_name":           labelNode,
 		"__meta_kubernetes_namespace":           export.KeyNamespace,
 		"__meta_kubernetes_pod_controller_name": labelTopLevelControllerName,
 		"__meta_kubernetes_pod_controller_kind": labelTopLevelControllerType,
@@ -759,6 +760,10 @@ func shouldSkipRelabelConfig(logger *slog.Logger, config pomonitoringv1.RelabelC
 			logger.Warn(fmt.Sprintf("Relabeling rule referencing pod annotation %q is unsupported in GMP. The rule has been dropped.", string(sl)))
 			return true
 		}
+		if strings.HasPrefix(string(sl), "__meta_kubernetes_node_label_") {
+			logger.Warn(fmt.Sprintf("Relabeling rule referencing node label %q is unsupported in GMP (only node name is supported). The rule has been dropped.", string(sl)))
+			return true
+		}
 	}
 	return false
 }
@@ -920,6 +925,19 @@ func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingDa
 	logger.Info(fmt.Sprintf("Complex relabeling rule (target: %q) promoted from pre-scrape 'relabelings' to post-scrape 'metricRelabeling'.", data.targetLabel))
 }
 
+// warnUnsupportedSpecFields logs warnings for spec-level fields that GMP does not support or need.
+func warnUnsupportedSpecFields(logger *slog.Logger, spec pomonitoringv1.PodMonitorSpec) {
+	if spec.TargetLimit != nil {
+		logger.Warn("Field 'targetLimit' is unnecessary in GMP Managed Collection and has been dropped. Target discovery and scaling are managed automatically by GKE.")
+	}
+	if spec.KeepDroppedTargets != nil {
+		logger.Warn("Field 'keepDroppedTargets' is unnecessary in GMP Managed Collection and has been dropped.")
+	}
+	if spec.BodySizeLimit != nil {
+		logger.Warn("Field 'bodySizeLimit' is unsupported by GMP Managed Collection and has been dropped. Scrape response buffer limits are managed automatically by GMP.")
+	}
+}
+
 // convertLimits maps PodMonitor limit settings to GMP ScrapeLimits.
 func convertLimits(sampleLimit, labelLimit, labelNameLengthLimit, labelValueLengthLimit *uint64) *monitoringv1.ScrapeLimits {
 	if sampleLimit == nil && labelLimit == nil && labelNameLengthLimit == nil && labelValueLengthLimit == nil {
@@ -937,6 +955,10 @@ func convertLimits(sampleLimit, labelLimit, labelNameLengthLimit, labelValueLeng
 	}
 	if labelValueLengthLimit != nil {
 		limits.LabelValueLength = *labelValueLengthLimit
+	}
+	// Return nil if all limit fields are zero to avoid emitting empty limits objects in YAML.
+	if *limits == (monitoringv1.ScrapeLimits{}) {
+		return nil
 	}
 	return limits
 }

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -758,8 +758,8 @@ func shouldSkipRelabelConfig(logger *slog.Logger, config pomonitoringv1.RelabelC
 			logger.Warn(fmt.Sprintf("Relabeling rule referencing pod annotation %q is unsupported in GMP. The rule has been dropped.", string(sl)))
 			return true
 		}
-		if strings.HasPrefix(string(sl), "__meta_kubernetes_node_label_") {
-			logger.Warn(fmt.Sprintf("Relabeling rule referencing node label %q is unsupported in GMP (only node name is supported). The rule has been dropped.", string(sl)))
+		if strings.HasPrefix(string(sl), "__meta_kubernetes_node_") && string(sl) != "__meta_kubernetes_node_name" {
+			logger.Warn(fmt.Sprintf("Relabeling rule referencing node metadata %q is unsupported in GMP (only node name is supported). The rule has been dropped.", string(sl)))
 			return true
 		}
 	}
@@ -956,6 +956,10 @@ func convertLimits(sampleLimit, labelLimit, labelNameLengthLimit, labelValueLeng
 	}
 	if labelValueLengthLimit != nil {
 		limits.LabelValueLength = *labelValueLengthLimit
+	}
+	// Return nil if all fields in limits remain zero since zero values are stripped by omitempty.
+	if *limits == (monitoringv1.ScrapeLimits{}) {
+		return nil
 	}
 	return limits
 }

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -41,6 +41,14 @@ const (
 	labelAddress                = "__address__"
 )
 
+// Constants representing the supported ScrapeProtocol enum values defined in upstream Prometheus Operator.
+const (
+	scrapeProtocolOpenMetricsText001 = pomonitoringv1.ScrapeProtocol("OpenMetricsText0.0.1")
+	scrapeProtocolOpenMetricsText100 = pomonitoringv1.ScrapeProtocol("OpenMetricsText1.0.0")
+	scrapeProtocolPrometheusProto    = pomonitoringv1.ScrapeProtocol("PrometheusProto")
+	scrapeProtocolPrometheusText004  = pomonitoringv1.ScrapeProtocol("PrometheusText0.0.4")
+)
+
 var (
 	// protectedLabels contains the list of labels that are protected by GMP and cannot
 	// be overwritten by targetLabels or relabeling rules.

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -926,7 +926,10 @@ func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingDa
 }
 
 // warnUnsupportedSpecFields logs warnings for spec-level fields that GMP does not support or need.
-func warnUnsupportedSpecFields(logger *slog.Logger, spec pomonitoringv1.PodMonitorSpec) {
+func warnUnsupportedSpecFields(logger *slog.Logger, spec *pomonitoringv1.PodMonitorSpec) {
+	if spec == nil {
+		return
+	}
 	if spec.TargetLimit != nil {
 		logger.Warn("Field 'targetLimit' is unnecessary in GMP Managed Collection and has been dropped. Target discovery and scaling are managed automatically by GKE.")
 	}

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -911,3 +911,24 @@ func convertRelabelingToMetricRelabeling(logger *slog.Logger, data *relabelingDa
 	res.PromotedRules = append(res.PromotedRules, promoted)
 	logger.Info(fmt.Sprintf("Complex relabeling rule (target: %q) promoted from pre-scrape 'relabelings' to post-scrape 'metricRelabeling'.", data.targetLabel))
 }
+
+// convertLimits maps PodMonitor limit settings to GMP ScrapeLimits.
+func convertLimits(sampleLimit, labelLimit, labelNameLengthLimit, labelValueLengthLimit *uint64) *monitoringv1.ScrapeLimits {
+	if sampleLimit == nil && labelLimit == nil && labelNameLengthLimit == nil && labelValueLengthLimit == nil {
+		return nil
+	}
+	limits := &monitoringv1.ScrapeLimits{}
+	if sampleLimit != nil {
+		limits.Samples = *sampleLimit
+	}
+	if labelLimit != nil {
+		limits.Labels = *labelLimit
+	}
+	if labelNameLengthLimit != nil {
+		limits.LabelNameLength = *labelNameLengthLimit
+	}
+	if labelValueLengthLimit != nil {
+		limits.LabelValueLength = *labelValueLengthLimit
+	}
+	return limits
+}

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -569,11 +569,9 @@ func TestConvertLimits(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name:        "Explicit zero value is preserved",
+			name:        "Explicit zero value returns nil as zero values are omitted by omitempty",
 			sampleLimit: ptrTo(uint64(0)),
-			expected: &monitoringv1.ScrapeLimits{
-				Samples: 0,
-			},
+			expected:    nil,
 		},
 		{
 			name:                  "Non-zero limits are converted",

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -554,3 +554,48 @@ func TestMergeFromPod(t *testing.T) {
 		t.Errorf("mergeFromPod mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestConvertLimits(t *testing.T) {
+	tests := []struct {
+		name                  string
+		sampleLimit           *uint64
+		labelLimit            *uint64
+		labelNameLengthLimit  *uint64
+		labelValueLengthLimit *uint64
+		expected              *monitoringv1.ScrapeLimits
+	}{
+		{
+			name:     "All nil inputs return nil",
+			expected: nil,
+		},
+		{
+			name:        "Explicit zero value is preserved",
+			sampleLimit: ptrTo(uint64(0)),
+			expected: &monitoringv1.ScrapeLimits{
+				Samples: 0,
+			},
+		},
+		{
+			name:                  "Non-zero limits are converted",
+			sampleLimit:           ptrTo(uint64(5000)),
+			labelLimit:            ptrTo(uint64(50)),
+			labelNameLengthLimit:  ptrTo(uint64(100)),
+			labelValueLengthLimit: ptrTo(uint64(200)),
+			expected: &monitoringv1.ScrapeLimits{
+				Samples:          5000,
+				Labels:           50,
+				LabelNameLength:  100,
+				LabelValueLength: 200,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertLimits(tc.sampleLimit, tc.labelLimit, tc.labelNameLengthLimit, tc.labelValueLengthLimit)
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("convertLimits() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -249,10 +249,10 @@ func (c *PodMonitorConverter) convertEndpoints(
 
 		// 5. Warnings for Unsupported Fields in Endpoint.
 		if ep.FollowRedirects != nil && !*ep.FollowRedirects {
-			convCtx.logger.Warn("Field 'followRedirects: false' is unsupported by GMP Managed Collection and has been dropped. The collector will always follow redirects.")
+			convCtx.logger.Warn(fmt.Sprintf("endpoint [%d]: field 'followRedirects: false' is unsupported by GMP Managed Collection and has been dropped. The collector will always follow redirects.", i))
 		}
 		if ep.EnableHttp2 != nil && !*ep.EnableHttp2 {
-			convCtx.logger.Warn("Field 'enableHttp2: false' is unsupported by GMP Managed Collection and has been dropped. The collector will always negotiate HTTP/2 for TLS connections.")
+			convCtx.logger.Warn(fmt.Sprintf("endpoint [%d]: field 'enableHttp2: false' is unsupported by GMP Managed Collection and has been dropped. The collector will always negotiate HTTP/2 for TLS connections.", i))
 		}
 
 		if ep.HonorLabels {
@@ -296,6 +296,7 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 	}
 
 	// Spec-level warnings for unsupported fields.
+	warnUnsupportedSpecFields(logger, pm.Spec)
 	// TODO(M2): Resolve and merge ScrapeClass configurations from Prometheus CR if scrapeClassName is specified.
 	if pm.Spec.ScrapeClassName != nil && *pm.Spec.ScrapeClassName != "" {
 		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
@@ -341,6 +342,7 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 			hasTrue = true
 		}
 	}
+	// A nil filterRunning defaults to true in the GMP operator.
 	var filterRunning *bool
 	if hasFalse {
 		falseVal := false
@@ -404,6 +406,7 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 	}
 
 	// Spec-level warnings for unsupported fields.
+	warnUnsupportedSpecFields(logger, pm.Spec)
 	// TODO(M2): Resolve and merge ScrapeClass configurations from Prometheus CR if scrapeClassName is specified.
 	if pm.Spec.ScrapeClassName != nil && *pm.Spec.ScrapeClassName != "" {
 		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
@@ -442,6 +445,7 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 			hasTrue = true
 		}
 	}
+	// A nil filterRunning defaults to true in the GMP operator.
 	var filterRunning *bool
 	if hasFalse {
 		falseVal := false

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -323,13 +323,20 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		}
 	}
 
-	var filterRunning *bool
+	var hasFalse, hasTrue bool
 	for _, ep := range pm.Spec.PodMetricsEndpoints {
 		if ep.FilterRunning != nil && !*ep.FilterRunning {
-			falseVal := false
-			filterRunning = &falseVal
-			logger.Warn("Endpoint-level configuration conflict detected: at least one endpoint is configured with 'filterRunning: false', but GMP only supports 'filterRunning' at the resource level. Setting 'filterRunning: false' globally on the PodMonitoring resource.")
-			break
+			hasFalse = true
+		} else {
+			hasTrue = true
+		}
+	}
+	var filterRunning *bool
+	if hasFalse {
+		falseVal := false
+		filterRunning = &falseVal
+		if hasTrue {
+			logger.Warn("Endpoint-level configuration conflict detected: some endpoints are configured with 'filterRunning: false' and others with 'true' (or default), but GMP only supports 'filterRunning' at the resource level. Setting 'filterRunning: false' globally on the PodMonitoring resource.")
 		}
 	}
 
@@ -404,13 +411,20 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		filteredMetadata = &union
 	}
 
-	var filterRunning *bool
+	var hasFalse, hasTrue bool
 	for _, ep := range pm.Spec.PodMetricsEndpoints {
 		if ep.FilterRunning != nil && !*ep.FilterRunning {
-			falseVal := false
-			filterRunning = &falseVal
-			logger.Warn("Endpoint-level configuration conflict detected: at least one endpoint is configured with 'filterRunning: false', but GMP only supports 'filterRunning' at the resource level. Setting 'filterRunning: false' globally on the ClusterPodMonitoring resource.")
-			break
+			hasFalse = true
+		} else {
+			hasTrue = true
+		}
+	}
+	var filterRunning *bool
+	if hasFalse {
+		falseVal := false
+		filterRunning = &falseVal
+		if hasTrue {
+			logger.Warn("Endpoint-level configuration conflict detected: some endpoints are configured with 'filterRunning: false' and others with 'true' (or default), but GMP only supports 'filterRunning' at the resource level. Setting 'filterRunning: false' globally on the ClusterPodMonitoring resource.")
 		}
 	}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -322,12 +322,15 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		}
 	}
 
+	// In GMP, Metadata: nil on a PodMonitoring defaults to emitting namespaced defaults (container, pod, etc.).
+	// When setting Metadata explicitly for AttachMetadata.Node, we must merge namespacedMetadataDefaults so that default metadata is not dropped.
 	if pm.Spec.AttachMetadata != nil && pm.Spec.AttachMetadata.Node != nil && *pm.Spec.AttachMetadata.Node {
 		if filteredMetadata == nil {
-			filteredMetadata = &[]string{labelNode}
-		} else if !slices.Contains(*filteredMetadata, labelNode) {
-			metadataCopy := append(slices.Clone(*filteredMetadata), labelNode)
-			filteredMetadata = &metadataCopy
+			union := unionMetadata([]string{labelNode}, namespacedMetadataDefaults)
+			filteredMetadata = &union
+		} else {
+			union := unionMetadata([]string{labelNode}, *filteredMetadata)
+			filteredMetadata = &union
 		}
 	}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -302,11 +302,8 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
 	}
 	// Check against the PrometheusProto enum value.
-	for _, sp := range pm.Spec.ScrapeProtocols {
-		if sp == scrapeProtocolPrometheusProto {
-			logger.Warn("Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.")
-			break
-		}
+	if slices.Contains(pm.Spec.ScrapeProtocols, scrapeProtocolPrometheusProto) {
+		logger.Warn("Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.")
 	}
 
 	var filteredMetadata *[]string
@@ -412,11 +409,8 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
 	}
 	// Check against the PrometheusProto enum value.
-	for _, sp := range pm.Spec.ScrapeProtocols {
-		if sp == scrapeProtocolPrometheusProto {
-			logger.Warn("Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.")
-			break
-		}
+	if slices.Contains(pm.Spec.ScrapeProtocols, scrapeProtocolPrometheusProto) {
+		logger.Warn("Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.")
 	}
 
 	var filteredMetadata *[]string

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -300,8 +300,9 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 	if pm.Spec.ScrapeClassName != nil && *pm.Spec.ScrapeClassName != "" {
 		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
 	}
+	// Check against the PrometheusProto enum value or the substring proto.
 	for _, sp := range pm.Spec.ScrapeProtocols {
-		if strings.Contains(strings.ToLower(string(sp)), "protobuf") {
+		if sp == scrapeProtocolPrometheusProto || strings.Contains(strings.ToLower(string(sp)), "proto") {
 			logger.Warn("Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.")
 			break
 		}
@@ -325,9 +326,9 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 
 	if pm.Spec.AttachMetadata != nil && pm.Spec.AttachMetadata.Node != nil && *pm.Spec.AttachMetadata.Node {
 		if filteredMetadata == nil {
-			filteredMetadata = &[]string{"node"}
-		} else if !slices.Contains(*filteredMetadata, "node") {
-			metadataCopy := append(slices.Clone(*filteredMetadata), "node")
+			filteredMetadata = &[]string{labelNode}
+		} else if !slices.Contains(*filteredMetadata, labelNode) {
+			metadataCopy := append(slices.Clone(*filteredMetadata), labelNode)
 			filteredMetadata = &metadataCopy
 		}
 	}
@@ -405,10 +406,11 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 	// Spec-level warnings for unsupported fields.
 	// TODO(M2): Resolve and merge ScrapeClass configurations from Prometheus CR if scrapeClassName is specified.
 	if pm.Spec.ScrapeClassName != nil && *pm.Spec.ScrapeClassName != "" {
-		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the pre-scanned inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
+		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
 	}
+	// Check against the PrometheusProto enum value or the substring proto.
 	for _, sp := range pm.Spec.ScrapeProtocols {
-		if strings.Contains(strings.ToLower(string(sp)), "protobuf") {
+		if sp == scrapeProtocolPrometheusProto || strings.Contains(strings.ToLower(string(sp)), "proto") {
 			logger.Warn("Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.")
 			break
 		}
@@ -420,12 +422,15 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		filteredMetadata = &union
 	}
 
+	// In GMP, Metadata: nil on a ClusterPodMonitoring defaults to emitting namespace and other cluster defaults.
+	// When setting Metadata explicitly for AttachMetadata.Node, we must merge clusterMetadataDefaults so that namespace is not dropped.
 	if pm.Spec.AttachMetadata != nil && pm.Spec.AttachMetadata.Node != nil && *pm.Spec.AttachMetadata.Node {
 		if filteredMetadata == nil {
-			filteredMetadata = &[]string{"node"}
-		} else if !slices.Contains(*filteredMetadata, "node") {
-			metadataCopy := append(slices.Clone(*filteredMetadata), "node")
-			filteredMetadata = &metadataCopy
+			union := unionMetadata([]string{labelNode}, clusterMetadataDefaults)
+			filteredMetadata = &union
+		} else {
+			union := unionMetadata([]string{labelNode}, *filteredMetadata)
+			filteredMetadata = &union
 		}
 	}
 

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -328,7 +328,7 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		if ep.FilterRunning != nil && !*ep.FilterRunning {
 			falseVal := false
 			filterRunning = &falseVal
-			logger.Warn("Endpoint-level configuration conflict detected: at least one endpoint is configured with 'filterRunning: false', but GMP only supports 'filterRunning' at the resource level. Set 'filterRunning: false' globally on the PodMonitoring resource.")
+			logger.Warn("Endpoint-level configuration conflict detected: at least one endpoint is configured with 'filterRunning: false', but GMP only supports 'filterRunning' at the resource level. Setting 'filterRunning: false' globally on the PodMonitoring resource.")
 			break
 		}
 	}
@@ -409,7 +409,7 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		if ep.FilterRunning != nil && !*ep.FilterRunning {
 			falseVal := false
 			filterRunning = &falseVal
-			logger.Warn("Endpoint-level configuration conflict detected: at least one endpoint is configured with 'filterRunning: false', but GMP only supports 'filterRunning' at the resource level. Set 'filterRunning: false' globally on the PodMonitoring resource.")
+			logger.Warn("Endpoint-level configuration conflict detected: at least one endpoint is configured with 'filterRunning: false', but GMP only supports 'filterRunning' at the resource level. Setting 'filterRunning: false' globally on the ClusterPodMonitoring resource.")
 			break
 		}
 	}

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -323,6 +323,15 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		}
 	}
 
+	if pm.Spec.AttachMetadata != nil && pm.Spec.AttachMetadata.Node != nil && *pm.Spec.AttachMetadata.Node {
+		if filteredMetadata == nil {
+			filteredMetadata = &[]string{"node"}
+		} else if !slices.Contains(*filteredMetadata, "node") {
+			metadataCopy := append(slices.Clone(*filteredMetadata), "node")
+			filteredMetadata = &metadataCopy
+		}
+	}
+
 	var hasFalse, hasTrue bool
 	for _, ep := range pm.Spec.PodMetricsEndpoints {
 		if ep.FilterRunning != nil && !*ep.FilterRunning {
@@ -409,6 +418,15 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 	if rules.ResourceCombined.Metadata != nil {
 		union := unionMetadata(*rules.ResourceCombined.Metadata, clusterMetadataDefaults)
 		filteredMetadata = &union
+	}
+
+	if pm.Spec.AttachMetadata != nil && pm.Spec.AttachMetadata.Node != nil && *pm.Spec.AttachMetadata.Node {
+		if filteredMetadata == nil {
+			filteredMetadata = &[]string{"node"}
+		} else if !slices.Contains(*filteredMetadata, "node") {
+			metadataCopy := append(slices.Clone(*filteredMetadata), "node")
+			filteredMetadata = &metadataCopy
+		}
 	}
 
 	var hasFalse, hasTrue bool

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -296,14 +296,14 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 	}
 
 	// Spec-level warnings for unsupported fields.
-	warnUnsupportedSpecFields(logger, pm.Spec)
+	warnUnsupportedSpecFields(logger, &pm.Spec)
 	// TODO(M2): Resolve and merge ScrapeClass configurations from Prometheus CR if scrapeClassName is specified.
 	if pm.Spec.ScrapeClassName != nil && *pm.Spec.ScrapeClassName != "" {
 		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
 	}
-	// Check against the PrometheusProto enum value or the substring proto.
+	// Check against the PrometheusProto enum value.
 	for _, sp := range pm.Spec.ScrapeProtocols {
-		if sp == scrapeProtocolPrometheusProto || strings.Contains(strings.ToLower(string(sp)), "proto") {
+		if sp == scrapeProtocolPrometheusProto {
 			logger.Warn("Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.")
 			break
 		}
@@ -406,14 +406,14 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 	}
 
 	// Spec-level warnings for unsupported fields.
-	warnUnsupportedSpecFields(logger, pm.Spec)
+	warnUnsupportedSpecFields(logger, &pm.Spec)
 	// TODO(M2): Resolve and merge ScrapeClass configurations from Prometheus CR if scrapeClassName is specified.
 	if pm.Spec.ScrapeClassName != nil && *pm.Spec.ScrapeClassName != "" {
 		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
 	}
-	// Check against the PrometheusProto enum value or the substring proto.
+	// Check against the PrometheusProto enum value.
 	for _, sp := range pm.Spec.ScrapeProtocols {
-		if sp == scrapeProtocolPrometheusProto || strings.Contains(strings.ToLower(string(sp)), "proto") {
+		if sp == scrapeProtocolPrometheusProto {
 			logger.Warn("Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.")
 			break
 		}

--- a/pkg/migrate/podmonitor.go
+++ b/pkg/migrate/podmonitor.go
@@ -248,6 +248,13 @@ func (c *PodMonitorConverter) convertEndpoints(
 		}
 
 		// 5. Warnings for Unsupported Fields in Endpoint.
+		if ep.FollowRedirects != nil && !*ep.FollowRedirects {
+			convCtx.logger.Warn("Field 'followRedirects: false' is unsupported by GMP Managed Collection and has been dropped. The collector will always follow redirects.")
+		}
+		if ep.EnableHttp2 != nil && !*ep.EnableHttp2 {
+			convCtx.logger.Warn("Field 'enableHttp2: false' is unsupported by GMP Managed Collection and has been dropped. The collector will always negotiate HTTP/2 for TLS connections.")
+		}
+
 		if ep.HonorLabels {
 			convCtx.logger.Warn("Field 'honorLabels: true' is unsupported and dropped. GMP always overrides conflicting labels. Clashing metric labels will be renamed with the 'exported_' prefix.")
 		}
@@ -288,6 +295,18 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		logger.Warn("Resulting PodMonitoring selector is empty. It will select and scrape all pods in this namespace. Verify if this is intended.")
 	}
 
+	// Spec-level warnings for unsupported fields.
+	// TODO(M2): Resolve and merge ScrapeClass configurations from Prometheus CR if scrapeClassName is specified.
+	if pm.Spec.ScrapeClassName != nil && *pm.Spec.ScrapeClassName != "" {
+		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
+	}
+	for _, sp := range pm.Spec.ScrapeProtocols {
+		if strings.Contains(strings.ToLower(string(sp)), "protobuf") {
+			logger.Warn("Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.")
+			break
+		}
+	}
+
 	var filteredMetadata *[]string
 	if rules.ResourceCombined.Metadata != nil {
 		union := unionMetadata(*rules.ResourceCombined.Metadata, namespacedMetadataDefaults)
@@ -304,6 +323,18 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 		}
 	}
 
+	var filterRunning *bool
+	for _, ep := range pm.Spec.PodMetricsEndpoints {
+		if ep.FilterRunning != nil && !*ep.FilterRunning {
+			falseVal := false
+			filterRunning = &falseVal
+			logger.Warn("Endpoint-level configuration conflict detected: at least one endpoint is configured with 'filterRunning: false', but GMP only supports 'filterRunning' at the resource level. Set 'filterRunning: false' globally on the PodMonitoring resource.")
+			break
+		}
+	}
+
+	limits := convertLimits(pm.Spec.SampleLimit, pm.Spec.LabelLimit, pm.Spec.LabelNameLengthLimit, pm.Spec.LabelValueLengthLimit)
+
 	gmpPM := &monitoringv1.PodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindPodMonitoring),
 		ObjectMeta: CopyObjectMeta(pm.ObjectMeta, pm.Namespace, logger),
@@ -314,6 +345,8 @@ func (c *PodMonitorConverter) convertToPodMonitoring(pm *pomonitoringv1.PodMonit
 				FromPod:  mergedFromPod,
 				Metadata: filteredMetadata,
 			},
+			Limits:        limits,
+			FilterRunning: filterRunning,
 		},
 	}
 
@@ -353,11 +386,35 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 		logger.Warn("Resulting ClusterPodMonitoring selector is empty. It will select and scrape all pods across all namespaces. Verify if this is intended.")
 	}
 
+	// Spec-level warnings for unsupported fields.
+	// TODO(M2): Resolve and merge ScrapeClass configurations from Prometheus CR if scrapeClassName is specified.
+	if pm.Spec.ScrapeClassName != nil && *pm.Spec.ScrapeClassName != "" {
+		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the pre-scanned inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *pm.Spec.ScrapeClassName))
+	}
+	for _, sp := range pm.Spec.ScrapeProtocols {
+		if strings.Contains(strings.ToLower(string(sp)), "protobuf") {
+			logger.Warn("Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.")
+			break
+		}
+	}
+
 	var filteredMetadata *[]string
 	if rules.ResourceCombined.Metadata != nil {
 		union := unionMetadata(*rules.ResourceCombined.Metadata, clusterMetadataDefaults)
 		filteredMetadata = &union
 	}
+
+	var filterRunning *bool
+	for _, ep := range pm.Spec.PodMetricsEndpoints {
+		if ep.FilterRunning != nil && !*ep.FilterRunning {
+			falseVal := false
+			filterRunning = &falseVal
+			logger.Warn("Endpoint-level configuration conflict detected: at least one endpoint is configured with 'filterRunning: false', but GMP only supports 'filterRunning' at the resource level. Set 'filterRunning: false' globally on the PodMonitoring resource.")
+			break
+		}
+	}
+
+	limits := convertLimits(pm.Spec.SampleLimit, pm.Spec.LabelLimit, pm.Spec.LabelNameLengthLimit, pm.Spec.LabelValueLengthLimit)
 
 	gmpCPM := &monitoringv1.ClusterPodMonitoring{
 		TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
@@ -369,6 +426,8 @@ func (c *PodMonitorConverter) convertToClusterPodMonitoring(pm *pomonitoringv1.P
 				FromPod:  mergedFromPod,
 				Metadata: filteredMetadata,
 			},
+			Limits:        limits,
+			FilterRunning: filterRunning,
 		},
 	}
 

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -1449,6 +1449,66 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Limits, AttachMetadata.Node, and FilterRunning conversion",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "advanced-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					AttachMetadata: &pomonitoringv1.AttachMetadata{
+						Node: ptrTo(true),
+					},
+					SampleLimit:           ptrTo(uint64(5000)),
+					LabelLimit:            ptrTo(uint64(50)),
+					LabelNameLengthLimit:  ptrTo(uint64(100)),
+					LabelValueLengthLimit: ptrTo(uint64(200)),
+					ScrapeClassName:       ptrTo("custom-class"),
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "advanced"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:            "web",
+							Interval:        "15s",
+							FilterRunning:   ptrTo(false),
+							FollowRedirects: ptrTo(false),
+							EnableHttp2:     ptrTo(false),
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "advanced-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "advanced"}},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("web"),
+								Interval: "15s",
+							},
+						},
+						TargetLabels: monitoringv1.TargetLabels{
+							Metadata: &[]string{"node"},
+						},
+						Limits: &monitoringv1.ScrapeLimits{
+							Samples:          5000,
+							Labels:           50,
+							LabelNameLength:  100,
+							LabelValueLength: 200,
+						},
+						FilterRunning: ptrTo(false),
+					},
+				},
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -34,11 +34,12 @@ import (
 
 func TestPodMonitorConversion(t *testing.T) {
 	tests := []struct {
-		name         string
-		input        *pomonitoringv1.PodMonitor
-		expected     []runtime.Object
-		wantErr      string
-		wantWarnings []string
+		name             string
+		input            *pomonitoringv1.PodMonitor
+		expected         []runtime.Object
+		wantErr          string
+		wantWarnings     []string
+		dontWantWarnings []string
 	}{
 		{
 			name: "Case A: Cluster-Scoped (Any Namespace)",
@@ -1943,6 +1944,55 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "All endpoints set filterRunning: false (no conflict warning emitted)",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "filter-running-consistent-false",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "filter-running"}},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:          "web-1",
+							FilterRunning: ptrTo(false),
+						},
+						{
+							Port:          "web-2",
+							FilterRunning: ptrTo(false),
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "filter-running-consistent-false", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "filter-running"}},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("web-1"),
+								Interval: "30s",
+							},
+							{
+								Port:     intstr.FromString("web-2"),
+								Interval: "30s",
+							},
+						},
+						FilterRunning: ptrTo(false),
+					},
+				},
+			},
+			dontWantWarnings: []string{
+				"Endpoint-level configuration conflict detected",
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}
@@ -1978,6 +2028,16 @@ func TestPodMonitorConversion(t *testing.T) {
 				for _, wantWarn := range tc.wantWarnings {
 					if !strings.Contains(outStr, wantWarn) {
 						t.Errorf("expected warning containing %q, got logs:\n%s", wantWarn, outStr)
+					}
+				}
+			}
+
+			// Check that no unwanted warning substrings appear in the log output.
+			if len(tc.dontWantWarnings) > 0 {
+				outStr := buf.String()
+				for _, dontWantWarn := range tc.dontWantWarnings {
+					if strings.Contains(outStr, dontWantWarn) {
+						t.Errorf("expected no warning containing %q, got logs:\n%s", dontWantWarn, outStr)
 					}
 				}
 			}

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -15,7 +15,9 @@
 package migrate
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -32,10 +34,11 @@ import (
 
 func TestPodMonitorConversion(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    *pomonitoringv1.PodMonitor
-		expected []runtime.Object
-		wantErr  string
+		name         string
+		input        *pomonitoringv1.PodMonitor
+		expected     []runtime.Object
+		wantErr      string
+		wantWarnings []string
 	}{
 		{
 			name: "Case A: Cluster-Scoped (Any Namespace)",
@@ -1207,6 +1210,56 @@ func TestPodMonitorConversion(t *testing.T) {
 			},
 		},
 		{
+			name: "Scope-aware Metadata: AttachMetadata.Node seeds from clusterMetadataDefaults in ClusterPodMonitoring",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-node-metadata-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					NamespaceSelector: pomonitoringv1.NamespaceSelector{
+						Any: true,
+					},
+					AttachMetadata: &pomonitoringv1.AttachMetadata{
+						Node: ptrTo(true),
+					},
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:     "metrics",
+							Interval: "30s",
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.ClusterPodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-node-metadata-monitor"},
+					Spec: monitoringv1.ClusterPodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+						TargetLabels: monitoringv1.ClusterTargetLabels{
+							Metadata: ptrTo([]string{"container", "namespace", labelNode, "pod", "top_level_controller_name", "top_level_controller_type"}),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Selector conflict: keep rule value conflicts with base matchLabels value",
 			input: &pomonitoringv1.PodMonitor{
 				TypeMeta: metav1.TypeMeta{
@@ -1496,7 +1549,80 @@ func TestPodMonitorConversion(t *testing.T) {
 							},
 						},
 						TargetLabels: monitoringv1.TargetLabels{
-							Metadata: &[]string{"node"},
+							Metadata: &[]string{labelNode},
+						},
+						Limits: &monitoringv1.ScrapeLimits{
+							Samples:          5000,
+							Labels:           50,
+							LabelNameLength:  100,
+							LabelValueLength: 200,
+						},
+						FilterRunning: ptrTo(false),
+					},
+				},
+			},
+			wantWarnings: []string{
+				"Field 'followRedirects: false' is unsupported by GMP Managed Collection and has been dropped.",
+				"Field 'enableHttp2: false' is unsupported by GMP Managed Collection and has been dropped.",
+				"was not found in the inputs. The 'scrapeClassName' field has been dropped",
+			},
+		},
+		{
+			name: "Limits, AttachMetadata.Node, and FilterRunning conversion in ClusterPodMonitoring",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-advanced-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					NamespaceSelector: pomonitoringv1.NamespaceSelector{
+						Any: true,
+					},
+					AttachMetadata: &pomonitoringv1.AttachMetadata{
+						Node: ptrTo(true),
+					},
+					SampleLimit:           ptrTo(uint64(5000)),
+					LabelLimit:            ptrTo(uint64(50)),
+					LabelNameLengthLimit:  ptrTo(uint64(100)),
+					LabelValueLengthLimit: ptrTo(uint64(200)),
+					ScrapeClassName:       ptrTo("custom-class"),
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "advanced"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:            "web",
+							Interval:        "15s",
+							FilterRunning:   ptrTo(false),
+							FollowRedirects: ptrTo(false),
+							EnableHttp2:     ptrTo(false),
+						},
+					},
+				},
+			},
+			wantWarnings: []string{
+				"Field 'followRedirects: false' is unsupported by GMP Managed Collection and has been dropped.",
+				"Field 'enableHttp2: false' is unsupported by GMP Managed Collection and has been dropped.",
+				"was not found in the inputs. The 'scrapeClassName' field has been dropped",
+			},
+			expected: []runtime.Object{
+				&monitoringv1.ClusterPodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-advanced-monitor"},
+					Spec: monitoringv1.ClusterPodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "advanced"}},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("web"),
+								Interval: "15s",
+							},
+						},
+						TargetLabels: monitoringv1.ClusterTargetLabels{
+							Metadata: ptrTo([]string{"container", "namespace", labelNode, "pod", "top_level_controller_name", "top_level_controller_type"}),
 						},
 						Limits: &monitoringv1.ScrapeLimits{
 							Samples:          5000,
@@ -1522,8 +1648,8 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 				Spec: pomonitoringv1.PodMonitorSpec{
 					ScrapeProtocols: []pomonitoringv1.ScrapeProtocol{
-						"application/openmetrics-text",
-						"application/vnd.google.protobuf",
+						scrapeProtocolOpenMetricsText100,
+						scrapeProtocolPrometheusProto,
 					},
 					Selector: metav1.LabelSelector{
 						MatchLabels: map[string]string{"app": "scrape-protocols"},
@@ -1549,6 +1675,57 @@ func TestPodMonitorConversion(t *testing.T) {
 						},
 					},
 				},
+			},
+			wantWarnings: []string{
+				"Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.",
+			},
+		},
+		{
+			name: "ScrapeProtocols protobuf warning in ClusterPodMonitoring",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-scrape-protocols-warn",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					NamespaceSelector: pomonitoringv1.NamespaceSelector{
+						Any: true,
+					},
+					ScrapeProtocols: []pomonitoringv1.ScrapeProtocol{
+						scrapeProtocolOpenMetricsText100,
+						scrapeProtocolPrometheusProto,
+					},
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "scrape-protocols"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "web",
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.ClusterPodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-scrape-protocols-warn"},
+					Spec: monitoringv1.ClusterPodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "scrape-protocols"}},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("web"),
+								Interval: "30s",
+							},
+						},
+					},
+				},
+			},
+			wantWarnings: []string{
+				"Scrape protocol settings (scrapeProtocols) requiring Protobuf are unsupported. Scrapes may fail if target lacks text fallback.",
 			},
 		},
 		{
@@ -1596,16 +1773,73 @@ func TestPodMonitorConversion(t *testing.T) {
 					},
 				},
 			},
+			wantWarnings: []string{
+				"Endpoint-level configuration conflict detected: some endpoints are configured with 'filterRunning: false' and others with 'true'",
+			},
+		},
+		{
+			name: "FilterRunning conflict resolution in ClusterPodMonitoring",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-filter-running-conflict",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					NamespaceSelector: pomonitoringv1.NamespaceSelector{
+						Any: true,
+					},
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "filter-running"}},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:          "web-1",
+							FilterRunning: ptrTo(false),
+						},
+						{
+							Port:          "web-2",
+							FilterRunning: ptrTo(true),
+						},
+					},
+				},
+			},
+			wantWarnings: []string{
+				"Endpoint-level configuration conflict detected: some endpoints are configured with 'filterRunning: false' and others with 'true'",
+			},
+			expected: []runtime.Object{
+				&monitoringv1.ClusterPodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-filter-running-conflict"},
+					Spec: monitoringv1.ClusterPodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "filter-running"}},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("web-1"),
+								Interval: "30s",
+							},
+							{
+								Port:     intstr.FromString("web-2"),
+								Interval: "30s",
+							},
+						},
+						FilterRunning: ptrTo(false),
+					},
+				},
+			},
 		},
 	}
 
 	converter := &PodMonitorConverter{}
-	logger := slog.New(slog.NewTextHandler(&testingWriter{t}, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	}))
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(io.MultiWriter(&buf, &testingWriter{t}), &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			}))
+
 			uInput := toUnstructured(t, tc.input)
 
 			actual, err := converter.Convert(context.Background(), logger, uInput, NewResourceCache())
@@ -1622,6 +1856,16 @@ func TestPodMonitorConversion(t *testing.T) {
 
 			if err != nil {
 				t.Fatalf("Convert failed: %v", err)
+			}
+
+			// Check that all expected warning substrings appear in the log output.
+			if len(tc.wantWarnings) > 0 {
+				outStr := buf.String()
+				for _, wantWarn := range tc.wantWarnings {
+					if !strings.Contains(outStr, wantWarn) {
+						t.Errorf("expected warning containing %q, got logs:\n%s", wantWarn, outStr)
+					}
+				}
 			}
 
 			if len(actual) != len(tc.expected) {

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -716,7 +716,8 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 			wantWarnings: []string{
-				"is unsupported in GMP (only node name is supported). The rule has been dropped.",
+				`Relabeling rule referencing node label \"__meta_kubernetes_node_label_topology_kubernetes_io_zone\" is unsupported in GMP (only node name is supported). The rule has been dropped.`,
+				`Relabeling rule referencing node label \"__meta_kubernetes_node_label_kubernetes_io_hostname\" is unsupported in GMP (only node name is supported). The rule has been dropped.`,
 			},
 			expected: []runtime.Object{
 				&monitoringv1.PodMonitoring{
@@ -1345,6 +1346,117 @@ func TestPodMonitorConversion(t *testing.T) {
 				&monitoringv1.ClusterPodMonitoring{
 					TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
 					ObjectMeta: metav1.ObjectMeta{Name: "cluster-node-metadata-monitor"},
+					Spec: monitoringv1.ClusterPodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+						TargetLabels: monitoringv1.ClusterTargetLabels{
+							Metadata: ptrTo([]string{"container", "namespace", labelNode, "pod", "top_level_controller_name", "top_level_controller_type"}),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Scope-aware Metadata: AttachMetadata.Node merges with existing relabeling metadata in PodMonitoring",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node-metadata-merge-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					AttachMetadata: &pomonitoringv1.AttachMetadata{
+						Node: ptrTo(true),
+					},
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:     "metrics",
+							Interval: "30s",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+									TargetLabel:  "pod",
+									Action:       "replace",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "node-metadata-merge-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+						TargetLabels: monitoringv1.TargetLabels{
+							Metadata: ptrTo([]string{labelContainer, labelNode, labelPod, labelTopLevelControllerName, labelTopLevelControllerType}),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Scope-aware Metadata: AttachMetadata.Node merges with existing relabeling metadata in ClusterPodMonitoring",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-node-metadata-merge-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					NamespaceSelector: pomonitoringv1.NamespaceSelector{
+						Any: true,
+					},
+					AttachMetadata: &pomonitoringv1.AttachMetadata{
+						Node: ptrTo(true),
+					},
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:     "metrics",
+							Interval: "30s",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+									TargetLabel:  "pod",
+									Action:       "replace",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.ClusterPodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindClusterPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-node-metadata-merge-monitor"},
 					Spec: monitoringv1.ClusterPodMonitoringSpec{
 						Selector: metav1.LabelSelector{
 							MatchLabels: map[string]string{"app": "test"},

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -682,7 +682,7 @@ func TestPodMonitorConversion(t *testing.T) {
 			},
 		},
 		{
-			name: "Pre-Scrape Relabelings: drop relabeling rule referencing node Kubernetes labels with warning",
+			name: "Pre-Scrape Relabelings: drop relabeling rule referencing node Kubernetes metadata with warning",
 			input: &pomonitoringv1.PodMonitor{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "monitoring.coreos.com/v1",
@@ -710,14 +710,20 @@ func TestPodMonitorConversion(t *testing.T) {
 									TargetLabel:  "hostname",
 									Action:       "replace",
 								},
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_node_annotation_example"},
+									TargetLabel:  "example",
+									Action:       "replace",
+								},
 							},
 						},
 					},
 				},
 			},
 			wantWarnings: []string{
-				`Relabeling rule referencing node label \"__meta_kubernetes_node_label_topology_kubernetes_io_zone\" is unsupported in GMP (only node name is supported). The rule has been dropped.`,
-				`Relabeling rule referencing node label \"__meta_kubernetes_node_label_kubernetes_io_hostname\" is unsupported in GMP (only node name is supported). The rule has been dropped.`,
+				`Relabeling rule referencing node metadata \"__meta_kubernetes_node_label_topology_kubernetes_io_zone\" is unsupported in GMP (only node name is supported). The rule has been dropped.`,
+				`Relabeling rule referencing node metadata \"__meta_kubernetes_node_label_kubernetes_io_hostname\" is unsupported in GMP (only node name is supported). The rule has been dropped.`,
+				`Relabeling rule referencing node metadata \"__meta_kubernetes_node_annotation_example\" is unsupported in GMP (only node name is supported). The rule has been dropped.`,
 			},
 			expected: []runtime.Object{
 				&monitoringv1.PodMonitoring{

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -1265,6 +1265,53 @@ func TestPodMonitorConversion(t *testing.T) {
 			},
 		},
 		{
+			name: "Scope-aware Metadata: AttachMetadata.Node seeds from namespacedMetadataDefaults in PodMonitoring",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node-metadata-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					AttachMetadata: &pomonitoringv1.AttachMetadata{
+						Node: ptrTo(true),
+					},
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:     "metrics",
+							Interval: "30s",
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "node-metadata-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+						TargetLabels: monitoringv1.TargetLabels{
+							Metadata: ptrTo([]string{labelContainer, labelNode, labelPod, labelTopLevelControllerName, labelTopLevelControllerType}),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Scope-aware Metadata: AttachMetadata.Node seeds from clusterMetadataDefaults in ClusterPodMonitoring",
 			input: &pomonitoringv1.PodMonitor{
 				TypeMeta: metav1.TypeMeta{
@@ -1607,7 +1654,7 @@ func TestPodMonitorConversion(t *testing.T) {
 							},
 						},
 						TargetLabels: monitoringv1.TargetLabels{
-							Metadata: &[]string{labelNode},
+							Metadata: ptrTo([]string{labelContainer, labelNode, labelPod, labelTopLevelControllerName, labelTopLevelControllerType}),
 						},
 						Limits: &monitoringv1.ScrapeLimits{
 							Samples:          5000,

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -681,6 +681,61 @@ func TestPodMonitorConversion(t *testing.T) {
 			},
 		},
 		{
+			name: "Pre-Scrape Relabelings: drop relabeling rule referencing node Kubernetes labels with warning",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node-relabel-monitor",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "metrics",
+							RelabelConfigs: []pomonitoringv1.RelabelConfig{
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_node_label_topology_kubernetes_io_zone"},
+									TargetLabel:  "zone",
+									Action:       "replace",
+								},
+								{
+									SourceLabels: []pomonitoringv1.LabelName{"__meta_kubernetes_node_label_kubernetes_io_hostname"},
+									TargetLabel:  "hostname",
+									Action:       "replace",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantWarnings: []string{
+				"is unsupported in GMP (only node name is supported). The rule has been dropped.",
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "node-relabel-monitor", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "test"},
+						},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("metrics"),
+								Interval: "30s",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Pre-Scrape Relabelings: target filtering keep rule translated to Pod Selector, drop rule falls through to metricRelabeling",
 			input: &pomonitoringv1.PodMonitor{
 				TypeMeta: metav1.TypeMeta{
@@ -1518,9 +1573,12 @@ func TestPodMonitorConversion(t *testing.T) {
 						Node: ptrTo(true),
 					},
 					SampleLimit:           ptrTo(uint64(5000)),
+					TargetLimit:           ptrTo(uint64(100)),
+					KeepDroppedTargets:    ptrTo(uint64(50)),
 					LabelLimit:            ptrTo(uint64(50)),
 					LabelNameLengthLimit:  ptrTo(uint64(100)),
 					LabelValueLengthLimit: ptrTo(uint64(200)),
+					BodySizeLimit:         ptrTo(pomonitoringv1.ByteSize("10MB")),
 					ScrapeClassName:       ptrTo("custom-class"),
 					Selector: metav1.LabelSelector{
 						MatchLabels: map[string]string{"app": "advanced"},
@@ -1562,8 +1620,11 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 			wantWarnings: []string{
-				"Field 'followRedirects: false' is unsupported by GMP Managed Collection and has been dropped.",
-				"Field 'enableHttp2: false' is unsupported by GMP Managed Collection and has been dropped.",
+				"Field 'targetLimit' is unnecessary in GMP Managed Collection and has been dropped. Target discovery and scaling are managed automatically by GKE.",
+				"Field 'keepDroppedTargets' is unnecessary in GMP Managed Collection and has been dropped.",
+				"Field 'bodySizeLimit' is unsupported by GMP Managed Collection and has been dropped. Scrape response buffer limits are managed automatically by GMP.",
+				"endpoint [0]: field 'followRedirects: false' is unsupported by GMP Managed Collection and has been dropped.",
+				"endpoint [0]: field 'enableHttp2: false' is unsupported by GMP Managed Collection and has been dropped.",
 				"was not found in the inputs. The 'scrapeClassName' field has been dropped",
 			},
 		},
@@ -1586,9 +1647,12 @@ func TestPodMonitorConversion(t *testing.T) {
 						Node: ptrTo(true),
 					},
 					SampleLimit:           ptrTo(uint64(5000)),
+					TargetLimit:           ptrTo(uint64(100)),
+					KeepDroppedTargets:    ptrTo(uint64(50)),
 					LabelLimit:            ptrTo(uint64(50)),
 					LabelNameLengthLimit:  ptrTo(uint64(100)),
 					LabelValueLengthLimit: ptrTo(uint64(200)),
+					BodySizeLimit:         ptrTo(pomonitoringv1.ByteSize("10MB")),
 					ScrapeClassName:       ptrTo("custom-class"),
 					Selector: metav1.LabelSelector{
 						MatchLabels: map[string]string{"app": "advanced"},
@@ -1605,8 +1669,11 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 			wantWarnings: []string{
-				"Field 'followRedirects: false' is unsupported by GMP Managed Collection and has been dropped.",
-				"Field 'enableHttp2: false' is unsupported by GMP Managed Collection and has been dropped.",
+				"Field 'targetLimit' is unnecessary in GMP Managed Collection and has been dropped. Target discovery and scaling are managed automatically by GKE.",
+				"Field 'keepDroppedTargets' is unnecessary in GMP Managed Collection and has been dropped.",
+				"Field 'bodySizeLimit' is unsupported by GMP Managed Collection and has been dropped. Scrape response buffer limits are managed automatically by GMP.",
+				"endpoint [0]: field 'followRedirects: false' is unsupported by GMP Managed Collection and has been dropped.",
+				"endpoint [0]: field 'enableHttp2: false' is unsupported by GMP Managed Collection and has been dropped.",
 				"was not found in the inputs. The 'scrapeClassName' field has been dropped",
 			},
 			expected: []runtime.Object{

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -1509,6 +1509,94 @@ func TestPodMonitorConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "ScrapeProtocols protobuf warning",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "scrape-protocols-warn",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					ScrapeProtocols: []pomonitoringv1.ScrapeProtocol{
+						"application/openmetrics-text",
+						"application/vnd.google.protobuf",
+					},
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "scrape-protocols"},
+					},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port: "web",
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "scrape-protocols-warn", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "scrape-protocols"}},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("web"),
+								Interval: "30s",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "FilterRunning conflict resolution",
+			input: &pomonitoringv1.PodMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       KindPodMonitor,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "filter-running-conflict",
+					Namespace: "default",
+				},
+				Spec: pomonitoringv1.PodMonitorSpec{
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "filter-running"}},
+					PodMetricsEndpoints: []pomonitoringv1.PodMetricsEndpoint{
+						{
+							Port:          "web-1",
+							FilterRunning: ptrTo(false),
+						},
+						{
+							Port:          "web-2",
+							FilterRunning: ptrTo(true),
+						},
+					},
+				},
+			},
+			expected: []runtime.Object{
+				&monitoringv1.PodMonitoring{
+					TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+					ObjectMeta: metav1.ObjectMeta{Name: "filter-running-conflict", Namespace: "default"},
+					Spec: monitoringv1.PodMonitoringSpec{
+						Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "filter-running"}},
+						Endpoints: []monitoringv1.ScrapeEndpoint{
+							{
+								Port:     intstr.FromString("web-1"),
+								Interval: "30s",
+							},
+							{
+								Port:     intstr.FromString("web-2"),
+								Interval: "30s",
+							},
+						},
+						FilterRunning: ptrTo(false),
+					},
+				},
+			},
+		},
 	}
 
 	converter := &PodMonitorConverter{}


### PR DESCRIPTION
This change completes the missing configuration fields in the PodMonitor migration path to GKE Managed Prometheus (PodMonitoring and ClusterPodMonitoring).

Key changes:
* **Node Metadata Mapping:** Maps `attachMetadata.node` to `targetLabels.metadata: ["node"]`.
* **Limits Mapping:** Maps `sampleLimit`, `labelLimit`, `labelNameLengthLimit`, and `labelValueLengthLimit` to GMP's `ScrapeLimits`.
* **FilterRunning aggregation:** Aggregates endpoint-level `filterRunning` configurations to the resource level.
* **ScrapeClass TODO & Warnings:** Emits warning logs when a `scrapeClassName` is configured, noting that inherited settings will be lost. Added a TODO code comments to resolve and merge `ScrapeClass` settings from the Prometheus CR once that migration pipeline is implemented.