### PR TITLE
PO to GMP Migration Tool: Service Resolution Functions

### DIFF
--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -1310,7 +1310,7 @@ func resolveServicePort(logger *slog.Logger, svc *corev1.Service, portStr string
 	}
 
 	for _, p := range svc.Spec.Ports {
-		if p.Port < 1 {
+		if p.Port < 1 || p.Port > 65535 {
 			logger.Warn("Service port entry has an invalid or out-of-range port number. Skipping malformed entry.",
 				slog.String("service", svc.Name),
 				slog.String("port_name", p.Name),
@@ -1336,6 +1336,7 @@ func convertServiceTargetLabels(logger *slog.Logger, svc *corev1.Service, target
 	}
 
 	var rules []monitoringv1.RelabelingRule
+	seenTargets := make(map[string]bool)
 
 	for _, l := range targetLabels {
 		val, ok := svc.Labels[l]
@@ -1353,6 +1354,15 @@ func convertServiceTargetLabels(logger *slog.Logger, svc *corev1.Service, target
 				slog.String("label", l),
 				slog.String("renamed_target", target))
 		}
+
+		if seenTargets[target] {
+			logger.Warn("Service targetLabel mapping collision. Skipping.",
+				slog.String("service", svc.Name),
+				slog.String("source_label", l),
+				slog.String("target_label", target))
+			continue
+		}
+		seenTargets[target] = true
 
 		rules = append(rules, monitoringv1.RelabelingRule{
 			TargetLabel: target,

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -1156,7 +1156,6 @@ func buildClusterPodMonitoring(
 
 // resolveScrapeClass handles ScrapeClass resolution.
 // Logs a warning that ScrapeClass settings will be lost.
-// TODO(M2): Lookup ScrapeClass from Prometheus CR and merge its settings.
 func resolveScrapeClass(name *string, logger *slog.Logger) {
 	if name != nil && *name != "" {
 		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *name))

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"slices"
 	"strings"
 
@@ -28,10 +27,10 @@ import (
 	prommodel "github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/google/export"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/util/strutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -1298,63 +1297,31 @@ func combineAndConvertRelabelings(logger *slog.Logger, promoted []monitoringv1.R
 	return allRules
 }
 
-// findServicesBySelector finds Services matching the selector in target namespaces (all if empty).
-func (c *ResourceCache) findServicesBySelector(selector metav1.LabelSelector, namespaces []string) ([]*unstructured.Unstructured, error) {
-	sel, err := metav1.LabelSelectorAsSelector(&selector)
-	if err != nil {
-		return nil, fmt.Errorf("invalid selector: %w", err)
-	}
-
-	var matched []*unstructured.Unstructured
-
-	if c == nil || c.resources == nil {
-		return nil, nil
-	}
-
-	services, ok := c.resources[KindService]
-	if !ok {
-		return nil, nil
-	}
-
-	// To make output deterministic, we sort the keys before iterating.
-	keys := slices.AppendSeq(make([]string, 0, len(services)), maps.Keys(services))
-	slices.Sort(keys)
-
-	for _, key := range keys {
-		svc := services[key]
-		svcNS := svc.GetNamespace()
-
-		if len(namespaces) > 0 && !slices.Contains(namespaces, svcNS) {
-			continue
-		}
-
-		svcLabels := svc.GetLabels()
-		if sel.Matches(labels.Set(svcLabels)) {
-			matched = append(matched, svc)
-		}
-	}
-	return matched, nil
-}
-
-// asInt32 coerces various Go numeric types into an int32.
+// asInt32 coerces various Go numeric types into an int32 within the valid port range [0, 65535].
 func asInt32(val any) (int32, bool) {
+	var n int64
 	switch v := val.(type) {
 	case int:
-		return int32(v), true
+		n = int64(v)
 	case int32:
-		return v, true
+		n = int64(v)
 	case int64:
-		return int32(v), true
+		n = v
 	case float32:
-		return int32(v), true
+		n = int64(v)
 	case float64:
-		return int32(v), true
+		n = int64(v)
+	default:
+		return 0, false
 	}
-	return 0, false
+	if n < 0 || n > 65535 {
+		return 0, false
+	}
+	return int32(n), true
 }
 
 // resolveServicePort resolves a Service port to the backing Pod's target port.
-func resolveServicePort(svc *unstructured.Unstructured, portStr string) (intstr.IntOrString, error) {
+func resolveServicePort(logger *slog.Logger, svc *unstructured.Unstructured, portStr string) (intstr.IntOrString, error) {
 	if portStr == "" {
 		return intstr.IntOrString{}, errors.New("port string cannot be empty")
 	}
@@ -1373,27 +1340,36 @@ func resolveServicePort(svc *unstructured.Unstructured, portStr string) (intstr.
 	for _, p := range ports {
 		portMap, ok := p.(map[string]any)
 		if !ok {
+			logger.Warn("Service port entry is not a valid map. Skipping malformed entry.",
+				slog.String("service", svc.GetName()))
 			continue
 		}
 
 		name, _, _ := unstructured.NestedString(portMap, "name")
 		portVal, foundField, err := unstructured.NestedFieldNoCopy(portMap, "port")
-		if err != nil {
-			return intstr.IntOrString{}, fmt.Errorf("failed to read port field: %w", err)
-		}
-		if !foundField {
-			return intstr.IntOrString{}, errors.New("service port spec is missing the port number")
+		if err != nil || !foundField {
+			logger.Warn("Service port spec is missing the port number. Skipping malformed entry.",
+				slog.String("service", svc.GetName()),
+				slog.String("port_name", name))
+			continue
 		}
 		portNum, ok := asInt32(portVal)
-		if !ok {
-			return intstr.IntOrString{}, fmt.Errorf("invalid port number type in Service spec: %T", portVal)
+		if !ok || portNum < 1 {
+			logger.Warn("Service port entry has an invalid or out-of-range port number. Skipping malformed entry.",
+				slog.String("service", svc.GetName()),
+				slog.String("port_name", name),
+				slog.Any("port_value", portVal))
+			continue
 		}
 
 		// Match by name or port number (as string).
 		if name == portStr || fmt.Sprintf("%d", portNum) == portStr {
 			targetPort, found, err := unstructured.NestedFieldNoCopy(portMap, "targetPort")
 			if err != nil {
-				return intstr.IntOrString{}, fmt.Errorf("failed to read targetPort: %w", err)
+				logger.Warn("Failed to read targetPort from Service port spec. Skipping malformed entry.",
+					slog.String("service", svc.GetName()),
+					slog.String("port_name", name))
+				continue
 			}
 			if !found {
 				// If targetPort is omitted, it defaults to the port number.
@@ -1402,6 +1378,9 @@ func resolveServicePort(svc *unstructured.Unstructured, portStr string) (intstr.
 
 			// targetPort can be int, float64, or string.
 			if valStr, ok := targetPort.(string); ok {
+				if valStr == "" {
+					return intstr.FromInt32(portNum), nil
+				}
 				return intstr.FromString(valStr), nil
 			}
 
@@ -1412,7 +1391,11 @@ func resolveServicePort(svc *unstructured.Unstructured, portStr string) (intstr.
 				return intstr.FromInt32(valNum), nil
 			}
 
-			return intstr.IntOrString{}, fmt.Errorf("invalid targetPort type: %T", targetPort)
+			logger.Warn("Service port entry has an invalid targetPort type. Skipping malformed entry.",
+				slog.String("service", svc.GetName()),
+				slog.String("port_name", name),
+				slog.Any("target_port", targetPort))
+			continue
 		}
 	}
 
@@ -1437,9 +1420,9 @@ func convertServiceTargetLabels(logger *slog.Logger, svc *unstructured.Unstructu
 			continue
 		}
 
-		target := l
-		if protectedLabels[l] {
-			target = "exported_" + l
+		target := strutil.SanitizeLabelName(l)
+		if protectedLabels[target] {
+			target = "exported_" + target
 			logger.Warn("Service targetLabel matches protected label. Renamed target.",
 				slog.String("label", l),
 				slog.String("renamed_target", target))

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 
@@ -30,7 +31,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -86,7 +89,7 @@ type relabelingData struct {
 	rewrittenSources []string
 }
 
-// preScrapeRelabelingResult holds the label mappings and selector rules extracted from pre-scrape relabelings.
+// PreScrapeRelabelingResult holds the label mappings and selector rules extracted from pre-scrape relabelings.
 type preScrapeRelabelingResult struct {
 	FromPod          []monitoringv1.LabelMapping
 	Metadata         *[]string
@@ -95,7 +98,7 @@ type preScrapeRelabelingResult struct {
 	PromotedRules    []monitoringv1.RelabelingRule
 }
 
-// extractedPreScrapeRules holds all translated rules, separated by where they belong in GMP.
+// ExtractedPreScrapeRules holds all translated rules, separated by where they belong in GMP.
 type extractedPreScrapeRules struct {
 	// PerEndpoint contains the rules (like promoted metric relabelings) specific to each scrape endpoint.
 	PerEndpoint []preScrapeRelabelingResult
@@ -1293,4 +1296,164 @@ func combineAndConvertRelabelings(logger *slog.Logger, promoted []monitoringv1.R
 		return nil
 	}
 	return allRules
+}
+
+// findServicesBySelector finds Services matching the selector in target namespaces (all if empty).
+func (c *ResourceCache) findServicesBySelector(selector metav1.LabelSelector, namespaces []string) ([]*unstructured.Unstructured, error) {
+	sel, err := metav1.LabelSelectorAsSelector(&selector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid selector: %w", err)
+	}
+
+	var matched []*unstructured.Unstructured
+
+	if c == nil || c.resources == nil {
+		return nil, nil
+	}
+
+	services, ok := c.resources[KindService]
+	if !ok {
+		return nil, nil
+	}
+
+	// To make output deterministic, we sort the keys before iterating.
+	keys := slices.AppendSeq(make([]string, 0, len(services)), maps.Keys(services))
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		svc := services[key]
+		svcNS := svc.GetNamespace()
+
+		if len(namespaces) > 0 && !slices.Contains(namespaces, svcNS) {
+			continue
+		}
+
+		svcLabels := svc.GetLabels()
+		if sel.Matches(labels.Set(svcLabels)) {
+			matched = append(matched, svc)
+		}
+	}
+	return matched, nil
+}
+
+// asInt32 coerces various Go numeric types into an int32.
+func asInt32(val any) (int32, bool) {
+	switch v := val.(type) {
+	case int:
+		return int32(v), true
+	case int32:
+		return v, true
+	case int64:
+		return int32(v), true
+	case float32:
+		return int32(v), true
+	case float64:
+		return int32(v), true
+	}
+	return 0, false
+}
+
+// resolveServicePort resolves a Service port to the backing Pod's target port.
+func resolveServicePort(svc *unstructured.Unstructured, portStr string) (intstr.IntOrString, error) {
+	if portStr == "" {
+		return intstr.IntOrString{}, errors.New("port string cannot be empty")
+	}
+	if svc == nil || svc.Object == nil {
+		return intstr.IntOrString{}, errors.New("cannot resolve port on nil or uninitialized Service")
+	}
+
+	ports, found, err := unstructured.NestedSlice(svc.Object, "spec", "ports")
+	if err != nil {
+		return intstr.IntOrString{}, fmt.Errorf("failed to read Service ports: %w", err)
+	}
+	if !found {
+		return intstr.IntOrString{}, errors.New("service has no ports defined in spec")
+	}
+
+	for _, p := range ports {
+		portMap, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _, _ := unstructured.NestedString(portMap, "name")
+		portVal, foundField, err := unstructured.NestedFieldNoCopy(portMap, "port")
+		if err != nil {
+			return intstr.IntOrString{}, fmt.Errorf("failed to read port field: %w", err)
+		}
+		if !foundField {
+			return intstr.IntOrString{}, errors.New("service port spec is missing the port number")
+		}
+		portNum, ok := asInt32(portVal)
+		if !ok {
+			return intstr.IntOrString{}, fmt.Errorf("invalid port number type in Service spec: %T", portVal)
+		}
+
+		// Match by name or port number (as string).
+		if name == portStr || fmt.Sprintf("%d", portNum) == portStr {
+			targetPort, found, err := unstructured.NestedFieldNoCopy(portMap, "targetPort")
+			if err != nil {
+				return intstr.IntOrString{}, fmt.Errorf("failed to read targetPort: %w", err)
+			}
+			if !found {
+				// If targetPort is omitted, it defaults to the port number.
+				return intstr.FromInt32(portNum), nil
+			}
+
+			// targetPort can be int, float64, or string.
+			if valStr, ok := targetPort.(string); ok {
+				return intstr.FromString(valStr), nil
+			}
+
+			if valNum, ok := asInt32(targetPort); ok {
+				if valNum == 0 {
+					return intstr.FromInt32(portNum), nil
+				}
+				return intstr.FromInt32(valNum), nil
+			}
+
+			return intstr.IntOrString{}, fmt.Errorf("invalid targetPort type: %T", targetPort)
+		}
+	}
+
+	return intstr.IntOrString{}, fmt.Errorf("port %q not found in Service spec", portStr)
+}
+
+// convertServiceTargetLabels maps Service labels to static metricRelabeling rules.
+func convertServiceTargetLabels(logger *slog.Logger, svc *unstructured.Unstructured, targetLabels []string) []monitoringv1.RelabelingRule {
+	if svc == nil || len(targetLabels) == 0 {
+		return nil
+	}
+
+	svcLabels := svc.GetLabels()
+	var rules []monitoringv1.RelabelingRule
+
+	for _, l := range targetLabels {
+		val, ok := svcLabels[l]
+		if !ok {
+			logger.Warn("Service-level targetLabel was not found on Service. Skipping mapping.",
+				slog.String("label", l),
+				slog.String("service", svc.GetName()))
+			continue
+		}
+
+		target := l
+		if protectedLabels[l] {
+			target = "exported_" + l
+			logger.Warn("Service targetLabel matches protected label. Renamed target.",
+				slog.String("label", l),
+				slog.String("renamed_target", target))
+		}
+
+		rules = append(rules, monitoringv1.RelabelingRule{
+			TargetLabel: target,
+			Replacement: val,
+			Action:      string(relabel.Replace),
+		})
+
+		logger.Info("Service label mapped statically to metricRelabeling. Note: Changes to the Service label will not be dynamically reflected on metrics.",
+			slog.String("label", fmt.Sprintf("%s: %s", l, val)))
+	}
+
+	return rules
 }

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -1297,105 +1297,32 @@ func combineAndConvertRelabelings(logger *slog.Logger, promoted []monitoringv1.R
 	return allRules
 }
 
-// asInt32 coerces various Go numeric types into an int32 within the valid port range [0, 65535].
-func asInt32(val any) (int32, bool) {
-	var n int64
-	switch v := val.(type) {
-	case int:
-		n = int64(v)
-	case int32:
-		n = int64(v)
-	case int64:
-		n = v
-	case float32:
-		n = int64(v)
-	case float64:
-		n = int64(v)
-	default:
-		return 0, false
-	}
-	if n < 0 || n > 65535 {
-		return 0, false
-	}
-	return int32(n), true
-}
-
 // resolveServicePort resolves a Service port to the backing Pod's target port.
-func resolveServicePort(logger *slog.Logger, svc *unstructured.Unstructured, portStr string) (intstr.IntOrString, error) {
+func resolveServicePort(logger *slog.Logger, svc *corev1.Service, portStr string) (intstr.IntOrString, error) {
 	if portStr == "" {
 		return intstr.IntOrString{}, errors.New("port string cannot be empty")
 	}
-	if svc == nil || svc.Object == nil {
+	if svc == nil {
 		return intstr.IntOrString{}, errors.New("cannot resolve port on nil or uninitialized Service")
 	}
-
-	ports, found, err := unstructured.NestedSlice(svc.Object, "spec", "ports")
-	if err != nil {
-		return intstr.IntOrString{}, fmt.Errorf("failed to read Service ports: %w", err)
-	}
-	if !found {
+	if len(svc.Spec.Ports) == 0 {
 		return intstr.IntOrString{}, errors.New("service has no ports defined in spec")
 	}
 
-	for _, p := range ports {
-		portMap, ok := p.(map[string]any)
-		if !ok {
-			logger.Warn("Service port entry is not a valid map. Skipping malformed entry.",
-				slog.String("service", svc.GetName()))
-			continue
-		}
-
-		name, _, _ := unstructured.NestedString(portMap, "name")
-		portVal, foundField, err := unstructured.NestedFieldNoCopy(portMap, "port")
-		if err != nil || !foundField {
-			logger.Warn("Service port spec is missing the port number. Skipping malformed entry.",
-				slog.String("service", svc.GetName()),
-				slog.String("port_name", name))
-			continue
-		}
-		portNum, ok := asInt32(portVal)
-		if !ok || portNum < 1 {
+	for _, p := range svc.Spec.Ports {
+		if p.Port < 1 {
 			logger.Warn("Service port entry has an invalid or out-of-range port number. Skipping malformed entry.",
-				slog.String("service", svc.GetName()),
-				slog.String("port_name", name),
-				slog.Any("port_value", portVal))
+				slog.String("service", svc.Name),
+				slog.String("port_name", p.Name),
+				slog.Int("port_value", int(p.Port)))
 			continue
 		}
 
-		// Match by name or port number (as string).
-		if name == portStr || fmt.Sprintf("%d", portNum) == portStr {
-			targetPort, found, err := unstructured.NestedFieldNoCopy(portMap, "targetPort")
-			if err != nil {
-				logger.Warn("Failed to read targetPort from Service port spec. Skipping malformed entry.",
-					slog.String("service", svc.GetName()),
-					slog.String("port_name", name))
-				continue
+		if p.Name == portStr || fmt.Sprintf("%d", p.Port) == portStr {
+			if p.TargetPort.IntVal == 0 && p.TargetPort.StrVal == "" {
+				return intstr.FromInt32(p.Port), nil
 			}
-			if !found {
-				// If targetPort is omitted, it defaults to the port number.
-				return intstr.FromInt32(portNum), nil
-			}
-
-			// targetPort can be int, float64, or string.
-			if valStr, ok := targetPort.(string); ok {
-				if valStr == "" {
-					return intstr.FromInt32(portNum), nil
-				}
-				return intstr.FromString(valStr), nil
-			}
-
-			if valNum, ok := asInt32(targetPort); ok {
-				if valNum == 0 {
-					return intstr.FromInt32(portNum), nil
-				}
-				return intstr.FromInt32(valNum), nil
-			}
-
-			logger.Warn("Service port entry has an invalid targetPort type. Skipping malformed entry.",
-				slog.String("service", svc.GetName()),
-				slog.String("port_name", name),
-				slog.Any("target_port", targetPort))
-			continue
+			return p.TargetPort, nil
 		}
 	}
 
@@ -1403,20 +1330,19 @@ func resolveServicePort(logger *slog.Logger, svc *unstructured.Unstructured, por
 }
 
 // convertServiceTargetLabels maps Service labels to static metricRelabeling rules.
-func convertServiceTargetLabels(logger *slog.Logger, svc *unstructured.Unstructured, targetLabels []string) []monitoringv1.RelabelingRule {
+func convertServiceTargetLabels(logger *slog.Logger, svc *corev1.Service, targetLabels []string) []monitoringv1.RelabelingRule {
 	if svc == nil || len(targetLabels) == 0 {
 		return nil
 	}
 
-	svcLabels := svc.GetLabels()
 	var rules []monitoringv1.RelabelingRule
 
 	for _, l := range targetLabels {
-		val, ok := svcLabels[l]
+		val, ok := svc.Labels[l]
 		if !ok {
 			logger.Warn("Service-level targetLabel was not found on Service. Skipping mapping.",
 				slog.String("label", l),
-				slog.String("service", svc.GetName()))
+				slog.String("service", svc.Name))
 			continue
 		}
 

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -1156,6 +1156,7 @@ func buildClusterPodMonitoring(
 
 // resolveScrapeClass handles ScrapeClass resolution.
 // Logs a warning that ScrapeClass settings will be lost.
+// TODO(M2): Lookup ScrapeClass from Prometheus CR and merge its settings.
 func resolveScrapeClass(name *string, logger *slog.Logger) {
 	if name != nil && *name != "" {
 		logger.Warn(fmt.Sprintf("ScrapeClass %q was not found in the inputs. The 'scrapeClassName' field has been dropped and inherited settings will be lost.", *name))

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -1081,14 +1081,14 @@ func TestFindServicesBySelector(t *testing.T) {
 func TestResolveServicePort(t *testing.T) {
 	tests := []struct {
 		name     string
-		service  *unstructured.Unstructured
+		service  *corev1.Service
 		portStr  string
 		expected intstr.IntOrString
 		wantErr  bool
 	}{
 		{
 			name: "Resolve by name to int",
-			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
+			service: makeTestTypedService("default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
 			}),
 			portStr:  "web",
@@ -1097,7 +1097,7 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Resolve by name to string",
-			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
+			service: makeTestTypedService("default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80, TargetPort: intstr.FromString("http-web")},
 			}),
 			portStr:  "web",
@@ -1106,7 +1106,7 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Resolve by port number to targetPort int",
-			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
+			service: makeTestTypedService("default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
 			}),
 			portStr:  "80",
@@ -1114,33 +1114,17 @@ func TestResolveServicePort(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "Resolve by port number (float64 port and targetPort)",
-			service: &unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]any{
-						"name":      "my-svc",
-						"namespace": "default",
-					},
-					"spec": map[string]any{
-						"ports": []any{
-							map[string]any{
-								"name":       "web",
-								"port":       float64(80),
-								"targetPort": float64(8080),
-							},
-						},
-					},
-				},
-			},
+			name: "Resolve by port number",
+			service: makeTestTypedService("default", "my-svc", nil, []corev1.ServicePort{
+				{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
+			}),
 			portStr:  "80",
 			expected: intstr.FromInt32(8080),
 			wantErr:  false,
 		},
 		{
 			name: "Resolve with omitted targetPort",
-			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
+			service: makeTestTypedService("default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80},
 			}),
 			portStr:  "web",
@@ -1149,7 +1133,7 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Port not found",
-			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
+			service: makeTestTypedService("default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80},
 			}),
 			portStr:  "admin",
@@ -1165,25 +1149,12 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Skip malformed port entry and resolve valid later entry",
-			service: &unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]any{
-						"name":      "my-svc",
-						"namespace": "default",
-					},
-					"spec": map[string]any{
-						"ports": []any{
-							map[string]any{
-								"name": "malformed",
-							},
-							map[string]any{
-								"name":       "web",
-								"port":       int64(80),
-								"targetPort": int64(8080),
-							},
-						},
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "malformed", Port: 0},
+						{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
 					},
 				},
 			},
@@ -1193,24 +1164,12 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "All ports malformed returns error",
-			service: &unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]any{
-						"name":      "my-svc",
-						"namespace": "default",
-					},
-					"spec": map[string]any{
-						"ports": []any{
-							map[string]any{
-								"name": "malformed1",
-							},
-							map[string]any{
-								"name": "malformed2",
-								"port": "invalid-string-port",
-							},
-						},
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "malformed1", Port: 0},
+						{Name: "malformed2", Port: -1},
 					},
 				},
 			},
@@ -1220,26 +1179,12 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Out of range port number is rejected",
-			service: &unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]any{
-						"name":      "my-svc",
-						"namespace": "default",
-					},
-					"spec": map[string]any{
-						"ports": []any{
-							map[string]any{
-								"name": "overflow-port",
-								"port": int64(4294967297),
-							},
-							map[string]any{
-								"name":       "web",
-								"port":       int64(80),
-								"targetPort": int64(8080),
-							},
-						},
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "overflow-port", Port: -5},
+						{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
 					},
 				},
 			},
@@ -1249,7 +1194,7 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Resolve with empty string targetPort defaults to port number",
-			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
+			service: makeTestTypedService("default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80, TargetPort: intstr.FromString("")},
 			}),
 			portStr:  "web",
@@ -1279,13 +1224,13 @@ func TestResolveServicePort(t *testing.T) {
 func TestConvertServiceTargetLabels(t *testing.T) {
 	tests := []struct {
 		name         string
-		service      *unstructured.Unstructured
+		service      *corev1.Service
 		targetLabels []string
 		expected     []monitoringv1.RelabelingRule
 	}{
 		{
 			name: "Map service labels",
-			service: makeTestService(t, "default", "my-svc", map[string]string{
+			service: makeTestTypedService("default", "my-svc", map[string]string{
 				"app": "foo",
 				"env": "prod",
 			}, nil),
@@ -1297,7 +1242,7 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 		},
 		{
 			name: "Map service labels with protected rename",
-			service: makeTestService(t, "default", "my-svc", map[string]string{
+			service: makeTestTypedService("default", "my-svc", map[string]string{
 				"job": "foo",
 			}, nil),
 			targetLabels: []string{"job"},
@@ -1307,7 +1252,7 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 		},
 		{
 			name: "Missing label on service",
-			service: makeTestService(t, "default", "my-svc", map[string]string{
+			service: makeTestTypedService("default", "my-svc", map[string]string{
 				"app": "foo",
 			}, nil),
 			targetLabels: []string{"app", "team"},
@@ -1317,7 +1262,7 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 		},
 		{
 			name: "Map service labels with sanitization",
-			service: makeTestService(t, "default", "my-svc", map[string]string{
+			service: makeTestTypedService("default", "my-svc", map[string]string{
 				"app.kubernetes.io/name":    "foo",
 				"app.kubernetes.io/part-of": "bar",
 			}, nil),
@@ -1329,7 +1274,7 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 		},
 		{
 			name: "Map service labels with sanitization and protected rename",
-			service: makeTestService(t, "default", "my-svc", map[string]string{
+			service: makeTestTypedService("default", "my-svc", map[string]string{
 				"project.id": "my-project",
 			}, nil),
 			targetLabels: []string{"project.id"},
@@ -1375,6 +1320,21 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 				t.Errorf("Generated RelabelingRules failed operator compilation check: %v", err)
 			}
 		})
+	}
+}
+
+// makeTestTypedService builds a corev1.Service object from labels and ports.
+func makeTestTypedService(namespace, name string, labels map[string]string, ports []corev1.ServicePort) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: ports,
+		},
 	}
 }
 

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -1114,12 +1114,12 @@ func TestResolveServicePort(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "Resolve by port number",
+			name: "Resolve by port number to targetPort string",
 			service: makeTestTypedService("default", "my-svc", nil, []corev1.ServicePort{
-				{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
+				{Name: "web", Port: 80, TargetPort: intstr.FromString("http-web")},
 			}),
 			portStr:  "80",
-			expected: intstr.FromInt32(8080),
+			expected: intstr.FromString("http-web"),
 			wantErr:  false,
 		},
 		{
@@ -1184,6 +1184,7 @@ func TestResolveServicePort(t *testing.T) {
 				Spec: corev1.ServiceSpec{
 					Ports: []corev1.ServicePort{
 						{Name: "overflow-port", Port: -5},
+						{Name: "high-port", Port: 70000},
 						{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
 					},
 				},
@@ -1280,6 +1281,17 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 			targetLabels: []string{"project.id"},
 			expected: []monitoringv1.RelabelingRule{
 				{TargetLabel: "exported_project_id", Replacement: "my-project", Action: "replace"},
+			},
+		},
+		{
+			name: "Map service labels with collision skip",
+			service: makeTestTypedService("default", "my-svc", map[string]string{
+				"app.kubernetes.io/name": "foo",
+				"app_kubernetes_io_name": "bar",
+			}, nil),
+			targetLabels: []string{"app.kubernetes.io/name", "app_kubernetes_io_name"},
+			expected: []monitoringv1.RelabelingRule{
+				{TargetLabel: "app_kubernetes_io_name", Replacement: "foo", Action: "replace"},
 			},
 		},
 		{

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -1070,8 +1070,8 @@ func TestFindServicesBySelector(t *testing.T) {
 			}
 
 			for i, svc := range matched {
-				if svc.GetName() != tc.expected[i] {
-					t.Errorf("expected matched service at index %d to be %s, got %s", i, tc.expected[i], svc.GetName())
+				if svc.Name != tc.expected[i] {
+					t.Errorf("expected matched service at index %d to be %s, got %s", i, tc.expected[i], svc.Name)
 				}
 			}
 		})

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func newTestConversionContext() *conversionContext {
@@ -956,4 +957,326 @@ func TestDecoupledNamespaces(t *testing.T) {
 	if genSecrets[0].GetNamespace() != "target-ns" {
 		t.Errorf("expected generated secret namespace %q, got %q", "target-ns", genSecrets[0].GetNamespace())
 	}
+}
+func TestFindServicesBySelector(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupCache func(cache *ResourceCache) error
+		selector   metav1.LabelSelector
+		namespaces []string
+		expected   []string
+		wantErr    bool
+	}{
+		{
+			name: "Match single service by label",
+			setupCache: func(cache *ResourceCache) error {
+				return addServiceToCache(cache, "default", "svc-a", map[string]string{"app": "foo"})
+			},
+			selector:   metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			namespaces: []string{"default"},
+			expected:   []string{"svc-a"},
+			wantErr:    false,
+		},
+		{
+			name: "Match multiple services",
+			setupCache: func(cache *ResourceCache) error {
+				if err := addServiceToCache(cache, "default", "svc-a", map[string]string{"app": "foo"}); err != nil {
+					return err
+				}
+				return addServiceToCache(cache, "default", "svc-b", map[string]string{"app": "foo", "env": "prod"})
+			},
+			selector:   metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			namespaces: []string{"default"},
+			expected:   []string{"svc-a", "svc-b"},
+			wantErr:    false,
+		},
+		{
+			name: "Filter by namespace",
+			setupCache: func(cache *ResourceCache) error {
+				if err := addServiceToCache(cache, "ns-a", "svc-a", map[string]string{"app": "foo"}); err != nil {
+					return err
+				}
+				return addServiceToCache(cache, "ns-b", "svc-b", map[string]string{"app": "foo"})
+			},
+			selector:   metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			namespaces: []string{"ns-a"},
+			expected:   []string{"svc-a"},
+			wantErr:    false,
+		},
+		{
+			name: "Match any namespace",
+			setupCache: func(cache *ResourceCache) error {
+				if err := addServiceToCache(cache, "ns-a", "svc-a", map[string]string{"app": "foo"}); err != nil {
+					return err
+				}
+				return addServiceToCache(cache, "ns-b", "svc-b", map[string]string{"app": "foo"})
+			},
+			selector:   metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			namespaces: nil,
+			expected:   []string{"svc-a", "svc-b"},
+			wantErr:    false,
+		},
+		{
+			name: "No match",
+			setupCache: func(cache *ResourceCache) error {
+				return addServiceToCache(cache, "default", "svc-a", map[string]string{"app": "bar"})
+			},
+			selector:   metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			namespaces: []string{"default"},
+			expected:   nil,
+			wantErr:    false,
+		},
+		{
+			name:       "Invalid selector",
+			setupCache: func(_ *ResourceCache) error { return nil },
+			selector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "app",
+						Operator: "InvalidOperator",
+					},
+				},
+			},
+			namespaces: []string{"default"},
+			expected:   nil,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := NewResourceCache()
+			if err := tc.setupCache(cache); err != nil {
+				t.Fatalf("failed to setup cache: %v", err)
+			}
+
+			matched, err := cache.findServicesBySelector(tc.selector, tc.namespaces)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("findServicesBySelector() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+
+			if len(matched) != len(tc.expected) {
+				t.Fatalf("expected %d matches, got %d", len(tc.expected), len(matched))
+			}
+
+			for i, svc := range matched {
+				if svc.GetName() != tc.expected[i] {
+					t.Errorf("expected matched service at index %d to be %s, got %s", i, tc.expected[i], svc.GetName())
+				}
+			}
+		})
+	}
+}
+
+func TestResolveServicePort(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  *unstructured.Unstructured
+		portStr  string
+		expected intstr.IntOrString
+		wantErr  bool
+	}{
+		{
+			name: "Resolve by name to int",
+			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+				{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
+			}),
+			portStr:  "web",
+			expected: intstr.FromInt32(8080),
+			wantErr:  false,
+		},
+		{
+			name: "Resolve by name to string",
+			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+				{Name: "web", Port: 80, TargetPort: intstr.FromString("http-web")},
+			}),
+			portStr:  "web",
+			expected: intstr.FromString("http-web"),
+			wantErr:  false,
+		},
+		{
+			name: "Resolve by port number to targetPort int",
+			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+				{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
+			}),
+			portStr:  "80",
+			expected: intstr.FromInt32(8080),
+			wantErr:  false,
+		},
+		{
+			name: "Resolve by port number (float64 port and targetPort)",
+			service: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]any{
+						"name":      "my-svc",
+						"namespace": "default",
+					},
+					"spec": map[string]any{
+						"ports": []any{
+							map[string]any{
+								"name":       "web",
+								"port":       float64(80),
+								"targetPort": float64(8080),
+							},
+						},
+					},
+				},
+			},
+			portStr:  "80",
+			expected: intstr.FromInt32(8080),
+			wantErr:  false,
+		},
+		{
+			name: "Resolve with omitted targetPort",
+			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+				{Name: "web", Port: 80},
+			}),
+			portStr:  "web",
+			expected: intstr.FromInt32(80),
+			wantErr:  false,
+		},
+		{
+			name: "Port not found",
+			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+				{Name: "web", Port: 80},
+			}),
+			portStr:  "admin",
+			expected: intstr.IntOrString{},
+			wantErr:  true,
+		},
+		{
+			name:     "Nil service",
+			service:  nil,
+			portStr:  "web",
+			expected: intstr.IntOrString{},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveServicePort(tc.service, tc.portStr)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("resolveServicePort() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if got != tc.expected {
+				t.Errorf("expected %+v, got %+v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestConvertServiceTargetLabels(t *testing.T) {
+	tests := []struct {
+		name         string
+		service      *unstructured.Unstructured
+		targetLabels []string
+		expected     []monitoringv1.RelabelingRule
+	}{
+		{
+			name: "Map service labels",
+			service: makeTestServiceWithLabels("default", "my-svc", map[string]string{
+				"app": "foo",
+				"env": "prod",
+			}),
+			targetLabels: []string{"app", "env"},
+			expected: []monitoringv1.RelabelingRule{
+				{TargetLabel: "app", Replacement: "foo", Action: "replace"},
+				{TargetLabel: "env", Replacement: "prod", Action: "replace"},
+			},
+		},
+		{
+			name: "Map service labels with protected rename",
+			service: makeTestServiceWithLabels("default", "my-svc", map[string]string{
+				"job": "foo",
+			}),
+			targetLabels: []string{"job"},
+			expected: []monitoringv1.RelabelingRule{
+				{TargetLabel: "exported_job", Replacement: "foo", Action: "replace"},
+			},
+		},
+		{
+			name: "Missing label on service",
+			service: makeTestServiceWithLabels("default", "my-svc", map[string]string{
+				"app": "foo",
+			}),
+			targetLabels: []string{"app", "team"},
+			expected: []monitoringv1.RelabelingRule{
+				{TargetLabel: "app", Replacement: "foo", Action: "replace"},
+			},
+		},
+		{
+			name:         "Nil service",
+			service:      nil,
+			targetLabels: []string{"app"},
+			expected:     nil,
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertServiceTargetLabels(logger, tc.service, tc.targetLabels)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("expected %d rules, got %d", len(tc.expected), len(got))
+			}
+			for i, r := range got {
+				if r.TargetLabel != tc.expected[i].TargetLabel ||
+					r.Replacement != tc.expected[i].Replacement ||
+					r.Action != tc.expected[i].Action {
+					t.Errorf("expected rule at %d to be %+v, got %+v", i, tc.expected[i], r)
+				}
+			}
+		})
+	}
+}
+
+func addServiceToCache(cache *ResourceCache, namespace, name string, labels map[string]string) error {
+	svc := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+	}
+	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(svc)
+	return cache.Add(&unstructured.Unstructured{Object: u})
+}
+
+func makeTestService(namespace, name string, ports []corev1.ServicePort) *unstructured.Unstructured {
+	svc := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: ports,
+		},
+	}
+	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(svc)
+	return &unstructured.Unstructured{Object: u}
+}
+
+func makeTestServiceWithLabels(namespace, name string, labels map[string]string) *unstructured.Unstructured {
+	svc := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+	}
+	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(svc)
+	return &unstructured.Unstructured{Object: u}
 }

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -15,6 +15,7 @@
 package migrate
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -53,7 +54,10 @@ func addSecretToCache(cache *ResourceCache, namespace, name, key, value string, 
 		secret.Data = map[string][]byte{key: []byte(value)}
 	}
 
-	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
+	if err != nil {
+		return fmt.Errorf("failed to convert Secret %s/%s to unstructured: %w", namespace, name, err)
+	}
 	return cache.Add(&unstructured.Unstructured{Object: u})
 }
 
@@ -67,7 +71,10 @@ func addConfigMapToCache(cache *ResourceCache, namespace, name, key, value strin
 		Data: map[string]string{key: value},
 	}
 
-	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+	if err != nil {
+		return fmt.Errorf("failed to convert ConfigMap %s/%s to unstructured: %w", namespace, name, err)
+	}
 	return cache.Add(&unstructured.Unstructured{Object: u})
 }
 
@@ -970,7 +977,7 @@ func TestFindServicesBySelector(t *testing.T) {
 		{
 			name: "Match single service by label",
 			setupCache: func(cache *ResourceCache) error {
-				return addServiceToCache(cache, "default", "svc-a", map[string]string{"app": "foo"})
+				return addServiceToCache(t, cache, "default", "svc-a", map[string]string{"app": "foo"})
 			},
 			selector:   metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
 			namespaces: []string{"default"},
@@ -980,10 +987,10 @@ func TestFindServicesBySelector(t *testing.T) {
 		{
 			name: "Match multiple services",
 			setupCache: func(cache *ResourceCache) error {
-				if err := addServiceToCache(cache, "default", "svc-a", map[string]string{"app": "foo"}); err != nil {
+				if err := addServiceToCache(t, cache, "default", "svc-b", map[string]string{"app": "foo", "env": "prod"}); err != nil {
 					return err
 				}
-				return addServiceToCache(cache, "default", "svc-b", map[string]string{"app": "foo", "env": "prod"})
+				return addServiceToCache(t, cache, "default", "svc-a", map[string]string{"app": "foo"})
 			},
 			selector:   metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
 			namespaces: []string{"default"},
@@ -993,10 +1000,10 @@ func TestFindServicesBySelector(t *testing.T) {
 		{
 			name: "Filter by namespace",
 			setupCache: func(cache *ResourceCache) error {
-				if err := addServiceToCache(cache, "ns-a", "svc-a", map[string]string{"app": "foo"}); err != nil {
+				if err := addServiceToCache(t, cache, "ns-a", "svc-a", map[string]string{"app": "foo"}); err != nil {
 					return err
 				}
-				return addServiceToCache(cache, "ns-b", "svc-b", map[string]string{"app": "foo"})
+				return addServiceToCache(t, cache, "ns-b", "svc-b", map[string]string{"app": "foo"})
 			},
 			selector:   metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
 			namespaces: []string{"ns-a"},
@@ -1006,10 +1013,10 @@ func TestFindServicesBySelector(t *testing.T) {
 		{
 			name: "Match any namespace",
 			setupCache: func(cache *ResourceCache) error {
-				if err := addServiceToCache(cache, "ns-a", "svc-a", map[string]string{"app": "foo"}); err != nil {
+				if err := addServiceToCache(t, cache, "ns-a", "svc-a", map[string]string{"app": "foo"}); err != nil {
 					return err
 				}
-				return addServiceToCache(cache, "ns-b", "svc-b", map[string]string{"app": "foo"})
+				return addServiceToCache(t, cache, "ns-b", "svc-b", map[string]string{"app": "foo"})
 			},
 			selector:   metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
 			namespaces: nil,
@@ -1019,7 +1026,7 @@ func TestFindServicesBySelector(t *testing.T) {
 		{
 			name: "No match",
 			setupCache: func(cache *ResourceCache) error {
-				return addServiceToCache(cache, "default", "svc-a", map[string]string{"app": "bar"})
+				return addServiceToCache(t, cache, "default", "svc-a", map[string]string{"app": "bar"})
 			},
 			selector:   metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
 			namespaces: []string{"default"},
@@ -1081,7 +1088,7 @@ func TestResolveServicePort(t *testing.T) {
 	}{
 		{
 			name: "Resolve by name to int",
-			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
 			}),
 			portStr:  "web",
@@ -1090,7 +1097,7 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Resolve by name to string",
-			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80, TargetPort: intstr.FromString("http-web")},
 			}),
 			portStr:  "web",
@@ -1099,7 +1106,7 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Resolve by port number to targetPort int",
-			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80, TargetPort: intstr.FromInt32(8080)},
 			}),
 			portStr:  "80",
@@ -1133,7 +1140,7 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Resolve with omitted targetPort",
-			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80},
 			}),
 			portStr:  "web",
@@ -1142,7 +1149,7 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Port not found",
-			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80},
 			}),
 			portStr:  "admin",
@@ -1242,7 +1249,7 @@ func TestResolveServicePort(t *testing.T) {
 		},
 		{
 			name: "Resolve with empty string targetPort defaults to port number",
-			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+			service: makeTestService(t, "default", "my-svc", nil, []corev1.ServicePort{
 				{Name: "web", Port: 80, TargetPort: intstr.FromString("")},
 			}),
 			portStr:  "web",
@@ -1278,10 +1285,10 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 	}{
 		{
 			name: "Map service labels",
-			service: makeTestServiceWithLabels("default", "my-svc", map[string]string{
+			service: makeTestService(t, "default", "my-svc", map[string]string{
 				"app": "foo",
 				"env": "prod",
-			}),
+			}, nil),
 			targetLabels: []string{"app", "env"},
 			expected: []monitoringv1.RelabelingRule{
 				{TargetLabel: "app", Replacement: "foo", Action: "replace"},
@@ -1290,9 +1297,9 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 		},
 		{
 			name: "Map service labels with protected rename",
-			service: makeTestServiceWithLabels("default", "my-svc", map[string]string{
+			service: makeTestService(t, "default", "my-svc", map[string]string{
 				"job": "foo",
-			}),
+			}, nil),
 			targetLabels: []string{"job"},
 			expected: []monitoringv1.RelabelingRule{
 				{TargetLabel: "exported_job", Replacement: "foo", Action: "replace"},
@@ -1300,9 +1307,9 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 		},
 		{
 			name: "Missing label on service",
-			service: makeTestServiceWithLabels("default", "my-svc", map[string]string{
+			service: makeTestService(t, "default", "my-svc", map[string]string{
 				"app": "foo",
-			}),
+			}, nil),
 			targetLabels: []string{"app", "team"},
 			expected: []monitoringv1.RelabelingRule{
 				{TargetLabel: "app", Replacement: "foo", Action: "replace"},
@@ -1310,10 +1317,10 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 		},
 		{
 			name: "Map service labels with sanitization",
-			service: makeTestServiceWithLabels("default", "my-svc", map[string]string{
+			service: makeTestService(t, "default", "my-svc", map[string]string{
 				"app.kubernetes.io/name":    "foo",
 				"app.kubernetes.io/part-of": "bar",
-			}),
+			}, nil),
 			targetLabels: []string{"app.kubernetes.io/name", "app.kubernetes.io/part-of"},
 			expected: []monitoringv1.RelabelingRule{
 				{TargetLabel: "app_kubernetes_io_name", Replacement: "foo", Action: "replace"},
@@ -1322,9 +1329,9 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 		},
 		{
 			name: "Map service labels with sanitization and protected rename",
-			service: makeTestServiceWithLabels("default", "my-svc", map[string]string{
+			service: makeTestService(t, "default", "my-svc", map[string]string{
 				"project.id": "my-project",
-			}),
+			}, nil),
 			targetLabels: []string{"project.id"},
 			expected: []monitoringv1.RelabelingRule{
 				{TargetLabel: "exported_project_id", Replacement: "my-project", Action: "replace"},
@@ -1343,57 +1350,57 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := convertServiceTargetLabels(logger, tc.service, tc.targetLabels)
-			if len(got) != len(tc.expected) {
-				t.Fatalf("expected %d rules, got %d", len(tc.expected), len(got))
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("convertServiceTargetLabels() mismatch (-want +got):\n%s", diff)
 			}
-			for i, r := range got {
-				if r.TargetLabel != tc.expected[i].TargetLabel ||
-					r.Replacement != tc.expected[i].Replacement ||
-					r.Action != tc.expected[i].Action {
-					t.Errorf("expected rule at %d to be %+v, got %+v", i, tc.expected[i], r)
-				}
+
+			// Validate generated rules end-to-end using the operator's config compilation check.
+			pm := &monitoringv1.PodMonitoring{
+				TypeMeta:   BuildTypeMeta(KindPodMonitoring),
+				ObjectMeta: metav1.ObjectMeta{Name: "test-monitor", Namespace: "default"},
+				Spec: monitoringv1.PodMonitoringSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					Endpoints: []monitoringv1.ScrapeEndpoint{
+						{
+							Port:             intstr.FromString("metrics"),
+							Interval:         "30s",
+							MetricRelabeling: got,
+						},
+					},
+				},
+			}
+			if _, err := pm.ScrapeConfigs("test-project", "test-location", "test-cluster", nil); err != nil {
+				t.Errorf("Generated RelabelingRules failed operator compilation check: %v", err)
 			}
 		})
 	}
 }
 
-func addServiceToCache(cache *ResourceCache, namespace, name string, labels map[string]string) error {
+// makeTestService builds a Service Unstructured object from labels and ports, failing the test on conversion error.
+func makeTestService(t *testing.T, namespace, name string, labels map[string]string, ports []corev1.ServicePort) *unstructured.Unstructured {
+	t.Helper()
 	svc := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels:    labels,
-		},
-	}
-	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(svc)
-	return cache.Add(&unstructured.Unstructured{Object: u})
-}
-
-func makeTestService(namespace, name string, ports []corev1.ServicePort) *unstructured.Unstructured {
-	svc := &corev1.Service{
-		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: ports,
 		},
 	}
-	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(svc)
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(svc)
+	if err != nil {
+		t.Fatalf("failed to convert Service %s/%s to unstructured: %v", namespace, name, err)
+	}
 	return &unstructured.Unstructured{Object: u}
 }
 
-func makeTestServiceWithLabels(namespace, name string, labels map[string]string) *unstructured.Unstructured {
-	svc := &corev1.Service{
-		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    labels,
-		},
-	}
-	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(svc)
-	return &unstructured.Unstructured{Object: u}
+// addServiceToCache creates a test Service and adds it to the resource cache.
+func addServiceToCache(t *testing.T, cache *ResourceCache, namespace, name string, labels map[string]string) error {
+	t.Helper()
+	return cache.Add(makeTestService(t, namespace, name, labels, nil))
 }

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -1156,11 +1156,106 @@ func TestResolveServicePort(t *testing.T) {
 			expected: intstr.IntOrString{},
 			wantErr:  true,
 		},
+		{
+			name: "Skip malformed port entry and resolve valid later entry",
+			service: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]any{
+						"name":      "my-svc",
+						"namespace": "default",
+					},
+					"spec": map[string]any{
+						"ports": []any{
+							map[string]any{
+								"name": "malformed",
+							},
+							map[string]any{
+								"name":       "web",
+								"port":       int64(80),
+								"targetPort": int64(8080),
+							},
+						},
+					},
+				},
+			},
+			portStr:  "web",
+			expected: intstr.FromInt32(8080),
+			wantErr:  false,
+		},
+		{
+			name: "All ports malformed returns error",
+			service: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]any{
+						"name":      "my-svc",
+						"namespace": "default",
+					},
+					"spec": map[string]any{
+						"ports": []any{
+							map[string]any{
+								"name": "malformed1",
+							},
+							map[string]any{
+								"name": "malformed2",
+								"port": "invalid-string-port",
+							},
+						},
+					},
+				},
+			},
+			portStr:  "web",
+			expected: intstr.IntOrString{},
+			wantErr:  true,
+		},
+		{
+			name: "Out of range port number is rejected",
+			service: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]any{
+						"name":      "my-svc",
+						"namespace": "default",
+					},
+					"spec": map[string]any{
+						"ports": []any{
+							map[string]any{
+								"name": "overflow-port",
+								"port": int64(4294967297),
+							},
+							map[string]any{
+								"name":       "web",
+								"port":       int64(80),
+								"targetPort": int64(8080),
+							},
+						},
+					},
+				},
+			},
+			portStr:  "web",
+			expected: intstr.FromInt32(8080),
+			wantErr:  false,
+		},
+		{
+			name: "Resolve with empty string targetPort defaults to port number",
+			service: makeTestService("default", "my-svc", []corev1.ServicePort{
+				{Name: "web", Port: 80, TargetPort: intstr.FromString("")},
+			}),
+			portStr:  "web",
+			expected: intstr.FromInt32(80),
+			wantErr:  false,
+		},
 	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := resolveServicePort(tc.service, tc.portStr)
