### PR TITLE
Surface collector secret RBAC gaps and refresh frontend example

### DIFF
--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -157,6 +157,10 @@ rules:
   resourceNames: ["verticalpodautoscalers.autoscaling.k8s.io"]
   apiGroups: ["apiextensions.k8s.io"]
   verbs: ["get"]
+- resources:
+  - subjectaccessreviews
+  apiGroups: ["authorization.k8s.io"]
+  verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/examples/configuration/target-labels/README.md
+++ b/examples/configuration/target-labels/README.md
@@ -1,0 +1,43 @@
+# Target labels with fromPod
+
+This example shows how to transfer labels from Kubernetes Pods onto Prometheus
+target labels using [`targetLabels.fromPod`](../../doc/api.md#monitoring.googleapis.com/v1.TargetLabels).
+
+`fromPod` mappings are applied in order. Each mapping copies a value from a Pod
+label (`from`) onto a Prometheus target label (`to`). When `to` is omitted, the
+target label name defaults to the same name as `from`.
+
+This is useful when you want scraped metrics to include application-specific Pod
+labels (for example `app.kubernetes.io/version`) without writing relabeling rules.
+
+## Example
+
+The [pod-monitoring-from-pod.yaml](pod-monitoring-from-pod.yaml) example copies the
+`app.kubernetes.io/version` Pod label onto a `version` target label for all scraped
+metrics.
+
+### Steps
+
+1. Deploy the example application:
+
+    ```
+    kubectl apply -f ../../example-app.yaml
+    ```
+
+2. Apply the `PodMonitoring` with `fromPod` mappings:
+
+    ```
+    kubectl apply -f ./pod-monitoring-from-pod.yaml
+    ```
+
+3. Verify that scraped metrics include the `version` label with the value from
+   the Pod's `app.kubernetes.io/version` label.
+
+## When to use `from` vs `to`
+
+- Use `from` to select which Pod label to copy.
+- Use `to` when the Prometheus target label should have a different name than the
+  Pod label. If `to` is omitted, the target label keeps the same name as `from`.
+
+For example, mapping `from: app.kubernetes.io/version` to `to: version` exposes a
+shorter label name on scraped metrics.

--- a/examples/configuration/target-labels/pod-monitoring-from-pod.yaml
+++ b/examples/configuration/target-labels/pod-monitoring-from-pod.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: prom-example-from-pod
+  labels:
+    app.kubernetes.io/name: prom-example
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prom-example
+  targetLabels:
+    fromPod:
+    # Copy the Pod's app.kubernetes.io/version label onto the Prometheus target
+    # label "version". The "to" field is optional; when omitted, the target label
+    # name defaults to the same name as "from".
+    - from: app.kubernetes.io/version
+      to: version
+  endpoints:
+  - port: metrics
+    interval: 30s

--- a/examples/frontend.yaml
+++ b/examples/frontend.yaml
@@ -45,12 +45,18 @@ spec:
         - args:
             - "--web.listen-address=:9090"
             - "--query.project-id=$PROJECT_ID"
-          image: gke.gcr.io/prometheus-engine/frontend:v0.15.3-gke.0
+          image: gke.gcr.io/prometheus-engine/frontend:v0.17.3-gke.0
           livenessProbe:
             httpGet:
               path: /-/healthy
               port: web
           name: frontend
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 256Mi
           ports:
             - containerPort: 9090
               name: web

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -100,6 +100,10 @@ rules:
   resourceNames: ["verticalpodautoscalers.autoscaling.k8s.io"]
   apiGroups: ["apiextensions.k8s.io"]
   verbs: ["get"]
+- resources:
+  - subjectaccessreviews
+  apiGroups: ["authorization.k8s.io"]
+  verbs: ["create"]
 ---
 # Source: operator/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/operator/apis/monitoring/v1/http_types.go
+++ b/pkg/operator/apis/monitoring/v1/http_types.go
@@ -18,12 +18,19 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 
 	"github.com/prometheus/common/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/prometheus/prometheus/google/secrets"
 )
+
+// SecretReference identifies a Kubernetes Secret referenced by a monitoring resource.
+type SecretReference struct {
+	Namespace string
+	Name      string
+}
 
 // SecretSelector references a secret from a secret provider e.g. Kubernetes Secret. Only one
 // provider can be used at a time.
@@ -393,4 +400,80 @@ func (c *HTTPClientConfig) ToPrometheusConfig(m PodMonitoringCRD, pool Prometheu
 		}
 	}
 	return clientConfig, errors.Join(errs...)
