### PR TITLE
fix(ops): ignore -linux-* suffixes when fetching distroless image tags

### DIFF
--- a/ops/gmpctl/lib.sh
+++ b/ops/gmpctl/lib.sh
@@ -373,7 +373,7 @@ release-lib::dockerfile_update_image() {
 	# Exclude RC images.
 	all_tags=$(echo "${all_tags}" | grep -v "rc.*")
 	# Ignore -linux-* architecture suffixes (e.g. -linux-arm64).
-	all_tags=$(echo "${all_tags}" | grep -v "\-linux\-")
+	all_tags=$(echo "${all_tags}" | grep -v -e "-linux-")
 	# Prefix allows sticking to e.g. latest minor.
 	all_tags=$(echo "${all_tags}" | grep "${tag_prefix}")
 	local latest_tag=$(echo "${all_tags}" | tail -n1)
@@ -408,7 +408,7 @@ release-lib::idemp::manifests_bash_image_bump() {
 	local bash_tag=$(yq '.images.bash.tag' "${values_file}")
 
 	# Use gcrane (over crane) for --json. Ignore -linux-* architecture suffixes.
-	local latest_bash_tag=$(gcrane ls "gke.gcr.io/gke-distroless/bash" --json | jq --raw-output '.tags[]' | grep "gke_distroless_" | grep -v "\-linux\-" | sort -V | tail -n1)
+	local latest_bash_tag=$(gcrane ls "gke.gcr.io/gke-distroless/bash" --json | jq --raw-output '.tags[]' | grep "gke_distroless_" | grep -v -e "-linux-" | sort -V | tail -n1)
 	if [[ "${bash_tag}" == "${latest_bash_tag}" ]]; then
 		echo "✅  Nothing to do; ${values_file} already uses ${latest_bash_tag}"
 		return 0
@@ -440,13 +440,18 @@ release-lib::manifests_regen() {
 	# dependencies, instead the ones populated by bingo on old versions.
 	# NOTE: Only needed before 0.19.
 	if [[ -f "${dir}/.bingo/variables.env" ]]; then
-    cp "${dir}/.bingo/variables.env" "${dir}/.bingo/variables.env.bak"
-    trap "mv \"${dir}/.bingo/variables.env.bak\" \"${dir}/.bingo/variables.env\" 2>/dev/null || true" EXIT
-    echo "#!/bin/bash" >"${dir}/.bingo/variables.env" # Clean the file.
-  fi
+		cp "${dir}/.bingo/variables.env" "${dir}/.bingo/variables.env.bak"
+		trap "mv \"${dir}/.bingo/variables.env.bak\" \"${dir}/.bingo/variables.env\" 2>/dev/null || true" EXIT
+		echo "#!/bin/bash" >"${dir}/.bingo/variables.env" # Clean the file.
+	fi
 
-  echo "🔄 Regenerating manifests..."
-  YQ="$(command -v yq)" HELM="$(command -v helm)" ADDLICENSE="$(command -v addlicense)" bash "${dir}/hack/presubmit.sh" manifests
+	echo "🔄 Regenerating manifests..."
+	YQ="$(command -v yq)" HELM="$(command -v helm)" ADDLICENSE="$(command -v addlicense)" bash "${dir}/hack/presubmit.sh" manifests
+
+	if [[ -f "${dir}/.bingo/variables.env.bak" ]]; then
+		mv "${dir}/.bingo/variables.env.bak" "${dir}/.bingo/variables.env"
+		trap - EXIT
+	fi
 
 	echo "✅  Manifests regenerated"
 	return 0

--- a/ops/gmpctl/lib.sh
+++ b/ops/gmpctl/lib.sh
@@ -372,6 +372,8 @@ release-lib::dockerfile_update_image() {
 	local all_tags=$(gcrane ls "${image}" --json | jq --raw-output '.tags[]' | sort -V)
 	# Exclude RC images.
 	all_tags=$(echo "${all_tags}" | grep -v "rc.*")
+	# Ignore -linux-* architecture suffixes (e.g. -linux-arm64).
+	all_tags=$(echo "${all_tags}" | grep -v "\-linux\-")
 	# Prefix allows sticking to e.g. latest minor.
 	all_tags=$(echo "${all_tags}" | grep "${tag_prefix}")
 	local latest_tag=$(echo "${all_tags}" | tail -n1)
@@ -405,8 +407,8 @@ release-lib::idemp::manifests_bash_image_bump() {
 	# TODO: Not enough, this has to check actual manifests.
 	local bash_tag=$(yq '.images.bash.tag' "${values_file}")
 
-	# Use gcrane (over crane) for --json.
-	local latest_bash_tag=$(gcrane ls "gke.gcr.io/gke-distroless/bash" --json | jq --raw-output '.tags[]' | grep "gke_distroless_" | sort -V | tail -n1)
+	# Use gcrane (over crane) for --json. Ignore -linux-* architecture suffixes.
+	local latest_bash_tag=$(gcrane ls "gke.gcr.io/gke-distroless/bash" --json | jq --raw-output '.tags[]' | grep "gke_distroless_" | grep -v "\-linux\-" | sort -V | tail -n1)
 	if [[ "${bash_tag}" == "${latest_bash_tag}" ]]; then
 		echo "✅  Nothing to do; ${values_file} already uses ${latest_bash_tag}"
 		return 0
@@ -414,7 +416,7 @@ release-lib::idemp::manifests_bash_image_bump() {
 
 	# Upgrade.
 	echo "🔄  Ensuring ${latest_bash_tag} on ${values_file}..."
-	if ! ${SED} -i -E "s#tag: ${bash_tag}#tag: ${latest_bash_tag}#g" "${values_file}"; then
+	if ! ${SED} -i -E "s#tag: \"?${bash_tag}\"?#tag: \"${latest_bash_tag}\"#g" "${values_file}"; then
 		# TODO: This is flaky, no failing actually on no match. Common bug is
 		log_err "sed didn't replace?"
 		return 1


### PR DESCRIPTION
Ignore `-linux-*` architecture-specific tag suffixes when searching for latest distroless tags in gmpctl.