### PR TITLE
revert: restore .bingo/variables.env

### DIFF
--- a/.bingo/variables.env
+++ b/.bingo/variables.env
@@ -1,1 +1,18 @@
-#!/bin/bash
+# Auto generated binary variables helper managed by https://github.com/bwplotka/bingo v0.9. DO NOT EDIT.
+# All tools are designed to be build inside $GOBIN.
+# Those variables will work only until 'bingo get' was invoked, or if tools were installed via Makefile's Variables.mk.
+GOBIN=${GOBIN:=$(go env GOBIN)}
+
+if [ -z "$GOBIN" ]; then
+	GOBIN="$(go env GOPATH)/bin"
+fi
+
+
+CONTROLLER_GEN="${GOBIN}/controller-gen-v0.17.1-0.20250103184936-50893dee96da"
+
+GEN_CRD_API_REFERENCE_DOCS="${GOBIN}/gen-crd-api-reference-docs-v0.3.0"
+
+HELM="${GOBIN}/helm-v3.14.0"
+
+MDOX="${GOBIN}/mdox-v0.9.0"
+


### PR DESCRIPTION
Reverts changes to .bingo/variables.env from 717f70d0bbd6413ef0f3000d5bf2e0a005b5942e