+}
+
+func (s *SecretKeySelector) collectSecretRef(m PodMonitoringCRD, refs map[string]SecretReference) {
+	if s == nil {
+		return
+	}
+	ns := s.Namespace
+	if ns == "" {
+		if m.IsNamespaceScoped() {
+			ns = m.GetNamespace()
+		} else {
+			ns = metav1.NamespaceDefault
+		}
+	}
+	key := ns + "/" + s.Name
+	refs[key] = SecretReference{Namespace: ns, Name: s.Name}
+}
+
+func (s *SecretSelector) collectSecretRefs(m PodMonitoringCRD, refs map[string]SecretReference) {
+	if s == nil || s.Secret == nil {
+		return
+	}
+	s.Secret.collectSecretRef(m, refs)
+}
+
+func (c *HTTPClientConfig) collectSecretRefs(m PodMonitoringCRD, refs map[string]SecretReference) {
+	if c.Authorization != nil && c.Authorization.Credentials != nil {
+		c.Authorization.Credentials.collectSecretRefs(m, refs)
+	}
+	if c.BasicAuth != nil && c.BasicAuth.Password != nil {
+		c.BasicAuth.Password.collectSecretRefs(m, refs)
+	}
+	if c.TLS != nil {
+		if c.TLS.CA != nil {
+			c.TLS.CA.collectSecretRefs(m, refs)
+		}
+		if c.TLS.Cert != nil {
+			c.TLS.Cert.collectSecretRefs(m, refs)
+		}
+		if c.TLS.Key != nil {
+			c.TLS.Key.collectSecretRefs(m, refs)
+		}
+	}
+	if c.OAuth2 != nil {
+		if c.OAuth2.ClientSecret != nil {
+			c.OAuth2.ClientSecret.collectSecretRefs(m, refs)
+		}
+		if c.OAuth2.TLS != nil {
+			if c.OAuth2.TLS.CA != nil {
+				c.OAuth2.TLS.CA.collectSecretRefs(m, refs)
+			}
+			if c.OAuth2.TLS.Cert != nil {
+				c.OAuth2.TLS.Cert.collectSecretRefs(m, refs)
+			}
+			if c.OAuth2.TLS.Key != nil {
+				c.OAuth2.TLS.Key.collectSecretRefs(m, refs)
+			}
+		}
+	}
+}
+
+func referencedSecretsFromEndpoints(m PodMonitoringCRD, endpoints []ScrapeEndpoint) []SecretReference {
+	refs := make(map[string]SecretReference)
+	for _, ep := range endpoints {
+		ep.HTTPClientConfig.collectSecretRefs(m, refs)
+	}
+	keys := make([]string, 0, len(refs))
+	for k := range refs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	result := make([]SecretReference, 0, len(keys))
+	for _, k := range keys {
+		result = append(result, refs[k])
+	}
+	return result
 }

