### PR TITLE
Add targetLabels.fromPod example and documentation

### DIFF
--- a/examples/configuration/target-labels/README.md
+++ b/examples/configuration/target-labels/README.md
@@ -1,0 +1,43 @@
+# Target labels with fromPod
+
+This example shows how to transfer labels from Kubernetes Pods onto Prometheus
+target labels using [`targetLabels.fromPod`](../../doc/api.md#monitoring.googleapis.com/v1.TargetLabels).
+
+`fromPod` mappings are applied in order. Each mapping copies a value from a Pod
+label (`from`) onto a Prometheus target label (`to`). When `to` is omitted, the
+target label name defaults to the same name as `from`.
+
+This is useful when you want scraped metrics to include application-specific Pod
+labels (for example `app.kubernetes.io/version`) without writing relabeling rules.
+
+## Example
+
+The [pod-monitoring-from-pod.yaml](pod-monitoring-from-pod.yaml) example copies the
+`app.kubernetes.io/version` Pod label onto a `version` target label for all scraped
+metrics.
+
+### Steps
+
+1. Deploy the example application:
+
+    ```
+    kubectl apply -f ../../example-app.yaml
+    ```
+
+2. Apply the `PodMonitoring` with `fromPod` mappings:
+
+    ```
+    kubectl apply -f ./pod-monitoring-from-pod.yaml
+    ```
+
+3. Verify that scraped metrics include the `version` label with the value from
+   the Pod's `app.kubernetes.io/version` label.
+
+## When to use `from` vs `to`
+
+- Use `from` to select which Pod label to copy.
+- Use `to` when the Prometheus target label should have a different name than the
+  Pod label. If `to` is omitted, the target label keeps the same name as `from`.
+
+For example, mapping `from: app.kubernetes.io/version` to `to: version` exposes a
+shorter label name on scraped metrics.

--- a/examples/configuration/target-labels/pod-monitoring-from-pod.yaml
+++ b/examples/configuration/target-labels/pod-monitoring-from-pod.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: prom-example-from-pod
+  labels:
+    app.kubernetes.io/name: prom-example
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prom-example
+  targetLabels:
+    fromPod:
+    # Copy the Pod's app.kubernetes.io/version label onto the Prometheus target
+    # label "version". The "to" field is optional; when omitted, the target label
+    # name defaults to the same name as "from".
+    - from: app.kubernetes.io/version
+      to: version
+  endpoints:
+  - port: metrics
+    interval: 30s


### PR DESCRIPTION
## Summary
- Add `examples/configuration/target-labels/pod-monitoring-from-pod.yaml` demonstrating `fromPod` label mappings.
- Add README explaining when to use `from` vs `to`.

Closes #875.

## Test plan
- [ ] Apply `examples/configuration/target-labels/pod-monitoring-from-pod.yaml` with the example app and verify scraped metrics include the mapped target label