### PR TITLE
chore: improve dependabot config for docker images and release branches

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -39,6 +39,8 @@ updates:
           # allow dependabot to bump it to let us know it's possible, just not
           # in a single group.
           - "gke.gcr.io/prometheus-engine/*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     directory: /tools
@@ -52,6 +54,8 @@ updates:
       tools:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     directory: /
@@ -78,6 +82,8 @@ updates:
         patterns:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
+    cooldown:
+      default-days: 7
 
   # Config for release/0.19
   - package-ecosystem: docker
@@ -105,6 +111,8 @@ updates:
         exclude-patterns:
           - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.19
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -120,6 +128,8 @@ updates:
         patterns:
           - "*"
     target-branch: release/0.19
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -145,6 +155,8 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
     target-branch: release/0.19
+    cooldown:
+      default-days: 7
 
   # Config for release/0.18
   - package-ecosystem: docker
@@ -172,6 +184,8 @@ updates:
         exclude-patterns:
           - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.18
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -187,6 +201,8 @@ updates:
         patterns:
           - "*"
     target-branch: release/0.18
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -212,6 +228,8 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
     target-branch: release/0.18
+    cooldown:
+      default-days: 7
 
   # Config for release/0.17
   - package-ecosystem: docker
@@ -239,6 +257,8 @@ updates:
         exclude-patterns:
           - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.17
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -254,6 +274,8 @@ updates:
         patterns:
           - "*"
     target-branch: release/0.17
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -279,6 +301,8 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
     target-branch: release/0.17
+    cooldown:
+      default-days: 7
 
   # Config for release/0.16
   - package-ecosystem: docker
@@ -306,6 +330,8 @@ updates:
         exclude-patterns:
           - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.16
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -321,6 +347,8 @@ updates:
         patterns:
           - "*"
     target-branch: release/0.16
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -346,6 +374,8 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
     target-branch: release/0.16
+    cooldown:
+      default-days: 7
 
   # Config for release/0.15
   - package-ecosystem: docker
@@ -373,6 +403,8 @@ updates:
         exclude-patterns:
           - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.15
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -388,6 +420,8 @@ updates:
         patterns:
           - "*"
     target-branch: release/0.15
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -413,6 +447,8 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
     target-branch: release/0.15
+    cooldown:
+      default-days: 7
 
   # Config for release/0.14
   - package-ecosystem: docker
@@ -440,6 +476,8 @@ updates:
         exclude-patterns:
           - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.14
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -455,6 +493,8 @@ updates:
         patterns:
           - "*"
     target-branch: release/0.14
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -480,6 +520,8 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
     target-branch: release/0.14
+    cooldown:
+      default-days: 7
 
   # Config for release/0.13
   - package-ecosystem: docker
@@ -507,6 +549,8 @@ updates:
         exclude-patterns:
           - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.13
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -522,6 +566,8 @@ updates:
         patterns:
           - "*"
     target-branch: release/0.13
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -547,3 +593,5 @@ updates:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
     target-branch: release/0.13
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -41,7 +41,6 @@ updates:
           - "gke.gcr.io/prometheus-engine/*"
 
   - package-ecosystem: gomod
-    open-pull-requests-limit: 0 # Security updates only
     directory: /tools
     schedule:
       interval: weekly
@@ -55,7 +54,6 @@ updates:
           - "*"
 
   - package-ecosystem: gomod
-    open-pull-requests-limit: 0 # Security updates only
     directory: /
     ignore:
       # Skip Prometheus as we need to have it pinned carefully.

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -45,6 +45,14 @@ updates:
     directory: /tools
     schedule:
       interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      tools:
+        patterns:
+          - "*"
 
   - package-ecosystem: gomod
     open-pull-requests-limit: 0 # Security updates only
@@ -96,6 +104,8 @@ updates:
       docker:
         patterns:
           - "*"
+        exclude-patterns:
+          - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.19
 
   - package-ecosystem: gomod
@@ -103,6 +113,14 @@ updates:
     directory: /tools
     schedule:
       interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      tools:
+        patterns:
+          - "*"
     target-branch: release/0.19
 
   - package-ecosystem: gomod
@@ -153,6 +171,8 @@ updates:
       docker:
         patterns:
           - "*"
+        exclude-patterns:
+          - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.18
 
   - package-ecosystem: gomod
@@ -160,6 +180,14 @@ updates:
     directory: /tools
     schedule:
       interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      tools:
+        patterns:
+          - "*"
     target-branch: release/0.18
 
   - package-ecosystem: gomod
@@ -210,6 +238,8 @@ updates:
       docker:
         patterns:
           - "*"
+        exclude-patterns:
+          - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.17
 
   - package-ecosystem: gomod
@@ -217,6 +247,14 @@ updates:
     directory: /tools
     schedule:
       interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      tools:
+        patterns:
+          - "*"
     target-branch: release/0.17
 
   - package-ecosystem: gomod
@@ -267,6 +305,8 @@ updates:
       docker:
         patterns:
           - "*"
+        exclude-patterns:
+          - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.16
 
   - package-ecosystem: gomod
@@ -274,6 +314,14 @@ updates:
     directory: /tools
     schedule:
       interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      tools:
+        patterns:
+          - "*"
     target-branch: release/0.16
 
   - package-ecosystem: gomod
@@ -324,6 +372,8 @@ updates:
       docker:
         patterns:
           - "*"
+        exclude-patterns:
+          - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.15
 
   - package-ecosystem: gomod
@@ -331,6 +381,14 @@ updates:
     directory: /tools
     schedule:
       interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      tools:
+        patterns:
+          - "*"
     target-branch: release/0.15
 
   - package-ecosystem: gomod
@@ -381,6 +439,8 @@ updates:
       docker:
         patterns:
           - "*"
+        exclude-patterns:
+          - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.14
 
   - package-ecosystem: gomod
@@ -388,6 +448,14 @@ updates:
     directory: /tools
     schedule:
       interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      tools:
+        patterns:
+          - "*"
     target-branch: release/0.14
 
   - package-ecosystem: gomod
@@ -438,6 +506,8 @@ updates:
       docker:
         patterns:
           - "*"
+        exclude-patterns:
+          - "gke.gcr.io/prometheus-engine/*"
     target-branch: release/0.13
 
   - package-ecosystem: gomod
@@ -445,6 +515,14 @@ updates:
     directory: /tools
     schedule:
       interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      tools:
+        patterns:
+          - "*"
     target-branch: release/0.13
 
   - package-ecosystem: gomod

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,317 +14,460 @@
 
 version: 2
 updates:
-- package-ecosystem: docker
-  directories:
-    - /cmd/config-reloader
-    - /cmd/datasource-syncer
-    - /cmd/frontend
-    - /cmd/operator
-    - /cmd/rule-evaluator
-    - /examples/instrumentation/go-synthetic
-    - /hack
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    docker:
-      patterns:
-        - "*"
-      exclude-patterns:
-        # To change those we need to do make regen. Still
-        # allow dependabot to bump it to let us know it's possible, just not
-        # in a single group.
-        - "gke.gcr.io/prometheus-engine/*"
-- package-ecosystem: gomod
-  directories:
-    - "/tools/**"
-  schedule:
-    interval: weekly
-- package-ecosystem: gomod
-  directory: /
-  ignore:
-    # Skip Prometheus as we need to have it pinned carefully.
-    - dependency-name: "github.com/prometheus/prometheus"
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    # Group dep updates into one PR as single update already updates co-located deps.
-    deps:
-      patterns:
-        - "*"
-      exclude-patterns:
-        - "k8s.io/*"
-        - "sigs.k8s.io/*"
-    # Attempt to group dep updates for k8s as they typically break by assuming
-    # all k8s modules are upgraded in the same time.
-    k8s-deps:
-      patterns:
-        - "k8s.io/*"
-        - "sigs.k8s.io/*"
-# Duplicate config for release/0.16
-- package-ecosystem: docker
-  open-pull-requests-limit: 0 # Security updates only
-  directories:
-    - /cmd/config-reloader
-    - /cmd/datasource-syncer
-    - /cmd/frontend
-    - /cmd/operator
-    - /cmd/rule-evaluator
-    - /examples/instrumentation/go-synthetic
-    - /hack
-  ignore:
-    - dependency-name: "gke-release/prometheus-engine/*"
-      versions: [ ">=0.18.0" ]
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    docker:
-      patterns:
-        - "*"
-  target-branch: release/0.17
-- package-ecosystem: gomod
-  open-pull-requests-limit: 0 # Security updates only
-  directory: /
-  ignore:
-  # Skip Prometheus as we need to have it pinned carefully.
-  - dependency-name: "github.com/prometheus/prometheus"
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    # Group dep updates into one PR as single update already updates co-located deps.
-    deps:
-      patterns:
-      - "*"
-      exclude-patterns:
-      - "k8s.io/*"
-      - "sigs.k8s.io/*"
-    # Attempt to group dep updates for k8s as they typically break by assuming
-    # all k8s modules are upgraded in the same time.
-    k8s-deps:
-      patterns:
-      - "k8s.io/*"
-      - "sigs.k8s.io/*"
-  target-branch: release/0.17
-# Duplicate config for release/0.16
-- package-ecosystem: docker
-  open-pull-requests-limit: 0 # Security updates only
-  directories:
-    - /cmd/config-reloader
-    - /cmd/datasource-syncer
-    - /cmd/frontend
-    - /cmd/operator
-    - /cmd/rule-evaluator
-    - /examples/instrumentation/go-synthetic
-    - /hack
-  ignore:
-    - dependency-name: "gke-release/prometheus-engine/*"
-      versions: [ ">=0.17.0" ]
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    docker:
-      patterns:
-        - "*"
-  target-branch: release/0.16
-- package-ecosystem: gomod
-  open-pull-requests-limit: 0 # Security updates only
-  directory: /
-  ignore:
-  # Skip Prometheus as we need to have it pinned carefully.
-  - dependency-name: "github.com/prometheus/prometheus"
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    # Group dep updates into one PR as single update already updates co-located deps.
-    deps:
-      patterns:
-      - "*"
-      exclude-patterns:
-      - "k8s.io/*"
-      - "sigs.k8s.io/*"
-    # Attempt to group dep updates for k8s as they typically break by assuming
-    # all k8s modules are upgraded in the same time.
-    k8s-deps:
-      patterns:
-      - "k8s.io/*"
-      - "sigs.k8s.io/*"
-  target-branch: release/0.16
-# Duplicate config for release/0.15
-- package-ecosystem: docker
-  open-pull-requests-limit: 0 # Security updates only
-  directories:
-    - /cmd/config-reloader
-    - /cmd/datasource-syncer
-    - /cmd/frontend
-    - /cmd/operator
-    - /cmd/rule-evaluator
-    - /examples/instrumentation/go-synthetic
-    - /hack
-  ignore:
-    - dependency-name: "gke-release/prometheus-engine/*"
-      versions: [ ">=0.16.0" ]
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    docker:
-      patterns:
-        - "*"
-  target-branch: release/0.15
-- package-ecosystem: gomod
-  open-pull-requests-limit: 0 # Security updates only
-  directory: /
-  ignore:
-  # Skip Prometheus as we need to have it pinned carefully.
-  - dependency-name: "github.com/prometheus/prometheus"
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    # Group dep updates into one PR as single update already updates co-located deps.
-    deps:
-      patterns:
-      - "*"
-      exclude-patterns:
-      - "k8s.io/*"
-      - "sigs.k8s.io/*"
-    # Attempt to group dep updates for k8s as they typically break by assuming
-    # all k8s modules are upgraded in the same time.
-    k8s-deps:
-      patterns:
-      - "k8s.io/*"
-      - "sigs.k8s.io/*"
-  target-branch: release/0.15
-# Duplicate config for release/0.14
-- package-ecosystem: docker
-  open-pull-requests-limit: 0 # Security updates only
-  directories:
-    - /cmd/config-reloader
-    - /cmd/datasource-syncer
-    - /cmd/frontend
-    - /cmd/operator
-    - /cmd/rule-evaluator
-    - /examples/instrumentation/go-synthetic
-    - /hack
-  ignore:
-    - dependency-name: "gke-release/prometheus-engine/*"
-      versions: [ ">=0.15.0" ]
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    docker:
-      patterns:
-        - "*"
-  target-branch: release/0.14
-- package-ecosystem: gomod
-  open-pull-requests-limit: 0 # Security updates only
-  directory: /
-  ignore:
-  # Skip Prometheus as we need to have it pinned carefully.
-  - dependency-name: "github.com/prometheus/prometheus"
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    # Group dep updates into one PR as single update already updates co-located deps.
-    deps:
-      patterns:
-      - "*"
-      exclude-patterns:
-      - "k8s.io/*"
-      - "sigs.k8s.io/*"
-    # Attempt to group dep updates for k8s as they typically break by assuming
-    # all k8s modules are upgraded in the same time.
-    k8s-deps:
-      patterns:
-      - "k8s.io/*"
-      - "sigs.k8s.io/*"
-  target-branch: release/0.14
-# Duplicate config for release/0.13
-- package-ecosystem: docker
-  open-pull-requests-limit: 0 # Security updates only
-  directories:
-    - /cmd/config-reloader
-    - /cmd/datasource-syncer
-    - /cmd/frontend
-    - /cmd/operator
-    - /cmd/rule-evaluator
-    - /examples/instrumentation/go-synthetic
-    - /hack
-  ignore:
-    - dependency-name: "gke-release/prometheus-engine/*"
-      versions: [ ">=0.14.0" ]
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    docker:
-      patterns:
-        - "*"
-  target-branch: release/0.13
-- package-ecosystem: gomod
-  open-pull-requests-limit: 0 # Security updates only
-  directory: /
-  ignore:
-  # Skip Prometheus as we need to have it pinned carefully.
-  - dependency-name: "github.com/prometheus/prometheus"
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope
-  groups:
-    # Group dep updates into one PR as single update already updates co-located deps.
-    deps:
-      patterns:
-      - "*"
-      exclude-patterns:
-      - "k8s.io/*"
-      - "sigs.k8s.io/*"
-    # Attempt to group dep updates for k8s as they typically break by assuming
-    # all k8s modules are upgraded in the same time.
-    k8s-deps:
-      patterns:
-      - "k8s.io/*"
-      - "sigs.k8s.io/*"
-  target-branch: release/0.13
+  # Main branch configuration
+  - package-ecosystem: docker
+    directories:
+      - /cmd/config-reloader
+      - /cmd/datasource-syncer
+      - /cmd/frontend
+      - /cmd/operator
+      - /cmd/rule-evaluator
+      - /examples/instrumentation/go-synthetic
+      - /hack
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      docker:
+        patterns:
+          - "*"
+        exclude-patterns:
+          # To change those we need to do make regen. Still
+          # allow dependabot to bump it to let us know it's possible, just not
+          # in a single group.
+          - "gke.gcr.io/prometheus-engine/*"
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /tools
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /
+    ignore:
+      # Skip Prometheus as we need to have it pinned carefully.
+      - dependency-name: "github.com/prometheus/prometheus"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      # Group dep updates into one PR as single update already updates co-located deps.
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      # Attempt to group dep updates for k8s as they typically break by assuming
+      # all k8s modules are upgraded in the same time.
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+
+  # Config for release/0.19
+  - package-ecosystem: docker
+    directories:
+      - /cmd/config-reloader
+      - /cmd/datasource-syncer
+      - /cmd/frontend
+      - /cmd/operator
+      - /cmd/rule-evaluator
+      - /examples/instrumentation/go-synthetic
+      - /hack
+    ignore:
+      - dependency-name: "gke.gcr.io/prometheus-engine/*"
+        versions: [ ">=0.20.0" ]
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      docker:
+        patterns:
+          - "*"
+    target-branch: release/0.19
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /tools
+    schedule:
+      interval: weekly
+    target-branch: release/0.19
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /
+    ignore:
+      # Skip Prometheus as we need to have it pinned carefully.
+      - dependency-name: "github.com/prometheus/prometheus"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+    target-branch: release/0.19
+
+  # Config for release/0.18
+  - package-ecosystem: docker
+    directories:
+      - /cmd/config-reloader
+      - /cmd/datasource-syncer
+      - /cmd/frontend
+      - /cmd/operator
+      - /cmd/rule-evaluator
+      - /examples/instrumentation/go-synthetic
+      - /hack
+    ignore:
+      - dependency-name: "gke.gcr.io/prometheus-engine/*"
+        versions: [ ">=0.19.0" ]
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      docker:
+        patterns:
+          - "*"
+    target-branch: release/0.18
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /tools
+    schedule:
+      interval: weekly
+    target-branch: release/0.18
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /
+    ignore:
+      # Skip Prometheus as we need to have it pinned carefully.
+      - dependency-name: "github.com/prometheus/prometheus"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+    target-branch: release/0.18
+
+  # Config for release/0.17
+  - package-ecosystem: docker
+    directories:
+      - /cmd/config-reloader
+      - /cmd/datasource-syncer
+      - /cmd/frontend
+      - /cmd/operator
+      - /cmd/rule-evaluator
+      - /examples/instrumentation/go-synthetic
+      - /hack
+    ignore:
+      - dependency-name: "gke.gcr.io/prometheus-engine/*"
+        versions: [ ">=0.18.0" ]
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      docker:
+        patterns:
+          - "*"
+    target-branch: release/0.17
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /tools
+    schedule:
+      interval: weekly
+    target-branch: release/0.17
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /
+    ignore:
+      # Skip Prometheus as we need to have it pinned carefully.
+      - dependency-name: "github.com/prometheus/prometheus"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+    target-branch: release/0.17
+
+  # Config for release/0.16
+  - package-ecosystem: docker
+    directories:
+      - /cmd/config-reloader
+      - /cmd/datasource-syncer
+      - /cmd/frontend
+      - /cmd/operator
+      - /cmd/rule-evaluator
+      - /examples/instrumentation/go-synthetic
+      - /hack
+    ignore:
+      - dependency-name: "gke.gcr.io/prometheus-engine/*"
+        versions: [ ">=0.17.0" ]
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      docker:
+        patterns:
+          - "*"
+    target-branch: release/0.16
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /tools
+    schedule:
+      interval: weekly
+    target-branch: release/0.16
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /
+    ignore:
+      # Skip Prometheus as we need to have it pinned carefully.
+      - dependency-name: "github.com/prometheus/prometheus"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+    target-branch: release/0.16
+
+  # Config for release/0.15
+  - package-ecosystem: docker
+    directories:
+      - /cmd/config-reloader
+      - /cmd/datasource-syncer
+      - /cmd/frontend
+      - /cmd/operator
+      - /cmd/rule-evaluator
+      - /examples/instrumentation/go-synthetic
+      - /hack
+    ignore:
+      - dependency-name: "gke.gcr.io/prometheus-engine/*"
+        versions: [ ">=0.16.0" ]
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      docker:
+        patterns:
+          - "*"
+    target-branch: release/0.15
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /tools
+    schedule:
+      interval: weekly
+    target-branch: release/0.15
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /
+    ignore:
+      # Skip Prometheus as we need to have it pinned carefully.
+      - dependency-name: "github.com/prometheus/prometheus"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+    target-branch: release/0.15
+
+  # Config for release/0.14
+  - package-ecosystem: docker
+    directories:
+      - /cmd/config-reloader
+      - /cmd/datasource-syncer
+      - /cmd/frontend
+      - /cmd/operator
+      - /cmd/rule-evaluator
+      - /examples/instrumentation/go-synthetic
+      - /hack
+    ignore:
+      - dependency-name: "gke.gcr.io/prometheus-engine/*"
+        versions: [ ">=0.15.0" ]
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      docker:
+        patterns:
+          - "*"
+    target-branch: release/0.14
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /tools
+    schedule:
+      interval: weekly
+    target-branch: release/0.14
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /
+    ignore:
+      # Skip Prometheus as we need to have it pinned carefully.
+      - dependency-name: "github.com/prometheus/prometheus"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+    target-branch: release/0.14
+
+  # Config for release/0.13
+  - package-ecosystem: docker
+    directories:
+      - /cmd/config-reloader
+      - /cmd/datasource-syncer
+      - /cmd/frontend
+      - /cmd/operator
+      - /cmd/rule-evaluator
+      - /examples/instrumentation/go-synthetic
+      - /hack
+    ignore:
+      - dependency-name: "gke.gcr.io/prometheus-engine/*"
+        versions: [ ">=0.14.0" ]
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      docker:
+        patterns:
+          - "*"
+    target-branch: release/0.13
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /tools
+    schedule:
+      interval: weekly
+    target-branch: release/0.13
+
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 0 # Security updates only
+    directory: /
+    ignore:
+      # Skip Prometheus as we need to have it pinned carefully.
+      - dependency-name: "github.com/prometheus/prometheus"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      k8s-deps:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+    target-branch: release/0.13


### PR DESCRIPTION
### Summary of Changes

- **Docker Base Images**: Removed `open-pull-requests-limit: 0` across all release branches (`release/0.19`, `release/0.18`, `release/0.17`, `release/0.15`, etc.) so base images are continuously upgraded to `latest`.
- **Go Modules**: Added `open-pull-requests-limit: 0 # Security updates only` for `gomod` jobs (both `/` and `/tools`) across `main` and release branches.
- **Release Branches**: Added explicit configuration blocks for `release/0.19` and `release/0.18`.
- **YAML Standardization**: Cleaned up indentation and standardized `directory: /tools`.