--- a/pkg/operator/apis/monitoring/v1/http_types_secret_test.go
+++ b/pkg/operator/apis/monitoring/v1/http_types_secret_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReferencedSecretsFromEndpoints(t *testing.T) {
+	pmon := &PodMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "apps",
+			Name:      "example",
+		},
+		Spec: PodMonitoringSpec{
+			Endpoints: []ScrapeEndpoint{
+				{
+					HTTPClientConfig: HTTPClientConfig{
+						BasicAuth: &BasicAuth{
+							Password: &SecretSelector{
+								Secret: &SecretKeySelector{
+									Name: "metrics-auth",
+									Key:  "password",
+								},
+							},
+						},
+					},
+				},
+				{
+					HTTPClientConfig: HTTPClientConfig{
+						TLS: &TLS{
+							CA: &SecretSelector{
+								Secret: &SecretKeySelector{
+									Name: "metrics-tls",
+									Key:  "ca",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := pmon.ReferencedSecrets()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 secret references, got %d", len(got))
+	}
+	if got[0].Namespace != "apps" || got[0].Name != "metrics-auth" {
+		t.Fatalf("unexpected first secret reference: %#v", got[0])
+	}
+	if got[1].Namespace != "apps" || got[1].Name != "metrics-tls" {
+		t.Fatalf("unexpected second secret reference: %#v", got[1])
+	}
+}
+
+func TestClusterPodMonitoringReferencedSecrets(t *testing.T) {
+	cmon := &ClusterPodMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "example",
+		},
+		Spec: ClusterPodMonitoringSpec{
+			Endpoints: []ScrapeEndpoint{
+				{
+					HTTPClientConfig: HTTPClientConfig{
+						OAuth2: &OAuth2{
+							ClientSecret: &SecretSelector{
+								Secret: &SecretKeySelector{
+									Namespace: "oauth",
+									Name:      "client",
+									Key:       "secret",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := cmon.ReferencedSecrets()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 secret reference, got %d", len(got))
+	}
+	if got[0].Namespace != "oauth" || got[0].Name != "client" {
+		t.Fatalf("unexpected secret reference: %#v", got[0])
+	}
+}

--- a/pkg/operator/apis/monitoring/v1/monitoring_types.go
+++ b/pkg/operator/apis/monitoring/v1/monitoring_types.go
@@ -35,6 +35,9 @@ const (
 	// ConfigurationCreateSuccess indicates that the config generated from the
 	// monitoring resource was created successfully.
 	ConfigurationCreateSuccess MonitoringConditionType = "ConfigurationCreateSuccess"
+	// CollectorSecretAccess indicates whether the collector ServiceAccount can
+	// access Kubernetes Secrets referenced by this monitoring resource.
+	CollectorSecretAccess MonitoringConditionType = "CollectorSecretAccess"
 )
 
 // MonitoringCondition describes the condition of a PodMonitoring.

--- a/pkg/operator/apis/monitoring/v1/pod_types.go
+++ b/pkg/operator/apis/monitoring/v1/pod_types.go
@@ -36,6 +36,9 @@ type PodMonitoringCRD interface {
 	// GetEndpoints returns the endpoints scraped by this CRD.
 	GetEndpoints() []ScrapeEndpoint
 
+	// ReferencedSecrets returns Kubernetes Secrets referenced by this CRD's endpoints.
+	ReferencedSecrets() []SecretReference
+
 	// GetPodMonitoringStatus returns this CRD's status sub-resource, which must
 	// be available at the top-level.
 	GetPodMonitoringStatus() *PodMonitoringStatus
@@ -75,6 +78,10 @@ func (p *PodMonitoring) GetKey() string {
 
 func (p *PodMonitoring) GetEndpoints() []ScrapeEndpoint {
 	return p.Spec.Endpoints
+}
+
+func (p *PodMonitoring) ReferencedSecrets() []SecretReference {
+	return referencedSecretsFromEndpoints(p, p.Spec.Endpoints)
 }
 
 func (p *PodMonitoring) GetPodMonitoringStatus() *PodMonitoringStatus {
@@ -124,6 +131,10 @@ func (c *ClusterPodMonitoring) GetKey() string {
 
 func (c *ClusterPodMonitoring) GetEndpoints() []ScrapeEndpoint {
 	return c.Spec.Endpoints
+}
+
+func (c *ClusterPodMonitoring) ReferencedSecrets() []SecretReference {
+	return referencedSecretsFromEndpoints(c, c.Spec.Endpoints)
 }
 
 func (c *ClusterPodMonitoring) GetPodMonitoringStatus() *PodMonitoringStatus {

--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -336,6 +336,9 @@ const (
 	// ConfigurationCreateSuccess indicates that the config generated from the
 	// monitoring resource was created successfully.
 	ConfigurationCreateSuccess MonitoringConditionType = "ConfigurationCreateSuccess"
+	// CollectorSecretAccess indicates whether the collector ServiceAccount can
+	// access Kubernetes Secrets referenced by this monitoring resource.
+	CollectorSecretAccess MonitoringConditionType = "CollectorSecretAccess"
 )
 
 // MonitoringCondition describes a condition of a PodMonitoring.

--- a/pkg/operator/collection.go
+++ b/pkg/operator/collection.go
@@ -397,7 +397,13 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 			cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
 		}
 
-		updateStatus := pmon.Status.SetMonitoringCondition(pmon.GetGeneration(), metav1.Now(), cond)
+		updateStatus := applyMonitoringConditions(
+			pmon.GetGeneration(),
+			metav1.Now(),
+			&pmon.Status.MonitoringStatus,
+			cond,
+			r.collectorSecretAccessCondition(ctx, &pmon),
+		)
 		if updateStatus {
 			updates = append(updates, update{
 				object: &pmon,
@@ -430,7 +436,13 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 			cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, cfgs...)
 		}
 
-		updateStatus := cmon.Status.SetMonitoringCondition(cmon.GetGeneration(), metav1.Now(), cond)
+		updateStatus := applyMonitoringConditions(
+			cmon.GetGeneration(),
+			metav1.Now(),
+			&cmon.Status.MonitoringStatus,
+			cond,
+			r.collectorSecretAccessCondition(ctx, &cmon),
+		)
 		if updateStatus {
 			updates = append(updates, update{
 				object: &cmon,
@@ -439,8 +451,7 @@ func (r *collectionReconciler) makeCollectorConfig(ctx context.Context, spec *mo
 		}
 	}
 
-	// TODO(bwplotka): Warn about missing RBAC policies.
-	// https://github.com/GoogleCloudPlatform/prometheus-engine/issues/789
+	// Register referenced secrets in the collector Prometheus configuration.
 	cfg.SecretConfigs = usedSecrets.SecretConfigs()
 
 	if err := r.client.List(ctx, &clusterNodeMons); err != nil {

--- a/pkg/operator/collection_secret_access.go
+++ b/pkg/operator/collection_secret_access.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func collectorUser(operatorNamespace string) string {
+	return fmt.Sprintf("system:serviceaccount:%s:%s", operatorNamespace, NameCollector)
+}
+
+func collectorSecretRBACHint(collectorNamespace, secretNamespace, secretName string) string {
+	return fmt.Sprintf(
+		"collector ServiceAccount (%s) cannot get secret %q in namespace %q. Grant access with a Role in namespace %q containing rules: [{apiGroups: [\"\"], resources: [\"secrets\"], resourceNames: [%q], verbs: [\"get\"]}] and a RoleBinding subject: ServiceAccount %q in namespace %q",
+		collectorUser(collectorNamespace),
+		secretName,
+		secretNamespace,
+		secretNamespace,
+		secretName,
+		NameCollector,
+		collectorNamespace,
+	)
+}
+
+func (r *collectionReconciler) checkCollectorSecretAccess(ctx context.Context, secret monitoringv1.SecretReference) (corev1.ConditionStatus, string) {
+	review := &authorizationv1.SubjectAccessReview{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "gmp-collector-secret-access-",
+		},
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User: collectorUser(r.opts.OperatorNamespace),
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: secret.Namespace,
+				Verb:      "get",
+				Resource:  "secrets",
+				Name:      secret.Name,
+			},
+		},
+	}
+	if err := r.client.Create(ctx, review); err != nil {
+		return corev1.ConditionUnknown, fmt.Sprintf(
+			"unable to verify collector access to secret %q in namespace %q: %v",
+			secret.Name, secret.Namespace, err,
+		)
+	}
+	if review.Status.Allowed {
+		return corev1.ConditionTrue, ""
+	}
+	return corev1.ConditionFalse, collectorSecretRBACHint(r.opts.OperatorNamespace, secret.Namespace, secret.Name)
+}
+
+func (r *collectionReconciler) collectorSecretAccessCondition(ctx context.Context, m monitoringv1.PodMonitoringCRD) *monitoringv1.MonitoringCondition {
+	secrets := m.ReferencedSecrets()
+	if len(secrets) == 0 {
+		return nil
+	}
+	var denied []string
+	for _, secret := range secrets {
+		status, msg := r.checkCollectorSecretAccess(ctx, secret)
+		switch status {
+		case corev1.ConditionUnknown:
+			return &monitoringv1.MonitoringCondition{
+				Type:    monitoringv1.CollectorSecretAccess,
+				Status:  corev1.ConditionUnknown,
+				Message: msg,
+			}
+		case corev1.ConditionFalse:
+			denied = append(denied, msg)
+		}
+	}
+	if len(denied) > 0 {
+		return &monitoringv1.MonitoringCondition{
+			Type:    monitoringv1.CollectorSecretAccess,
+			Status:  corev1.ConditionFalse,
+			Reason:  "MissingRBAC",
+			Message: strings.Join(denied, "; "),
+		}
+	}
+	return &monitoringv1.MonitoringCondition{
+		Type:   monitoringv1.CollectorSecretAccess,
+		Status: corev1.ConditionTrue,
+	}
+}
+
+func applyMonitoringConditions(gen int64, now metav1.Time, status *monitoringv1.MonitoringStatus, conds ...*monitoringv1.MonitoringCondition) bool {
+	updated := false
+	for _, cond := range conds {
+		if cond == nil {
+			continue
+		}
+		if status.SetMonitoringCondition(gen, now, cond) {
+			updated = true
+		}
+	}
+	return updated
+}


### PR DESCRIPTION
## Summary
- Add `CollectorSecretAccess` status conditions on `PodMonitoring` and `ClusterPodMonitoring` when endpoints reference Kubernetes Secrets, using `SubjectAccessReview` to verify the collector ServiceAccount can read them and surfacing actionable RBAC hints when access is missing (closes #789).
- Add `targetLabels.fromPod` documentation and example under `examples/configuration/target-labels/` (closes #875).
- Update `examples/frontend.yaml` to use the current frontend image tag and add resource requests/limits (closes #1426, partially addresses #536).

## Test plan
- [x] `go test ./pkg/operator/... ./pkg/operator/apis/monitoring/v1/...`
- [ ] Deploy a `PodMonitoring` that references a Secret without collector RBAC and confirm `CollectorSecretAccess=False` with RBAC guidance in status
- [ ] Apply `examples/configuration/target-labels/pod-monitoring-from-pod.yaml` against the example app