### PR TITLE
fix: gmpctl ensure correct tools are installed across old and new releases

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -51,4 +51,5 @@ policies:
           - datasource-syncer
           - config-reloader
           - rule-evaluator
+          - ops
         descriptionLength: 80

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
+.bin/
 /**/node_modules/.cache
 e2e_*
 .idea/
@@ -6,3 +7,4 @@ e2e_*
 # We vendor Go code internally (on Louhi import), don't vendor here.
 vendor/
 .DS_Store
+

--- a/ops/gmpctl.sh
+++ b/ops/gmpctl.sh
@@ -26,6 +26,15 @@ SCRIPT_DIR="$(
 	pwd -P
 )"
 
+# Install dependencies in the current context. We switch Go toolchain versions so using go tool might not work.
+go install github.com/google/go-containerregistry/cmd/gcrane@latest
+go install github.com/mikefarah/yq/v4@latest
+go install helm.sh/helm/v3/cmd/helm@latest
+go install github.com/google/addlicense@latest
+go install golang.org/x/vuln/cmd/govulncheck@latest
+
+export PATH="$(go env GOPATH)/bin:${PATH}"
+
 # NOTE gmpctl expects the gmpctl directory to be present on execution for
 # local bash scripts and configuration.
 #

--- a/ops/gmpctl.sh
+++ b/ops/gmpctl.sh
@@ -26,14 +26,15 @@ SCRIPT_DIR="$(
 	pwd -P
 )"
 
-# Install dependencies in the current context. We switch Go toolchain versions so using go tool might not work.
+# Install dependencies in a local directory. We switch Go toolchain versions so using go tool might not work.
+export GOBIN="${SCRIPT_DIR}/.bin"
+export PATH="${GOBIN}:${PATH}"
+
 go install github.com/google/go-containerregistry/cmd/gcrane@latest
 go install github.com/mikefarah/yq/v4@latest
 go install helm.sh/helm/v3/cmd/helm@latest
 go install github.com/google/addlicense@latest
 go install golang.org/x/vuln/cmd/govulncheck@latest
-
-export PATH="$(go env GOPATH)/bin:${PATH}"
 
 # NOTE gmpctl expects the gmpctl directory to be present on execution for
 # local bash scripts and configuration.

--- a/ops/gmpctl/README.md
+++ b/ops/gmpctl/README.md
@@ -47,7 +47,7 @@ key information and confirmations e.g.
 same parameters, and it will continue the previous work or at least yield same results. This is crucial when iterating
 on breaking go mod updates for vulnerabilities or fork sync conflicts.
 
-```text mdox-exec="bash ops/gmpctl.sh --help"
+```text mdox-exec="bash -c \"bash ops/gmpctl.sh --help 2>&1 | sed -n '/Usage/,$p'\""
 Usage: gmpctl [COMMAND] [FLAGS]
   -c string
     	Path to the configuration file. See config.go#Config for the structure. (default ".gmpctl.default.yaml")