+			got, err := resolveServicePort(logger, tc.service, tc.portStr)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("resolveServicePort() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -1211,6 +1306,28 @@ func TestConvertServiceTargetLabels(t *testing.T) {
 			targetLabels: []string{"app", "team"},
 			expected: []monitoringv1.RelabelingRule{
 				{TargetLabel: "app", Replacement: "foo", Action: "replace"},
+			},
+		},
+		{
+			name: "Map service labels with sanitization",
+			service: makeTestServiceWithLabels("default", "my-svc", map[string]string{
+				"app.kubernetes.io/name":    "foo",
+				"app.kubernetes.io/part-of": "bar",
+			}),
+			targetLabels: []string{"app.kubernetes.io/name", "app.kubernetes.io/part-of"},
+			expected: []monitoringv1.RelabelingRule{
+				{TargetLabel: "app_kubernetes_io_name", Replacement: "foo", Action: "replace"},
+				{TargetLabel: "app_kubernetes_io_part_of", Replacement: "bar", Action: "replace"},
+			},
+		},
+		{
+			name: "Map service labels with sanitization and protected rename",
+			service: makeTestServiceWithLabels("default", "my-svc", map[string]string{
+				"project.id": "my-project",
+			}),
+			targetLabels: []string{"project.id"},
+			expected: []monitoringv1.RelabelingRule{
+				{TargetLabel: "exported_project_id", Replacement: "my-project", Action: "replace"},
 			},
 		},
 		{

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -328,37 +328,33 @@ func (m *Migrator) convertResources() []*unstructured.Unstructured {
 	// Track generated outputs by unique key to deduplicate identical secrets and detect name collisions.
 	outputsMap := make(map[string]generatedResource)
 
-	kinds := slices.AppendSeq(make([]string, 0, len(m.cache.resources)), maps.Keys(m.cache.resources))
-	slices.Sort(kinds)
+	kinds := m.cache.ListKinds()
 
 	for _, kind := range kinds {
-		nsMap := m.cache.resources[kind]
 		converter, registered := m.converters[kind]
 		if !registered {
 			continue
 		}
 
-		keys := slices.AppendSeq(make([]string, 0, len(nsMap)), maps.Keys(nsMap))
-		slices.Sort(keys)
-
-		for _, key := range keys {
-			res := nsMap[key].DeepCopy()
+		resources := m.cache.ListByKind(kind)
+		for _, res := range resources {
+			resCopy := res.DeepCopy()
 
 			// Create the resource logger.
 			resourceLogger := m.logger.With(
 				slog.String("kind", kind),
-				slog.String("namespace", res.GetNamespace()),
-				slog.String("name", res.GetName()),
+				slog.String("namespace", resCopy.GetNamespace()),
+				slog.String("name", resCopy.GetName()),
 			)
 
-			outputs, err := converter.Convert(ctx, resourceLogger, res, m.cache)
+			outputs, err := converter.Convert(ctx, resourceLogger, resCopy, m.cache)
 
 			if err != nil {
 				resourceLogger.Error(err.Error())
 				continue
 			}
 
-			if err := m.accumulateOutputs(resourceLogger, outputsMap, outputs, kind, res.GetNamespace(), res.GetName()); err != nil {
+			if err := m.accumulateOutputs(resourceLogger, outputsMap, outputs, kind, resCopy.GetNamespace(), resCopy.GetName()); err != nil {
 				resourceLogger.Error(err.Error())
 				continue
 			}

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -83,14 +83,14 @@ func getResourceKey(kind, namespace, name string) string {
 // NewResourceCache creates a new initialized ResourceCache.
 func NewResourceCache() *ResourceCache {
 	indexers := cache.Indexers{
-		indexKind: func(obj interface{}) ([]string, error) {
+		indexKind: func(obj any) ([]string, error) {
 			res, ok := obj.(*CachedResource)
 			if !ok {
 				return nil, fmt.Errorf("expected *CachedResource, got %T", obj)
 			}
 			return []string{res.Unstructured.GetKind()}, nil
 		},
-		indexKindNamespace: func(obj interface{}) ([]string, error) {
+		indexKindNamespace: func(obj any) ([]string, error) {
 			res, ok := obj.(*CachedResource)
 			if !ok {
 				return nil, fmt.Errorf("expected *CachedResource, got %T", obj)
@@ -99,7 +99,7 @@ func NewResourceCache() *ResourceCache {
 		},
 	}
 
-	keyFunc := func(obj interface{}) (string, error) {
+	keyFunc := func(obj any) (string, error) {
 		res, ok := obj.(*CachedResource)
 		if !ok {
 			return "", fmt.Errorf("expected *CachedResource, got %T", obj)
@@ -214,7 +214,7 @@ func (c *ResourceCache) findServicesBySelector(selector metav1.LabelSelector, na
 		return nil, fmt.Errorf("invalid selector: %w", err)
 	}
 
-	var candidateItems []interface{}
+	var candidateItems []any
 	if len(namespaces) > 0 {
 		for _, ns := range namespaces {
 			items, err := c.indexer.ByIndex(indexKindNamespace, fmt.Sprintf("%s/%s", KindService, ns))

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -19,14 +19,15 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (
@@ -51,22 +52,69 @@ type ResourceConverter interface {
 	Convert(ctx context.Context, logger *slog.Logger, unstruct *unstructured.Unstructured, cache *ResourceCache) (outputs []*unstructured.Unstructured, err error)
 }
 
+const (
+	indexKind          = "kind"
+	indexKindNamespace = "kindNamespace"
+)
+
+// CachedResource holds the raw unstructured object and optional pre-converted typed struct.
+type CachedResource struct {
+	Unstructured *unstructured.Unstructured
+	TypedService *corev1.Service
+}
+
+// compareObjectMeta compares two Kubernetes resources deterministically by Namespace first, then by Name.
+func compareObjectMeta[T metav1.Object](a, b T) int {
+	if a.GetNamespace() != b.GetNamespace() {
+		return strings.Compare(a.GetNamespace(), b.GetNamespace())
+	}
+	return strings.Compare(a.GetName(), b.GetName())
+}
+
 // ResourceCache stores parsed Kubernetes resources for cross-resource resolution.
 type ResourceCache struct {
-	// Map of Kind -> Namespace/Name -> Resource.
-	resources map[string]map[string]*unstructured.Unstructured
+	indexer cache.Indexer
+}
+
+func getResourceKey(kind, namespace, name string) string {
+	return fmt.Sprintf("%s/%s/%s", kind, namespace, name)
 }
 
 // NewResourceCache creates a new initialized ResourceCache.
 func NewResourceCache() *ResourceCache {
+	indexers := cache.Indexers{
+		indexKind: func(obj interface{}) ([]string, error) {
+			res, ok := obj.(*CachedResource)
+			if !ok {
+				return nil, fmt.Errorf("expected *CachedResource, got %T", obj)
+			}
+			return []string{res.Unstructured.GetKind()}, nil
+		},
+		indexKindNamespace: func(obj interface{}) ([]string, error) {
+			res, ok := obj.(*CachedResource)
+			if !ok {
+				return nil, fmt.Errorf("expected *CachedResource, got %T", obj)
+			}
+			return []string{fmt.Sprintf("%s/%s", res.Unstructured.GetKind(), res.Unstructured.GetNamespace())}, nil
+		},
+	}
+
+	keyFunc := func(obj interface{}) (string, error) {
+		res, ok := obj.(*CachedResource)
+		if !ok {
+			return "", fmt.Errorf("expected *CachedResource, got %T", obj)
+		}
+		return getResourceKey(res.Unstructured.GetKind(), res.Unstructured.GetNamespace(), res.Unstructured.GetName()), nil
+	}
+
 	return &ResourceCache{
-		resources: make(map[string]map[string]*unstructured.Unstructured),
+		indexer: cache.NewIndexer(keyFunc, indexers),
 	}
 }
 
 // Add adds a resource to the cache, returning an error if inputs are invalid.
 func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
-	if c == nil {
+	if c == nil || c.indexer == nil {
 		return errors.New("cannot add to nil ResourceCache")
 	}
 	if u == nil {
@@ -86,43 +134,78 @@ func (c *ResourceCache) Add(u *unstructured.Unstructured) error {
 		return errors.New("cannot add resource with empty apiVersion to cache")
 	}
 
-	if c.resources == nil {
-		c.resources = make(map[string]map[string]*unstructured.Unstructured)
-	}
-
-	if _, ok := c.resources[kind]; !ok {
-		c.resources[kind] = make(map[string]*unstructured.Unstructured)
-	}
-
 	ns := u.GetNamespace()
-
-	key := fmt.Sprintf("%s/%s", ns, name)
-	if _, exists := c.resources[kind][key]; exists {
+	key := getResourceKey(kind, ns, name)
+	if _, exists, _ := c.indexer.GetByKey(key); exists {
 		return fmt.Errorf("duplicate resource %s/%s found in cache", kind, key)
 	}
-	c.resources[kind][key] = u
-	return nil
+
+	res := &CachedResource{
+		Unstructured: u,
+	}
+
+	if kind == KindService {
+		var svc corev1.Service
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &svc); err != nil {
+			return fmt.Errorf("failed to convert Service %s/%s to corev1.Service: %w", ns, name, err)
+		}
+		res.TypedService = &svc
+	}
+
+	return c.indexer.Add(res)
 }
 
 // Get retrieves a resource from the cache by kind, namespace, and name.
 func (c *ResourceCache) Get(kind, namespace, name string) (*unstructured.Unstructured, bool) {
-	if c == nil || c.resources == nil {
+	if c == nil || c.indexer == nil {
 		return nil, false
 	}
-	nsMap, ok := c.resources[kind]
-	if !ok {
+	key := getResourceKey(kind, namespace, name)
+	item, exists, err := c.indexer.GetByKey(key)
+	if err != nil || !exists {
 		return nil, false
 	}
-	key := fmt.Sprintf("%s/%s", namespace, name)
-	r, ok := nsMap[key]
-	return r, ok
+	res, ok := item.(*CachedResource)
+	if !ok || res.Unstructured == nil {
+		return nil, false
+	}
+	return res.Unstructured, true
+}
+
+// ListKinds returns a sorted slice of all resource kinds currently in the cache.
+func (c *ResourceCache) ListKinds() []string {
+	if c == nil || c.indexer == nil {
+		return nil
+	}
+	kinds := c.indexer.ListIndexFuncValues(indexKind)
+	slices.Sort(kinds)
+	return kinds
+}
+
+// ListByKind returns a sorted slice of unstructured resources for a specified kind.
+func (c *ResourceCache) ListByKind(kind string) []*unstructured.Unstructured {
+	if c == nil || c.indexer == nil {
+		return nil
+	}
+	items, err := c.indexer.ByIndex(indexKind, kind)
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+	var res []*unstructured.Unstructured
+	for _, item := range items {
+		if r, ok := item.(*CachedResource); ok && r.Unstructured != nil {
+			res = append(res, r.Unstructured)
+		}
+	}
+	slices.SortFunc(res, compareObjectMeta)
+	return res
 }
 
 // findServicesBySelector finds Services matching the label selector within the specified namespaces.
 // Note for callers: passing nil or an empty namespaces slice matches Services across every namespace.
 // Callers should use determineNamespaceScoping to resolve default namespace rules before calling this method.
 func (c *ResourceCache) findServicesBySelector(selector metav1.LabelSelector, namespaces []string) ([]*corev1.Service, error) {
-	if c == nil || c.resources == nil {
+	if c == nil || c.indexer == nil {
 		return nil, nil
 	}
 
@@ -131,33 +214,36 @@ func (c *ResourceCache) findServicesBySelector(selector metav1.LabelSelector, na
 		return nil, fmt.Errorf("invalid selector: %w", err)
 	}
 
-	var matched []*corev1.Service
-
-	services, ok := c.resources[KindService]
-	if !ok {
-		return nil, nil
+	var candidateItems []interface{}
+	if len(namespaces) > 0 {
+		for _, ns := range namespaces {
+			items, err := c.indexer.ByIndex(indexKindNamespace, fmt.Sprintf("%s/%s", KindService, ns))
+			if err != nil {
+				return nil, err
+			}
+			candidateItems = append(candidateItems, items...)
+		}
+	} else {
+		var err error
+		candidateItems, err = c.indexer.ByIndex(indexKind, KindService)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// To make output deterministic, we sort the keys before iterating.
-	keys := slices.AppendSeq(make([]string, 0, len(services)), maps.Keys(services))
-	slices.Sort(keys)
-
-	for _, key := range keys {
-		svc := services[key]
-		svcNS := svc.GetNamespace()
-
-		if len(namespaces) > 0 && !slices.Contains(namespaces, svcNS) {
+	var matched []*corev1.Service
+	for _, item := range candidateItems {
+		res, ok := item.(*CachedResource)
+		if !ok || res.TypedService == nil {
 			continue
 		}
-
-		svcLabels := svc.GetLabels()
-		if sel.Matches(labels.Set(svcLabels)) {
-			var typedSvc corev1.Service
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(svc.Object, &typedSvc); err != nil {
-				return nil, fmt.Errorf("failed to convert Service %s/%s to corev1.Service: %w", svc.GetNamespace(), svc.GetName(), err)
-			}
-			matched = append(matched, &typedSvc)
+		svc := res.TypedService
+		if sel.Matches(labels.Set(svc.Labels)) {
+			matched = append(matched, svc)
 		}
 	}
+
+	slices.SortFunc(matched, compareObjectMeta)
+
 	return matched, nil
 }

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -19,8 +19,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 const (
@@ -110,4 +113,44 @@ func (c *ResourceCache) Get(kind, namespace, name string) (*unstructured.Unstruc
 	key := fmt.Sprintf("%s/%s", namespace, name)
 	r, ok := nsMap[key]
 	return r, ok
+}
+
+// findServicesBySelector finds Services matching the label selector within the specified namespaces.
+// Note for callers: passing nil or an empty namespaces slice matches Services across every namespace.
+// Callers should use determineNamespaceScoping to resolve default namespace rules before calling this method.
+func (c *ResourceCache) findServicesBySelector(selector metav1.LabelSelector, namespaces []string) ([]*unstructured.Unstructured, error) {
+	if c == nil || c.resources == nil {
+		return nil, nil
+	}
+
+	sel, err := metav1.LabelSelectorAsSelector(&selector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid selector: %w", err)
+	}
+
+	var matched []*unstructured.Unstructured
+
+	services, ok := c.resources[KindService]
+	if !ok {
+		return nil, nil
+	}
+
+	// To make output deterministic, we sort the keys before iterating.
+	keys := slices.AppendSeq(make([]string, 0, len(services)), maps.Keys(services))
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		svc := services[key]
+		svcNS := svc.GetNamespace()
+
+		if len(namespaces) > 0 && !slices.Contains(namespaces, svcNS) {
+			continue
+		}
+
+		svcLabels := svc.GetLabels()
+		if sel.Matches(labels.Set(svcLabels)) {
+			matched = append(matched, svc)
+		}
+	}
+	return matched, nil
 }

--- a/pkg/migrate/types.go
+++ b/pkg/migrate/types.go
@@ -22,8 +22,11 @@ import (
 	"maps"
 	"slices"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -118,7 +121,7 @@ func (c *ResourceCache) Get(kind, namespace, name string) (*unstructured.Unstruc
 // findServicesBySelector finds Services matching the label selector within the specified namespaces.
 // Note for callers: passing nil or an empty namespaces slice matches Services across every namespace.
 // Callers should use determineNamespaceScoping to resolve default namespace rules before calling this method.
-func (c *ResourceCache) findServicesBySelector(selector metav1.LabelSelector, namespaces []string) ([]*unstructured.Unstructured, error) {
+func (c *ResourceCache) findServicesBySelector(selector metav1.LabelSelector, namespaces []string) ([]*corev1.Service, error) {
 	if c == nil || c.resources == nil {
 		return nil, nil
 	}
@@ -128,7 +131,7 @@ func (c *ResourceCache) findServicesBySelector(selector metav1.LabelSelector, na
 		return nil, fmt.Errorf("invalid selector: %w", err)
 	}
 
-	var matched []*unstructured.Unstructured
+	var matched []*corev1.Service
 
 	services, ok := c.resources[KindService]
 	if !ok {
@@ -149,7 +152,11 @@ func (c *ResourceCache) findServicesBySelector(selector metav1.LabelSelector, na
 
 		svcLabels := svc.GetLabels()
 		if sel.Matches(labels.Set(svcLabels)) {
-			matched = append(matched, svc)
+			var typedSvc corev1.Service
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(svc.Object, &typedSvc); err != nil {
+				return nil, fmt.Errorf("failed to convert Service %s/%s to corev1.Service: %w", svc.GetNamespace(), svc.GetName(), err)
+			}
+			matched = append(matched, &typedSvc)
 		}
 	}
 	return matched, nil


### PR DESCRIPTION
This PR implements the core service and port resolution helper functions in `pkg/migrate/helpers.go` required for the upcoming ServiceMonitor migration work.

Key additions:
- `findServicesBySelector`: Traverses the ResourceCache to return Service CRs matching a specified LabelSelector within target namespaces.
- `resolveServicePort`: Inspects a Service's `spec.ports` list to map a target port reference (either a string name or a port number) to the Pod's actual container targetPort value.
- `convertServiceTargetLabels`: Maps Service-level labels (as defined in `spec.targetLabels` of ServiceMonitor) to static metric relabeling rules (action: replace), appending the "exported_" prefix if it clashes with protected Prometheus labels.
- Added comprehensive unit tests in `helpers_test.go` verifying all helper behaviors, error paths, and edge cases.