### PR TITLE
fix(ops): resolve binaries from GOBIN before PATH in manifests_regen

### DIFF
--- a/ops/gmpctl/lib.sh
+++ b/ops/gmpctl/lib.sh
@@ -444,13 +444,13 @@ release-lib::manifests_regen() {
 	# dependencies, instead the ones populated by bingo on old versions.
 	# NOTE: Only needed before 0.19.
 	if [[ -f "${dir}/.bingo/variables.env" ]]; then
-    cp "${dir}/.bingo/variables.env" "${dir}/.bingo/variables.env.bak"
-    trap "mv \"${dir}/.bingo/variables.env.bak\" \"${dir}/.bingo/variables.env\" 2>/dev/null || true" EXIT
-    echo "#!/bin/bash" >"${dir}/.bingo/variables.env" # Clean the file.
-  fi
+		cp "${dir}/.bingo/variables.env" "${dir}/.bingo/variables.env.bak"
+		trap "mv \"${dir}/.bingo/variables.env.bak\" \"${dir}/.bingo/variables.env\" 2>/dev/null || true" EXIT
+		echo "#!/bin/bash" >"${dir}/.bingo/variables.env" # Clean the file.
+	fi
 
-  echo "🔄 Regenerating manifests..."
-  YQ="$(command -v yq)" HELM="$(command -v helm)" ADDLICENSE="$(command -v addlicense)" bash "${dir}/hack/presubmit.sh" manifests
+	echo "🔄 Regenerating manifests..."
+	YQ="${GOBIN}/yq" HELM="${GOBIN}/helm" ADDLICENSE="${GOBIN}/addlicense" bash "${dir}/hack/presubmit.sh" manifests
 
 	echo "✅  Manifests regenerated"
 	return 0


### PR DESCRIPTION
Addressing discussion comment https://github.com/GoogleCloudPlatform/prometheus-engine/pull/2005#discussion_r3648156111 from #2005.

Instead of strictly using `command -v` to search `$PATH`, `release-lib::manifests_regen` now resolves `yq`, `helm`, and `addlicense` from `$GOBIN` first (falling back to `$PATH` if not found in `$GOBIN`).