### PR TITLE
Update frontend example to current image tag

### DIFF
--- a/examples/frontend.yaml
+++ b/examples/frontend.yaml
@@ -45,7 +45,7 @@ spec:
         - args:
             - "--web.listen-address=:9090"
             - "--query.project-id=$PROJECT_ID"
-          image: gke.gcr.io/prometheus-engine/frontend:v0.15.3-gke.0
+          image: gke.gcr.io/prometheus-engine/frontend:v0.17.3-gke.0
           livenessProbe:
             httpGet:
               path: /-/healthy


### PR DESCRIPTION
## Summary
- Update `examples/frontend.yaml` image from `v0.15.3-gke.0` to `v0.17.3-gke.0` to match current manifests.

Closes #1426.

## Test plan
- [ ] Confirm the image tag exists in release manifests / presubmit image checks