### PR TITLE
Add resource requests to frontend example

### DIFF
--- a/examples/frontend.yaml
+++ b/examples/frontend.yaml
@@ -51,6 +51,12 @@ spec:
               path: /-/healthy
               port: web
           name: frontend
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 256Mi
           ports:
             - containerPort: 9090
               name: web


### PR DESCRIPTION
## Summary
- Add CPU/memory requests and memory limits to the frontend example Deployment.

Part of #536 (one example file; broader issue covers all example containers).

## Test plan
- [ ] `kubectl apply -f examples/frontend.yaml` succeeds with expected resource fields