--- a/ops/gmpctl/lib.sh
+++ b/ops/gmpctl/lib.sh
@@ -407,8 +407,6 @@ release-lib::idemp::manifests_bash_image_bump() {
 		return 1
 	fi
 
-	go install github.com/mikefarah/yq/v4@latest
-
 	local values_file="${dir}/charts/values.global.yaml"
 	# TODO: Not enough, this has to check actual manifests.
 	local bash_tag=$(yq '.images.bash.tag' "${values_file}")
@@ -442,17 +440,17 @@ release-lib::manifests_regen() {
 		return 1
 	fi
 
-	# TODO(bwplotka): Manage deps better. It's getting confusing what bins we should use (worktree bingo? script bingo?).
-	go install helm.sh/helm/v3/cmd/helm@latest
-	go install github.com/google/addlicense@latest
-	go install github.com/mikefarah/yq/v4@latest
+	# Hack: Do the bingo variable swap. This allows injecting our local
+	# dependencies, instead the ones populated by bingo on old versions.
+	# NOTE: Only needed before 0.19.
+	if [[ -f "${dir}/.bingo/variables.env" ]]; then
+    cp "${dir}/.bingo/variables.env" "${dir}/.bingo/variables.env.bak"
+    trap 'mv "${dir}/.bingo/variables.env.bak" "${dir}/.bingo/variables.env" 2>/dev/null || true' EXIT
+    echo "#!/bin/bash" >"${dir}/.bingo/variables.env" # Clean the file.
+  fi
 
-	# Hack: Do the bingo variable swap. This allows injecting our own.
-	# This is faster than running requiring bingo and running bingo get.
-	cp "${dir}/.bingo/variables.env" "${dir}/.bingo/variables.env.bak"
-	echo "#!/bin/bash" >"${dir}/.bingo/variables.env" # Clean the file.
-	YQ="$(which yq)" HELM="$(which helm)" ADDLICENSE="$(which addlicense)" bash "${dir}/hack/presubmit.sh" manifests
-	cp "${dir}/.bingo/variables.env.bak" "${dir}/.bingo/variables.env"
+  echo "🔄 Regenerating manifests..."
+  YQ="$(command -v yq)" HELM="$(command -v helm)" ADDLICENSE="$(command -v addlicense)" bash "${dir}/hack/presubmit.sh" manifests
 
 	echo "✅  Manifests regenerated"
 	return 0

--- a/ops/gmpctl/lib.sh
+++ b/ops/gmpctl/lib.sh
@@ -445,7 +445,7 @@ release-lib::manifests_regen() {
 	# NOTE: Only needed before 0.19.
 	if [[ -f "${dir}/.bingo/variables.env" ]]; then
     cp "${dir}/.bingo/variables.env" "${dir}/.bingo/variables.env.bak"
-    trap 'mv "${dir}/.bingo/variables.env.bak" "${dir}/.bingo/variables.env" 2>/dev/null || true' EXIT
+    trap "mv \"${dir}/.bingo/variables.env.bak\" \"${dir}/.bingo/variables.env\" 2>/dev/null || true" EXIT
     echo "#!/bin/bash" >"${dir}/.bingo/variables.env" # Clean the file.
   fi
 

--- a/ops/gmpctl/prep-rc.sh
+++ b/ops/gmpctl/prep-rc.sh
@@ -28,29 +28,29 @@ fi
 SED=$(which gsed || which sed)
 
 # TODO(bwplotka): Finding correct script dir is not so trivial.
-if [[ -z "${SCRIPT_DIR}" ]]; then
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
   log_err "SCRIPT_DIR envvar is required."
   exit 1
 fi
 
 source "${SCRIPT_DIR}/lib.sh"
 
-if [[ -z "${DIR}" ]]; then
+if [[ -z "${DIR:-}" ]]; then
   log_err "DIR envvar is required."
   exit 1
 fi
 
-if [[ -z "${BRANCH}" ]]; then
+if [[ -z "${BRANCH:-}" ]]; then
   log_err "BRANCH envvar is required."
   exit 1
 fi
 
-if [[ -z "${TAG}" ]]; then
+if [[ -z "${TAG:-}" ]]; then
   log_err "TAG envvar is required."
   exit 1
 fi
 
-if [[ -z "${PROJECT}" ]]; then
+if [[ -z "${PROJECT:-}" ]]; then
   log_err "PROJECT envvar is required."
   exit 1
 fi

--- a/ops/gmpctl/vulnfix.sh
+++ b/ops/gmpctl/vulnfix.sh
@@ -33,9 +33,6 @@ fi
 
 source "${SCRIPT_DIR}/lib.sh"
 
-# TODO: Find better way. Go tool grane is tricky as we run in different directory.
-go install github.com/google/go-containerregistry/cmd/gcrane@latest
-
 # Also accepts SYNC_DOCKERFILES_FROM.
 
 if [[ -z "${DIR}" ]]; then


### PR DESCRIPTION
This should unblock the `release` command, so it works across branches and repos.