### PR TITLE
Publish CRD JSON schemas for kubeconform

### DIFF
--- a/hack/gen-jsonschemas/main.go
+++ b/hack/gen-jsonschemas/main.go
@@ -1,0 +1,95 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// gen-jsonschemas extracts openAPIV3Schema from CRD manifests and writes JSON
+// schema files for kubeconform and similar validators.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "gen-jsonschemas: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	crdDir := filepath.Join("charts", "operator", "crds")
+	outDir := "schemas"
+	if len(args) > 0 {
+		crdDir = args[0]
+	}
+	if len(args) > 1 {
+		outDir = args[1]
+	}
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
+	entries, err := os.ReadDir(crdDir)
+	if err != nil {
+		return fmt.Errorf("read crd dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		path := filepath.Join(crdDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+
+		var crd apiextensionsv1.CustomResourceDefinition
+		if err := yaml.Unmarshal(data, &crd); err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+
+		groupShort := strings.SplitN(crd.Spec.Group, ".", 2)[0]
+		singular := crd.Spec.Names.Singular
+
+		for _, version := range crd.Spec.Versions {
+			if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
+				continue
+			}
+
+			name := fmt.Sprintf("%s-%s-%s.json", singular, groupShort, version.Name)
+			outPath := filepath.Join(outDir, name)
+
+			encoded, err := json.MarshalIndent(version.Schema.OpenAPIV3Schema, "", "  ")
+			if err != nil {
+				return fmt.Errorf("marshal schema for %s: %w", name, err)
+			}
+			encoded = append(encoded, '\n')
+
+			if err := os.WriteFile(outPath, encoded, 0o644); err != nil {
+				return fmt.Errorf("write %s: %w", outPath, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/hack/presubmit.sh
+++ b/hack/presubmit.sh
@@ -24,7 +24,7 @@ fi
 
 usage() {
 	cat >&2 <<EOF
-usage: $(basename "$0") [all] [codegen] [crdgen] [diff] [docgen] [manifests] [format] [test]
+usage: $(basename "$0") [all] [codegen] [crdgen] [jsonschemas] [diff] [docgen] [manifests] [format] [test]
   $(basename "$0") executes presubmit tasks on the respository to prepare code
   before submitting changes. Running with no arguments runs every check
   (i.e. the 'all' subcommand).
@@ -86,6 +86,11 @@ update_crdgen() {
 	done
 
 	combine ${CRD_DIR} ${REPO_ROOT}/manifests/setup.yaml
+}
+
+update_jsonschemas() {
+	echo ">>> generating CRD JSON schemas"
+	go run "${REPO_ROOT}/hack/gen-jsonschemas" "${CRD_DIR}" "${REPO_ROOT}/schemas"
 }
 
 update_docgen() {
@@ -154,6 +159,7 @@ exit_msg() {
 update_all() {
 	reformat
 	update_crdgen
+	update_jsonschemas
 	update_manifests
 	update_docgen
 }
@@ -172,6 +178,10 @@ main() {
 				;;
 			crdgen)
 				update_crdgen
+				update_jsonschemas
+				;;
+			jsonschemas)
+				update_jsonschemas
 				;;
 			diff)
 				git diff --exit-code go.mod go.sum '*.md' '*.go' '*.yml' '*.yaml' ||

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -14,7 +14,7 @@ Validate manifests against a pinned release of this repository:
 ```bash
 kubeconform -kubernetes-version 1.32.0 \
   -schema-location default \
-  -schema-location 'https://raw.githubusercontent.com/GoogleCloudPlatform/prometheus-engine/v0.17.3/schemas/{{ .ResourceKind | lower }}-monitoring-{{ .ResourceAPIVersion }}.json' \
+  -schema-location 'https://raw.githubusercontent.com/GoogleCloudPlatform/prometheus-engine/v0.17.3/schemas/{{ .ResourceKind }}-monitoring-{{ .ResourceAPIVersion }}.json' \
   -summary \
   examples/
 ```
@@ -24,7 +24,7 @@ For a local checkout, point `-schema-location` at this directory:
 ```bash
 kubeconform -kubernetes-version 1.32.0 \
   -schema-location default \
-  -schema-location 'schemas/{{ .ResourceKind | lower }}-monitoring-{{ .ResourceAPIVersion }}.json' \
+  -schema-location 'schemas/{{ .ResourceKind }}-monitoring-{{ .ResourceAPIVersion }}.json' \
   -summary \
   examples/
 ```

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,35 @@
+# GMP CRD JSON Schemas
+
+JSON schemas extracted from the operator CRDs for validating GMP custom resources with
+[kubeconform](https://github.com/yannh/kubeconform) or similar tools.
+
+Schemas follow the naming convention used by
+[flux2-schemas](https://github.com/fluxcd-community/flux2-schemas):
+`{singular}-{group}-{version}.json` (for example, `podmonitoring-monitoring-v1.json`).
+
+## Kubeconform
+
+Validate manifests against a pinned release of this repository:
+
+```bash
+kubeconform -kubernetes-version 1.32.0 \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/GoogleCloudPlatform/prometheus-engine/v0.17.3/schemas/{{ .ResourceKind | lower }}-monitoring-{{ .ResourceAPIVersion }}.json' \
+  -summary \
+  examples/
+```
+
+For a local checkout, point `-schema-location` at this directory:
+
+```bash
+kubeconform -kubernetes-version 1.32.0 \
+  -schema-location default \
+  -schema-location 'schemas/{{ .ResourceKind | lower }}-monitoring-{{ .ResourceAPIVersion }}.json' \
+  -summary \
+  examples/
+```
+
+## Regenerating
+
+Schemas are generated from `charts/operator/crds` when running `./hack/presubmit.sh crdgen`
+or `./hack/presubmit.sh all`.

--- a/schemas/clusternodemonitoring-monitoring-v1.json
+++ b/schemas/clusternodemonitoring-monitoring-v1.json
@@ -1,0 +1,285 @@
+{
+  "description": "ClusterNodeMonitoring defines monitoring for a set of nodes.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired node selection for target discovery by\nPrometheus.",
+      "type": "object",
+      "required": [
+        "endpoints"
+      ],
+      "properties": {
+        "endpoints": {
+          "description": "The endpoints to scrape on the selected nodes.",
+          "type": "array",
+          "maxItems": 10,
+          "minItems": 1,
+          "items": {
+            "description": "ScrapeNodeEndpoint specifies a Prometheus metrics endpoint on a node to scrape.\nIt contains all the fields used in the ScrapeEndpoint except for port and HTTPClientConfig.",
+            "type": "object",
+            "required": [
+              "interval"
+            ],
+            "properties": {
+              "interval": {
+                "description": "Interval at which to scrape metrics. Must be a valid Prometheus duration.",
+                "type": "string",
+                "format": "duration",
+                "default": "1m"
+              },
+              "metricRelabeling": {
+                "description": "Relabeling rules for metrics scraped from this endpoint. Relabeling rules that\noverride protected target labels (project_id, location, cluster, namespace, job,\ninstance, or __address__) are not permitted. The labelmap action is not permitted\nin general.",
+                "type": "array",
+                "maxItems": 250,
+                "items": {
+                  "description": "RelabelingRule defines a single Prometheus relabeling rule.",
+                  "type": "object",
+                  "properties": {
+                    "action": {
+                      "description": "Action to perform based on regex matching. Defaults to 'replace'.",
+                      "type": "string",
+                      "enum": [
+                        "replace",
+                        "lowercase",
+                        "uppercase",
+                        "keep",
+                        "drop",
+                        "keepequal",
+                        "dropequal",
+                        "hashmod",
+                        "labeldrop",
+                        "labelkeep"
+                      ]
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Defaults to '(.*)'.",
+                      "type": "string",
+                      "maxLength": 10000
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Defaults to '$1'.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. Defaults to ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
+                      "type": "array",
+                      "maxItems": 100,
+                      "items": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+                      }
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                      "x-kubernetes-validations": [
+                        {
+                          "rule": "self != 'project_id' \u0026\u0026 self != 'location' \u0026\u0026 self != 'cluster' \u0026\u0026 self != 'namespace' \u0026\u0026 self != 'job' \u0026\u0026 self != 'instance' \u0026\u0026 self != 'top_level_controller' \u0026\u0026 self != 'top_level_controller_type' \u0026\u0026 self != '__address__'",
+                          "messageExpression": "'cannot relabel onto protected label \"%s\"'.format([self])"
+                        }
+                      ]
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "rule": "!has(self.action) ||  self.action != 'labeldrop' || has(self.regex)"
+                    }
+                  ]
+                }
+              },
+              "params": {
+                "description": "HTTP GET params to use when scraping.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "path": {
+                "description": "HTTP path to scrape metrics from. Defaults to \"/metrics\".",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Protocol scheme to use to scrape.",
+                "type": "string",
+                "enum": [
+                  "http",
+                  "https"
+                ]
+              },
+              "timeout": {
+                "description": "Timeout for metrics scrapes. Must be a valid Prometheus duration.\nMust not be larger then the scrape interval.",
+                "type": "string",
+                "format": "duration"
+              },
+              "tls": {
+                "description": "TLS configures the scrape request's TLS settings.",
+                "type": "object",
+                "properties": {
+                  "insecureSkipVerify": {
+                    "description": "InsecureSkipVerify disables target certificate validation.",
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "x-kubernetes-validations": [
+              {
+                "rule": "!has(self.timeout) || self.timeout \u003c= self.interval",
+                "messageExpression": "'scrape timeout (%s) must not be greater than scrape interval (%s)'.format([self.timeout, self.interval])"
+              }
+            ]
+          }
+        },
+        "limits": {
+          "description": "Limits to apply at scrape time.",
+          "type": "object",
+          "properties": {
+            "labelNameLength": {
+              "description": "Maximum label name length.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "labelValueLength": {
+              "description": "Maximum label value length.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "labels": {
+              "description": "Maximum number of labels accepted for a single sample.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "samples": {
+              "description": "Maximum number of samples accepted within a single scrape.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "selector": {
+          "description": "Label selector that specifies which nodes are selected for this monitoring\nconfiguration. If left empty all nodes are selected.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                }
+              },
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "type": "array",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    }
+  }
+}

--- a/schemas/clusterpodmonitoring-monitoring-v1.json
+++ b/schemas/clusterpodmonitoring-monitoring-v1.json
@@ -1,0 +1,846 @@
+{
+  "description": "ClusterPodMonitoring defines monitoring for a set of pods, scoped to all\npods within the cluster.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Pod selection for target discovery by\nPrometheus.",
+      "type": "object",
+      "required": [
+        "endpoints",
+        "selector"
+      ],
+      "properties": {
+        "endpoints": {
+          "description": "The endpoints to scrape on the selected pods.",
+          "type": "array",
+          "maxItems": 10,
+          "minItems": 1,
+          "items": {
+            "description": "ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.",
+            "type": "object",
+            "required": [
+              "interval",
+              "port"
+            ],
+            "properties": {
+              "authorization": {
+                "description": "Authorization is the HTTP authorization credentials for the targets.",
+                "type": "object",
+                "properties": {
+                  "credentials": {
+                    "description": "Credentials uses the secret as the credentials (token) for the authentication header.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "type": {
+                    "description": "Type is the authentication type. Defaults to Bearer.\nBasic will cause an error, as the BasicAuth object should be used instead.",
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                      {
+                        "rule": "self != 'Basic'",
+                        "message": "authorization type cannot be set to \"basic\", use \"basic_auth\" instead"
+                      }
+                    ]
+                  }
+                }
+              },
+              "basicAuth": {
+                "description": "BasicAuth is the HTTP basic authentication credentials for the targets.",
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "description": "Password uses the secret as the BasicAuth password.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "username": {
+                    "description": "Username is the BasicAuth username.",
+                    "type": "string"
+                  }
+                }
+              },
+              "interval": {
+                "description": "Interval at which to scrape metrics. Must be a valid Prometheus duration.",
+                "type": "string",
+                "format": "duration"
+              },
+              "metricRelabeling": {
+                "description": "Relabeling rules for metrics scraped from this endpoint. Relabeling rules that\noverride protected target labels (project_id, location, cluster, namespace, job,\ninstance, top_level_controller, top_level_controller_type, or __address__) are\nnot permitted. The labelmap action is not permitted in general.",
+                "type": "array",
+                "maxItems": 250,
+                "items": {
+                  "description": "RelabelingRule defines a single Prometheus relabeling rule.",
+                  "type": "object",
+                  "properties": {
+                    "action": {
+                      "description": "Action to perform based on regex matching. Defaults to 'replace'.",
+                      "type": "string",
+                      "enum": [
+                        "replace",
+                        "lowercase",
+                        "uppercase",
+                        "keep",
+                        "drop",
+                        "keepequal",
+                        "dropequal",
+                        "hashmod",
+                        "labeldrop",
+                        "labelkeep"
+                      ]
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Defaults to '(.*)'.",
+                      "type": "string",
+                      "maxLength": 10000
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Defaults to '$1'.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. Defaults to ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
+                      "type": "array",
+                      "maxItems": 100,
+                      "items": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+                      }
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                      "x-kubernetes-validations": [
+                        {
+                          "rule": "self != 'project_id' \u0026\u0026 self != 'location' \u0026\u0026 self != 'cluster' \u0026\u0026 self != 'namespace' \u0026\u0026 self != 'job' \u0026\u0026 self != 'instance' \u0026\u0026 self != 'top_level_controller' \u0026\u0026 self != 'top_level_controller_type' \u0026\u0026 self != '__address__'",
+                          "messageExpression": "'cannot relabel onto protected label \"%s\"'.format([self])"
+                        }
+                      ]
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "rule": "!has(self.action) ||  self.action != 'labeldrop' || has(self.regex)"
+                    }
+                  ]
+                }
+              },
+              "oauth2": {
+                "description": "OAuth2 is the OAuth2 client credentials used to fetch a token for the targets.",
+                "type": "object",
+                "properties": {
+                  "clientID": {
+                    "description": "ClientID is the public identifier for the client.",
+                    "type": "string"
+                  },
+                  "clientSecret": {
+                    "description": "ClientSecret uses the secret as the client secret token.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "endpointParams": {
+                    "description": "EndpointParams are additional parameters to append to the token URL.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "proxyUrl": {
+                    "description": "ProxyURL is the HTTP proxy server to use to connect to the targets.\n\nEncoded passwords are not supported.",
+                    "type": "string",
+                    "maxLength": 2000,
+                    "x-kubernetes-validations": [
+                      {
+                        "rule": "isURL(self) \u0026\u0026 !self.matches('@')"
+                      }
+                    ]
+                  },
+                  "scopes": {
+                    "description": "Scopes represents the scopes for the token request.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "tlsConfig": {
+                    "description": "TLS configures the token request's TLS settings.",
+                    "type": "object",
+                    "properties": {
+                      "ca": {
+                        "description": "SecretSelector references a secret from a secret provider e.g. Kubernetes Secret. Only one\nprovider can be used at a time.",
+                        "type": "object",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "type": "object",
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "cert": {
+                        "description": "Cert uses the secret as the certificate for client authentication to the server.",
+                        "type": "object",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "type": "object",
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "insecureSkipVerify": {
+                        "description": "InsecureSkipVerify disables target certificate validation.",
+                        "type": "boolean"
+                      },
+                      "key": {
+                        "description": "Key uses the secret as the private key for client authentication to the server.",
+                        "type": "object",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "type": "object",
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "maxVersion": {
+                        "description": "MaxVersion is the maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string",
+                        "enum": [
+                          "TLS10",
+                          "TLS11",
+                          "TLS12",
+                          "TLS13"
+                        ]
+                      },
+                      "minVersion": {
+                        "description": "MinVersion is the minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string",
+                        "enum": [
+                          "TLS10",
+                          "TLS11",
+                          "TLS12",
+                          "TLS13"
+                        ]
+                      },
+                      "serverName": {
+                        "description": "ServerName is used to verify the hostname for the targets.",
+                        "type": "string"
+                      }
+                    },
+                    "x-kubernetes-validations": [
+                      {
+                        "rule": "has(self.cert) == has(self.key)",
+                        "message": "client cert and client key must be provided together, when either is provided"
+                      }
+                    ]
+                  },
+                  "tokenURL": {
+                    "description": "TokenURL is the URL to fetch the token from.",
+                    "type": "string"
+                  }
+                }
+              },
+              "params": {
+                "description": "HTTP GET params to use when scraping.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "path": {
+                "description": "HTTP path to scrape metrics from. Defaults to \"/metrics\".",
+                "type": "string"
+              },
+              "port": {
+                "description": "Name or number of the port to scrape.\nThe container metadata label is only populated if the port is referenced by name\nbecause port numbers are not unique across containers.",
+                "maxLength": 253,
+                "minLength": 1,
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "x-kubernetes-int-or-string": true,
+                "x-kubernetes-validations": [
+                  {
+                    "rule": "self != 0",
+                    "message": "Port is required"
+                  }
+                ]
+              },
+              "proxyUrl": {
+                "description": "ProxyURL is the HTTP proxy server to use to connect to the targets.\n\nEncoded passwords are not supported.",
+                "type": "string",
+                "maxLength": 2000,
+                "x-kubernetes-validations": [
+                  {
+                    "rule": "isURL(self) \u0026\u0026 !self.matches('@')"
+                  }
+                ]
+              },
+              "scheme": {
+                "description": "Protocol scheme to use to scrape.",
+                "type": "string",
+                "enum": [
+                  "http",
+                  "https"
+                ]
+              },
+              "timeout": {
+                "description": "Timeout for metrics scrapes. Must be a valid Prometheus duration.\nMust not be larger than the scrape interval.",
+                "type": "string",
+                "format": "duration"
+              },
+              "tls": {
+                "description": "TLS configures the scrape request's TLS settings.",
+                "type": "object",
+                "properties": {
+                  "ca": {
+                    "description": "SecretSelector references a secret from a secret provider e.g. Kubernetes Secret. Only one\nprovider can be used at a time.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "cert": {
+                    "description": "Cert uses the secret as the certificate for client authentication to the server.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "insecureSkipVerify": {
+                    "description": "InsecureSkipVerify disables target certificate validation.",
+                    "type": "boolean"
+                  },
+                  "key": {
+                    "description": "Key uses the secret as the private key for client authentication to the server.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "maxVersion": {
+                    "description": "MaxVersion is the maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                    "type": "string",
+                    "enum": [
+                      "TLS10",
+                      "TLS11",
+                      "TLS12",
+                      "TLS13"
+                    ]
+                  },
+                  "minVersion": {
+                    "description": "MinVersion is the minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                    "type": "string",
+                    "enum": [
+                      "TLS10",
+                      "TLS11",
+                      "TLS12",
+                      "TLS13"
+                    ]
+                  },
+                  "serverName": {
+                    "description": "ServerName is used to verify the hostname for the targets.",
+                    "type": "string"
+                  }
+                },
+                "x-kubernetes-validations": [
+                  {
+                    "rule": "has(self.cert) == has(self.key)",
+                    "message": "client cert and client key must be provided together, when either is provided"
+                  }
+                ]
+              }
+            },
+            "x-kubernetes-validations": [
+              {
+                "rule": "!has(self.timeout) || self.timeout \u003c= self.interval",
+                "messageExpression": "'scrape timeout (%s) must not be greater than scrape interval (%s)'.format([self.timeout, self.interval])"
+              },
+              {
+                "rule": "((has(self.authorization) ? 1 : 0) + (has(self.basicAuth) ? 1 : 0) + (has(self.oauth2) ? 1 : 0)) \u003c= 1"
+              }
+            ]
+          }
+        },
+        "filterRunning": {
+          "description": "FilterRunning will drop any pods that are in the \"Failed\" or \"Succeeded\"\npod lifecycle.\nSee: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase\nSpecifically, this prevents scraping Succeeded pods from K8s jobs, which\ncould contribute to noisy logs or irrelevant metrics.\nAdditionally, it can mitigate issues with reusing stale target\nlabels in cases where Pod IPs are reused (e.g. spot containers).\nSee: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145",
+          "type": "boolean"
+        },
+        "limits": {
+          "description": "Limits to apply at scrape time.",
+          "type": "object",
+          "properties": {
+            "labelNameLength": {
+              "description": "Maximum label name length.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "labelValueLength": {
+              "description": "Maximum label value length.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "labels": {
+              "description": "Maximum number of labels accepted for a single sample.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "samples": {
+              "description": "Maximum number of samples accepted within a single scrape.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "selector": {
+          "description": "Label selector that specifies which pods are selected for this monitoring\nconfiguration.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                }
+              },
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "targetLabels": {
+          "description": "Labels to add to the Prometheus target for discovered endpoints.\nThe `instance` label is always set to `\u003cpod_name\u003e:\u003cport\u003e` or `\u003cnode_name\u003e:\u003cport\u003e`\nif the scraped pod is controlled by a DaemonSet.",
+          "type": "object",
+          "default": {},
+          "properties": {
+            "fromPod": {
+              "description": "Labels to transfer from the Kubernetes Pod to Prometheus target labels.\nMappings are applied in order.",
+              "type": "array",
+              "maxItems": 100,
+              "items": {
+                "description": "LabelMapping specifies how to transfer a label from a Kubernetes resource\nonto a Prometheus target.",
+                "type": "object",
+                "required": [
+                  "from"
+                ],
+                "properties": {
+                  "from": {
+                    "description": "Kubernetes resource label to remap.",
+                    "type": "string"
+                  },
+                  "to": {
+                    "description": "Remapped Prometheus target label.\nDefaults to the same name as `From`.",
+                    "type": "string",
+                    "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                    "x-kubernetes-validations": [
+                      {
+                        "rule": "self != 'project_id' \u0026\u0026 self != 'location' \u0026\u0026 self != 'cluster' \u0026\u0026 self != 'namespace' \u0026\u0026 self != 'job' \u0026\u0026 self != 'instance' \u0026\u0026 self != 'top_level_controller' \u0026\u0026 self != 'top_level_controller_type' \u0026\u0026 self != '__address__'",
+                        "messageExpression": "'cannot relabel onto protected label \"%s\"'.format([self])"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "metadata": {
+              "description": "Pod metadata labels that are set on all scraped targets.\nPermitted keys are `container`, `namespace`, `node`, `pod`,\n`top_level_controller_name` and `top_level_controller_type`. The `container`\nlabel is only populated if the scrape port is referenced by name.\nDefaults to [container, namespace, pod, top_level_controller_name, top_level_controller_type].\nIf set to null, it will be interpreted as  [namespace]. This is for backwards-compatibility\nonly.",
+              "type": "array",
+              "default": [
+                "container",
+                "namespace",
+                "pod",
+                "top_level_controller_name",
+                "top_level_controller_type"
+              ],
+              "items": {
+                "type": "string",
+                "enum": [
+                  "container",
+                  "namespace",
+                  "node",
+                  "pod",
+                  "top_level_controller_name",
+                  "top_level_controller_type"
+                ]
+              },
+              "x-kubernetes-list-type": "set"
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "type": "array",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "endpointStatuses": {
+          "description": "Represents the latest available observations of target state for each ScrapeEndpoint.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "activeTargets": {
+                "description": "Total number of active targets.",
+                "type": "integer",
+                "format": "int64"
+              },
+              "collectorsFraction": {
+                "description": "Fraction of collectors included in status, bounded [0,1].\nIdeally, this should always be 1. Anything less can\nbe considered a problem and should be investigated.",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "Last time this status was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "name": {
+                "description": "The name of the ScrapeEndpoint.",
+                "type": "string"
+              },
+              "sampleGroups": {
+                "description": "A fixed sample of targets grouped by error type.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "description": "Total count of similar errors.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "sampleTargets": {
+                      "description": "Targets emitting the error message.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "health": {
+                            "description": "Health status.",
+                            "type": "string"
+                          },
+                          "labels": {
+                            "description": "The label set, keys and values, of the target.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "description": "A LabelValue is an associated value for a LabelName.",
+                              "type": "string"
+                            }
+                          },
+                          "lastError": {
+                            "description": "Error message.",
+                            "type": "string"
+                          },
+                          "lastScrapeDurationSeconds": {
+                            "description": "Scrape duration in seconds.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "unhealthyTargets": {
+                "description": "Total number of active, unhealthy targets.",
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    }
+  }
+}

--- a/schemas/clusterpodmonitoring-monitoring-v1alpha1.json
+++ b/schemas/clusterpodmonitoring-monitoring-v1alpha1.json
@@ -1,0 +1,283 @@
+{
+  "description": "ClusterPodMonitoring defines monitoring for a set of pods.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Pod selection for target discovery by\nPrometheus.",
+      "type": "object",
+      "required": [
+        "endpoints",
+        "selector"
+      ],
+      "properties": {
+        "endpoints": {
+          "description": "The endpoints to scrape on the selected pods.",
+          "type": "array",
+          "items": {
+            "description": "ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.",
+            "type": "object",
+            "required": [
+              "port"
+            ],
+            "properties": {
+              "interval": {
+                "description": "Interval at which to scrape metrics. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "metricRelabeling": {
+                "description": "Relabeling rules for metrics scraped from this endpoint. Relabeling rules that\noverride protected target labels (project_id, location, cluster, namespace, job,\ninstance, or __address__) are not permitted. The labelmap action is not permitted\nin general.",
+                "type": "array",
+                "items": {
+                  "description": "RelabelingRule defines a single Prometheus relabeling rule.",
+                  "type": "object",
+                  "properties": {
+                    "action": {
+                      "description": "Action to perform based on regex matching. Defaults to 'replace'.",
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Defaults to '(.*)'.",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Defaults to '$1'.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. Defaults to ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "params": {
+                "description": "HTTP GET params to use when scraping.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "path": {
+                "description": "HTTP path to scrape metrics from. Defaults to \"/metrics\".",
+                "type": "string"
+              },
+              "port": {
+                "description": "Name or number of the port to scrape.",
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "x-kubernetes-int-or-string": true
+              },
+              "proxyUrl": {
+                "description": "Proxy URL to scrape through. Encoded passwords are not supported.",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Protocol scheme to use to scrape.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout for metrics scrapes. Must be a valid Prometheus duration.\nMust not be larger then the scrape interval.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "limits": {
+          "description": "Limits to apply at scrape time.",
+          "type": "object",
+          "properties": {
+            "labelNameLength": {
+              "description": "Maximum label name length.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "labelValueLength": {
+              "description": "Maximum label value length.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "labels": {
+              "description": "Maximum number of labels accepted for a single sample.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "samples": {
+              "description": "Maximum number of samples accepted within a single scrape.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "selector": {
+          "description": "Label selector that specifies which pods are selected for this monitoring\nconfiguration.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                }
+              },
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "targetLabels": {
+          "description": "Labels to add to the Prometheus target for discovered endpoints.",
+          "type": "object",
+          "properties": {
+            "fromPod": {
+              "description": "Labels to transfer from the Kubernetes Pod to Prometheus target labels.\nMappings are applied in order.",
+              "type": "array",
+              "items": {
+                "description": "LabelMapping specifies how to transfer a label from a Kubernetes resource\nonto a Prometheus target.",
+                "type": "object",
+                "required": [
+                  "from"
+                ],
+                "properties": {
+                  "from": {
+                    "description": "Kubernetes resource label to remap.",
+                    "type": "string"
+                  },
+                  "to": {
+                    "description": "Remapped Prometheus target label.\nDefaults to the same name as `From`.",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "metadata": {
+              "description": "Pod metadata labels that are set on all scraped targets.\nPermitted keys are `pod`, `container`, and `node` for PodMonitoring and\n`pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring.\nDefaults to [pod, container] for PodMonitoring and [namespace, pod, container]\nfor ClusterPodMonitoring.\nIf set to null, it will be interpreted as the empty list for PodMonitoring\nand to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility\nonly.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "type": "array",
+          "items": {
+            "description": "MonitoringCondition describes a condition of a PodMonitoring.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    }
+  }
+}

--- a/schemas/clusterrules-monitoring-v1.json
+++ b/schemas/clusterrules-monitoring-v1.json
@@ -1,0 +1,160 @@
+{
+  "description": "ClusterRules defines Prometheus alerting and recording rules that are scoped\nto the current cluster. Only metric data from the current cluster is processed\nand all rule results have their project_id and cluster label preserved\nfor query processing.\nIf the location label is not preserved by the rule, it defaults to the cluster's location.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "type": "object",
+      "required": [
+        "groups"
+      ],
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "type": "array",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "type": "object",
+            "required": [
+              "name",
+              "rules"
+            ],
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string",
+                "format": "duration",
+                "default": "1m"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "type": "object",
+                  "required": [
+                    "expr"
+                  ],
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string",
+                      "format": "duration"
+                    },
+                    "labels": {
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "rule": "(has(self.record) ? 1 : 0) + (has(self.alert) ? 1 : 0) == 1",
+                      "message": "Must set exactly one of Record or Alert"
+                    },
+                    {
+                      "rule": "!has(self.annotations) || has(self.alert)",
+                      "message": "Annotations are only allowed for alerting rules"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "type": "array",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    }
+  }
+}

--- a/schemas/clusterrules-monitoring-v1alpha1.json
+++ b/schemas/clusterrules-monitoring-v1alpha1.json
@@ -1,0 +1,99 @@
+{
+  "description": "ClusterRules defines Prometheus alerting and recording rules that are scoped\nto the current cluster. Only metric data from the current cluster is processed\nand all rule results have their project_id and cluster label preserved\nfor query processing.\nIf the location label is not preserved by the rule, it defaults to the cluster's location.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "type": "object",
+      "required": [
+        "groups"
+      ],
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "type": "array",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "type": "object",
+            "required": [
+              "interval",
+              "name",
+              "rules"
+            ],
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "type": "array",
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "type": "object",
+                  "required": [
+                    "expr"
+                  ],
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object"
+    }
+  }
+}

--- a/schemas/globalrules-monitoring-v1.json
+++ b/schemas/globalrules-monitoring-v1.json
@@ -1,0 +1,160 @@
+{
+  "description": "GlobalRules defines Prometheus alerting and recording rules that are scoped\nto all data in the queried project.\nIf the project_id or location labels are not preserved by the rule, they default to\nthe values of the cluster.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "type": "object",
+      "required": [
+        "groups"
+      ],
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "type": "array",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "type": "object",
+            "required": [
+              "name",
+              "rules"
+            ],
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string",
+                "format": "duration",
+                "default": "1m"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "type": "object",
+                  "required": [
+                    "expr"
+                  ],
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string",
+                      "format": "duration"
+                    },
+                    "labels": {
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "rule": "(has(self.record) ? 1 : 0) + (has(self.alert) ? 1 : 0) == 1",
+                      "message": "Must set exactly one of Record or Alert"
+                    },
+                    {
+                      "rule": "!has(self.annotations) || has(self.alert)",
+                      "message": "Annotations are only allowed for alerting rules"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "type": "array",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    }
+  }
+}

--- a/schemas/globalrules-monitoring-v1alpha1.json
+++ b/schemas/globalrules-monitoring-v1alpha1.json
@@ -1,0 +1,99 @@
+{
+  "description": "GlobalRules defines Prometheus alerting and recording rules that are scoped\nto all data in the queried project.\nIf the project_id or location labels are not preserved by the rule, they default to\nthe values of the cluster.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "type": "object",
+      "required": [
+        "groups"
+      ],
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "type": "array",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "type": "object",
+            "required": [
+              "interval",
+              "name",
+              "rules"
+            ],
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "type": "array",
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "type": "object",
+                  "required": [
+                    "expr"
+                  ],
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object"
+    }
+  }
+}

--- a/schemas/operatorconfig-monitoring-v1.json
+++ b/schemas/operatorconfig-monitoring-v1.json
@@ -1,0 +1,556 @@
+{
+  "description": "OperatorConfig defines configuration of the gmp-operator.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "collection": {
+      "description": "Collection specifies how the operator configures collection, including\nscraping and an integrated export to Google Cloud Monitoring.",
+      "type": "object",
+      "properties": {
+        "compression": {
+          "description": "Compression enables compression of metrics collection data.",
+          "type": "string",
+          "enum": [
+            "none",
+            "gzip"
+          ]
+        },
+        "credentials": {
+          "description": "A reference to GCP service account credentials with which Prometheus collectors\nare run. It needs to have metric write permissions for all project IDs to which\ndata is written.\nWithin GKE, this can typically be left empty if the compute default\nservice account has the required permissions.",
+          "type": "object",
+          "required": [
+            "key"
+          ],
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string",
+              "default": ""
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "x-kubernetes-map-type": "atomic",
+          "x-kubernetes-validations": [
+            {
+              "rule": "has(self.name) \u0026\u0026 self.name != ''",
+              "message": "missing secret key selector name"
+            }
+          ]
+        },
+        "externalLabels": {
+          "description": "ExternalLabels specifies external labels that are attached to all scraped\ndata before being written to Google Cloud Monitoring or any other additional exports\nspecified in the OperatorConfig. The precedence behavior matches that of Prometheus.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "filter": {
+          "description": "Filter limits which metric data is sent to Cloud Monitoring (it doesn't apply to additional exports).",
+          "type": "object",
+          "properties": {
+            "enableMatchOneOf": {
+              "description": "EnableMatchOneOf allows additional control over MatchOneOf filtering.\n\nAvailable settings:\n* not set: The MatchOneOf settings are ignored, default is used.\n* false: MatchOneOf feature is explicitly disabled; export is forced to match all series.\n* true: The MatchOneOf settings are used, overwriting a default.\n\nSee MatchOneOf IMPORTANT section to learn about the MatchOneOf default.",
+              "type": "boolean"
+            },
+            "matchOneOf": {
+              "description": "MatchOneOf, if EnableMatchOneOf is true, controls the export filtering setting.\n\nMatchOneOf expects a list of Prometheus time series matchers. Every time series\nmust match at least one of the matchers to be exported. This field can be used\nequivalently to the match[] parameter of the Prometheus federation endpoint to\nselectively export data.\n\nExample: `[\"{job!='foobar'}\", \"{__name__!~'container_foo.*|container_bar.*'}\"]`\n\nIMPORTANT: MatchOneOf is guarded by the additional flag (EnableMatchOneOf)\nand removed from the public docs. Replacements: https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#filter-metrics.\n\nRationales:\n* This option is prone to misconfiguration, e.g. you need to manually\n  match important built-in metrics (up, scrape_samples_added, etc.).\n* Unmatched metrics are still in the local collector memory\n  (this filters on export only).\n* Typically, the default (empty array), means match all metrics. However,\n  for the clusters that were using MatchOneOf filtering before the GMP 0.14.x,\n  version, the default is what has been configured back then in the orphaned\n  collector DaemonSet EXTRA_ARGS environment variable. If you are impacted:\n  * use EnableMatchOneOf = false to reset the default\n  * use EnableMatchOneOf = true to apply this configuration's MatchOneOf\n  * Remove EXTRA_ARGS environment variable from the collector DaemonSet (it's safe to do so).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "kubeletScraping": {
+          "description": "Configuration to scrape the metric endpoints of the Kubelets.",
+          "type": "object",
+          "required": [
+            "interval"
+          ],
+          "properties": {
+            "interval": {
+              "description": "The interval at which the metric endpoints are scraped.",
+              "type": "string",
+              "format": "duration"
+            },
+            "tlsInsecureSkipVerify": {
+              "description": "TLSInsecureSkipVerify disables verifying the target cert.\nThis can be useful for clusters provisioned with kubeadm.",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "exports": {
+      "description": "Exports is an EXPERIMENTAL feature that specifies additional, optional endpoints to export to,\non top of Google Cloud Monitoring collection.\nNote: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in the \"collection.filter\" field.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "description": "The URL of the endpoint that supports Prometheus Remote Write to export samples to.",
+            "type": "string",
+            "format": "uri",
+            "x-kubernetes-validations": [
+              {
+                "rule": "self == '' || isURL(self)",
+                "message": "url must be a valid URL"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "features": {
+      "description": "Features holds configuration for optional managed-collection features.",
+      "type": "object",
+      "properties": {
+        "config": {
+          "description": "Settings for the collector configuration propagation.",
+          "type": "object",
+          "properties": {
+            "compression": {
+              "description": "Compression enables compression of the config data propagated by the operator to collectors\nand the rule-evaluator. It is recommended to use the gzip option when using a large number of\nClusterPodMonitoring, PodMonitoring, GlobalRules, ClusterRules, and/or Rules.",
+              "type": "string",
+              "enum": [
+                "none",
+                "gzip"
+              ]
+            }
+          }
+        },
+        "targetStatus": {
+          "description": "Configuration of target status reporting.",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Enable target status reporting.",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "managedAlertmanager": {
+      "description": "ManagedAlertmanager holds information for configuring the managed instance of Alertmanager.",
+      "type": "object",
+      "default": {
+        "configSecret": {
+          "key": "alertmanager.yaml",
+          "name": "alertmanager"
+        }
+      },
+      "properties": {
+        "configSecret": {
+          "description": "ConfigSecret refers to the name of a single-key Secret in the public namespace that\nholds the managed Alertmanager config file.",
+          "type": "object",
+          "required": [
+            "key"
+          ],
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string",
+              "default": ""
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "x-kubernetes-map-type": "atomic",
+          "x-kubernetes-validations": [
+            {
+              "rule": "has(self.name) \u0026\u0026 self.name != ''",
+              "message": "missing secret key selector name"
+            }
+          ]
+        },
+        "externalURL": {
+          "description": "ExternalURL is the URL under which Alertmanager is externally reachable (for example, if\nAlertmanager is served via a reverse proxy). Used for generating relative and absolute\nlinks back to Alertmanager itself. If the URL has a path portion, it will be used to\nprefix all HTTP endpoints served by Alertmanager, otherwise relevant URL components will\nbe derived automatically.\n\nIf no URL is provided, Alertmanager will point to the Google Cloud Metric Explorer page.",
+          "type": "string",
+          "format": "uri",
+          "x-kubernetes-validations": [
+            {
+              "rule": "self == '' || isURL(self)",
+              "message": "externalURL must be a valid URL"
+            }
+          ]
+        }
+      }
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "rules": {
+      "description": "Rules specifies how the operator configures and deploys rule-evaluator.",
+      "type": "object",
+      "properties": {
+        "alerting": {
+          "description": "Alerting contains how the rule-evaluator configures alerting.",
+          "type": "object",
+          "properties": {
+            "alertmanagers": {
+              "description": "Alertmanagers contains endpoint configuration for designated Alertmanagers.",
+              "type": "array",
+              "items": {
+                "description": "AlertmanagerEndpoints defines a selection of a single Endpoints object\ncontaining alertmanager IPs to fire alerts against.",
+                "type": "object",
+                "required": [
+                  "name",
+                  "namespace",
+                  "port"
+                ],
+                "properties": {
+                  "apiVersion": {
+                    "description": "Version of the Alertmanager API that rule-evaluator uses to send alerts. It\ncan be \"v1\" or \"v2\".",
+                    "type": "string"
+                  },
+                  "authorization": {
+                    "description": "Authorization section for this alertmanager endpoint.",
+                    "type": "object",
+                    "properties": {
+                      "credentials": {
+                        "description": "The secret's key that contains the credentials of the request",
+                        "type": "object",
+                        "required": [
+                          "key"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string",
+                            "default": ""
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic",
+                        "x-kubernetes-validations": [
+                          {
+                            "rule": "has(self.name) \u0026\u0026 self.name != ''",
+                            "message": "missing secret key selector name"
+                          }
+                        ]
+                      },
+                      "type": {
+                        "description": "Set the authentication type. Defaults to Bearer, Basic will cause an\nerror.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "name": {
+                    "description": "Name of Endpoints object in Namespace.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of Endpoints object.",
+                    "type": "string"
+                  },
+                  "pathPrefix": {
+                    "description": "Prefix for the HTTP path alerts are pushed to.",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "Port the Alertmanager API is exposed on.",
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "scheme": {
+                    "description": "Scheme to use when firing alerts.",
+                    "type": "string"
+                  },
+                  "timeout": {
+                    "description": "Timeout is a per-target Alertmanager timeout when pushing alerts.",
+                    "type": "string",
+                    "format": "duration"
+                  },
+                  "tls": {
+                    "description": "TLS Config to use for alertmanager connection.",
+                    "type": "object",
+                    "properties": {
+                      "ca": {
+                        "description": "Struct containing the CA cert to use for the targets.",
+                        "type": "object",
+                        "properties": {
+                          "configMap": {
+                            "description": "ConfigMap containing data to use for the targets.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string",
+                                "default": ""
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "secret": {
+                            "description": "Secret containing data to use for the targets.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string",
+                                "default": ""
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic",
+                            "x-kubernetes-validations": [
+                              {
+                                "rule": "has(self.name) \u0026\u0026 self.name != ''",
+                                "message": "missing secret key selector name"
+                              }
+                            ]
+                          }
+                        },
+                        "x-kubernetes-validations": [
+                          {
+                            "rule": "!(has(self.secret) \u0026\u0026 has(self.configMap))",
+                            "message": "SecretOrConfigMap fields are mutually exclusive"
+                          }
+                        ]
+                      },
+                      "cert": {
+                        "description": "Struct containing the client cert file for the targets.",
+                        "type": "object",
+                        "properties": {
+                          "configMap": {
+                            "description": "ConfigMap containing data to use for the targets.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string",
+                                "default": ""
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "secret": {
+                            "description": "Secret containing data to use for the targets.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string",
+                                "default": ""
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic",
+                            "x-kubernetes-validations": [
+                              {
+                                "rule": "has(self.name) \u0026\u0026 self.name != ''",
+                                "message": "missing secret key selector name"
+                              }
+                            ]
+                          }
+                        },
+                        "x-kubernetes-validations": [
+                          {
+                            "rule": "!(has(self.secret) \u0026\u0026 has(self.configMap))",
+                            "message": "SecretOrConfigMap fields are mutually exclusive"
+                          }
+                        ]
+                      },
+                      "insecureSkipVerify": {
+                        "description": "Disable target certificate validation.",
+                        "type": "boolean"
+                      },
+                      "keySecret": {
+                        "description": "Secret containing the client key file for the targets.",
+                        "type": "object",
+                        "required": [
+                          "key"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string",
+                            "default": ""
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic",
+                        "x-kubernetes-validations": [
+                          {
+                            "rule": "has(self.name) \u0026\u0026 self.name != ''",
+                            "message": "missing secret key selector name"
+                          }
+                        ]
+                      },
+                      "maxVersion": {
+                        "description": "Maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string"
+                      },
+                      "minVersion": {
+                        "description": "Minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string"
+                      },
+                      "serverName": {
+                        "description": "Used to verify the hostname for the targets.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "credentials": {
+          "description": "A reference to GCP service account credentials with which the rule\nevaluator container is run. It needs to have metric read permissions\nagainst queryProjectId and metric write permissions against all projects\nto which rule results are written.\nWithin GKE, this can typically be left empty if the compute default\nservice account has the required permissions.",
+          "type": "object",
+          "required": [
+            "key"
+          ],
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string",
+              "default": ""
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "x-kubernetes-map-type": "atomic",
+          "x-kubernetes-validations": [
+            {
+              "rule": "has(self.name) \u0026\u0026 self.name != ''",
+              "message": "missing secret key selector name"
+            }
+          ]
+        },
+        "externalLabels": {
+          "description": "ExternalLabels specifies external labels that are attached to any rule\nresults and alerts produced by rules. The precedence behavior matches that\nof Prometheus.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "generatorUrl": {
+          "description": "The base URL used for the generator URL in the alert notification payload.\nShould point to an instance of a query frontend that gives access to queryProjectID.",
+          "type": "string",
+          "format": "uri",
+          "x-kubernetes-validations": [
+            {
+              "rule": "self == '' || isURL(self)",
+              "message": "generatorUrl must be a valid URL"
+            }
+          ]
+        },
+        "queryProjectID": {
+          "description": "QueryProjectID is the GCP project ID to evaluate rules against.\nIf left blank, the rule-evaluator will try attempt to infer the Project ID\nfrom the environment.",
+          "type": "string"
+        }
+      }
+    },
+    "scaling": {
+      "description": "Scaling contains configuration options for scaling GMP.",
+      "type": "object",
+      "properties": {
+        "vpa": {
+          "description": "VPASpec defines configuration options for vertical pod autoscaling.",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Enabled configures whether the operator configures Vertical Pod Autoscaling for GMP workloads.\nIn GKE, installing Vertical Pod Autoscaling requires a cluster restart, and therefore it also results in an operator restart.\nIn other environments, the operator may need to be restarted to enable VPA to run the following check again and watch for the objects.",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/operatorconfig-monitoring-v1alpha1.json
+++ b/schemas/operatorconfig-monitoring-v1alpha1.json
@@ -1,0 +1,337 @@
+{
+  "description": "OperatorConfig defines configuration of the gmp-operator.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "collection": {
+      "description": "Collection specifies how the operator configures collection.",
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "description": "A reference to GCP service account credentials with which Prometheus collectors\nare run. It needs to have metric write permissions for all project IDs to which\ndata is written.\nWithin GKE, this can typically be left empty if the compute default\nservice account has the required permissions.",
+          "type": "object",
+          "required": [
+            "key"
+          ],
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string",
+              "default": ""
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "externalLabels": {
+          "description": "ExternalLabels specifies external labels that are attached to all scraped\ndata before being written to Cloud Monitoring. The precedence behavior matches that\nof Prometheus.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "filter": {
+          "description": "Filter limits which metric data is sent to Cloud Monitoring.",
+          "type": "object",
+          "properties": {
+            "matchOneOf": {
+              "description": "A list Prometheus time series matchers. Every time series must match at least one\nof the matchers to be exported. This field can be used equivalently to the match[]\nparameter of the Prometheus federation endpoint to selectively export data.\nExample: `[\"{job='prometheus'}\", \"{__name__=~'job:.*'}\"]`.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "rules": {
+      "description": "Rules specifies how the operator configures and deployes rule-evaluator.",
+      "type": "object",
+      "properties": {
+        "alerting": {
+          "description": "Alerting contains how the rule-evaluator configures alerting.",
+          "type": "object",
+          "properties": {
+            "alertmanagers": {
+              "description": "Alertmanagers contains endpoint configuration for designated Alertmanagers.",
+              "type": "array",
+              "items": {
+                "description": "AlertmanagerEndpoints defines a selection of a single Endpoints object\ncontaining alertmanager IPs to fire alerts against.",
+                "type": "object",
+                "required": [
+                  "name",
+                  "namespace",
+                  "port"
+                ],
+                "properties": {
+                  "apiVersion": {
+                    "description": "Version of the Alertmanager API that rule-evaluator uses to send alerts. It\ncan be \"v1\" or \"v2\".",
+                    "type": "string"
+                  },
+                  "authorization": {
+                    "description": "Authorization section for this alertmanager endpoint.",
+                    "type": "object",
+                    "properties": {
+                      "credentials": {
+                        "description": "The secret's key that contains the credentials of the request.",
+                        "type": "object",
+                        "required": [
+                          "key"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string",
+                            "default": ""
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "type": {
+                        "description": "Set the authentication type. Defaults to Bearer, Basic will cause an\nerror.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "name": {
+                    "description": "Name of Endpoints object in Namespace.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of Endpoints object.",
+                    "type": "string"
+                  },
+                  "pathPrefix": {
+                    "description": "Prefix for the HTTP path alerts are pushed to.",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "Port the Alertmanager API is exposed on.",
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "scheme": {
+                    "description": "Scheme to use when firing alerts.",
+                    "type": "string"
+                  },
+                  "timeout": {
+                    "description": "Timeout is a per-target Alertmanager timeout when pushing alerts.",
+                    "type": "string"
+                  },
+                  "tls": {
+                    "description": "TLS Config to use for alertmanager connection.",
+                    "type": "object",
+                    "properties": {
+                      "ca": {
+                        "description": "Struct containing the CA cert to use for the targets.",
+                        "type": "object",
+                        "properties": {
+                          "configMap": {
+                            "description": "ConfigMap containing data to use for the targets.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string",
+                                "default": ""
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "secret": {
+                            "description": "Secret containing data to use for the targets.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string",
+                                "default": ""
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      },
+                      "cert": {
+                        "description": "Struct containing the client cert file for the targets.",
+                        "type": "object",
+                        "properties": {
+                          "configMap": {
+                            "description": "ConfigMap containing data to use for the targets.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string",
+                                "default": ""
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "secret": {
+                            "description": "Secret containing data to use for the targets.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string",
+                                "default": ""
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      },
+                      "insecureSkipVerify": {
+                        "description": "Disable target certificate validation.",
+                        "type": "boolean"
+                      },
+                      "keySecret": {
+                        "description": "Secret containing the client key file for the targets.",
+                        "type": "object",
+                        "required": [
+                          "key"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string",
+                            "default": ""
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "serverName": {
+                        "description": "Used to verify the hostname for the targets.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "credentials": {
+          "description": "A reference to GCP service account credentials with which the rule\nevaluator container is run. It needs to have metric read permissions\nagainst queryProjectId and metric write permissions against all projects\nto which rule results are written.\nWithin GKE, this can typically be left empty if the compute default\nservice account has the required permissions.",
+          "type": "object",
+          "required": [
+            "key"
+          ],
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string",
+              "default": ""
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "externalLabels": {
+          "description": "ExternalLabels specifies external labels that are attached to any rule\nresults and alerts produced by rules. The precedence behavior matches that\nof Prometheus.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "queryProjectID": {
+          "description": "QueryProjectID is the GCP project ID to evaluate rules against.\nIf left blank, the rule-evaluator will try attempt to infer the Project ID\nfrom the environment.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/podmonitoring-monitoring-v1.json
+++ b/schemas/podmonitoring-monitoring-v1.json
@@ -1,0 +1,876 @@
+{
+  "description": "PodMonitoring defines monitoring for a set of pods, scoped to pods\nwithin the PodMonitoring's namespace.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Pod selection for target discovery by\nPrometheus.",
+      "type": "object",
+      "required": [
+        "endpoints",
+        "selector"
+      ],
+      "properties": {
+        "endpoints": {
+          "description": "The endpoints to scrape on the selected pods.",
+          "type": "array",
+          "maxItems": 10,
+          "minItems": 1,
+          "items": {
+            "description": "ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.",
+            "type": "object",
+            "required": [
+              "interval",
+              "port"
+            ],
+            "properties": {
+              "authorization": {
+                "description": "Authorization is the HTTP authorization credentials for the targets.",
+                "type": "object",
+                "properties": {
+                  "credentials": {
+                    "description": "Credentials uses the secret as the credentials (token) for the authentication header.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "type": {
+                    "description": "Type is the authentication type. Defaults to Bearer.\nBasic will cause an error, as the BasicAuth object should be used instead.",
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                      {
+                        "rule": "self != 'Basic'",
+                        "message": "authorization type cannot be set to \"basic\", use \"basic_auth\" instead"
+                      }
+                    ]
+                  }
+                }
+              },
+              "basicAuth": {
+                "description": "BasicAuth is the HTTP basic authentication credentials for the targets.",
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "description": "Password uses the secret as the BasicAuth password.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "username": {
+                    "description": "Username is the BasicAuth username.",
+                    "type": "string"
+                  }
+                }
+              },
+              "interval": {
+                "description": "Interval at which to scrape metrics. Must be a valid Prometheus duration.",
+                "type": "string",
+                "format": "duration"
+              },
+              "metricRelabeling": {
+                "description": "Relabeling rules for metrics scraped from this endpoint. Relabeling rules that\noverride protected target labels (project_id, location, cluster, namespace, job,\ninstance, top_level_controller, top_level_controller_type, or __address__) are\nnot permitted. The labelmap action is not permitted in general.",
+                "type": "array",
+                "maxItems": 250,
+                "items": {
+                  "description": "RelabelingRule defines a single Prometheus relabeling rule.",
+                  "type": "object",
+                  "properties": {
+                    "action": {
+                      "description": "Action to perform based on regex matching. Defaults to 'replace'.",
+                      "type": "string",
+                      "enum": [
+                        "replace",
+                        "lowercase",
+                        "uppercase",
+                        "keep",
+                        "drop",
+                        "keepequal",
+                        "dropequal",
+                        "hashmod",
+                        "labeldrop",
+                        "labelkeep"
+                      ]
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Defaults to '(.*)'.",
+                      "type": "string",
+                      "maxLength": 10000
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Defaults to '$1'.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. Defaults to ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
+                      "type": "array",
+                      "maxItems": 100,
+                      "items": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+                      }
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                      "x-kubernetes-validations": [
+                        {
+                          "rule": "self != 'project_id' \u0026\u0026 self != 'location' \u0026\u0026 self != 'cluster' \u0026\u0026 self != 'namespace' \u0026\u0026 self != 'job' \u0026\u0026 self != 'instance' \u0026\u0026 self != 'top_level_controller' \u0026\u0026 self != 'top_level_controller_type' \u0026\u0026 self != '__address__'",
+                          "messageExpression": "'cannot relabel onto protected label \"%s\"'.format([self])"
+                        }
+                      ]
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "rule": "!has(self.action) ||  self.action != 'labeldrop' || has(self.regex)"
+                    }
+                  ]
+                }
+              },
+              "oauth2": {
+                "description": "OAuth2 is the OAuth2 client credentials used to fetch a token for the targets.",
+                "type": "object",
+                "properties": {
+                  "clientID": {
+                    "description": "ClientID is the public identifier for the client.",
+                    "type": "string"
+                  },
+                  "clientSecret": {
+                    "description": "ClientSecret uses the secret as the client secret token.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "endpointParams": {
+                    "description": "EndpointParams are additional parameters to append to the token URL.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "proxyUrl": {
+                    "description": "ProxyURL is the HTTP proxy server to use to connect to the targets.\n\nEncoded passwords are not supported.",
+                    "type": "string",
+                    "maxLength": 2000,
+                    "x-kubernetes-validations": [
+                      {
+                        "rule": "isURL(self) \u0026\u0026 !self.matches('@')"
+                      }
+                    ]
+                  },
+                  "scopes": {
+                    "description": "Scopes represents the scopes for the token request.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "tlsConfig": {
+                    "description": "TLS configures the token request's TLS settings.",
+                    "type": "object",
+                    "properties": {
+                      "ca": {
+                        "description": "SecretSelector references a secret from a secret provider e.g. Kubernetes Secret. Only one\nprovider can be used at a time.",
+                        "type": "object",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "type": "object",
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "cert": {
+                        "description": "Cert uses the secret as the certificate for client authentication to the server.",
+                        "type": "object",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "type": "object",
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "insecureSkipVerify": {
+                        "description": "InsecureSkipVerify disables target certificate validation.",
+                        "type": "boolean"
+                      },
+                      "key": {
+                        "description": "Key uses the secret as the private key for client authentication to the server.",
+                        "type": "object",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "type": "object",
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "maxVersion": {
+                        "description": "MaxVersion is the maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string",
+                        "enum": [
+                          "TLS10",
+                          "TLS11",
+                          "TLS12",
+                          "TLS13"
+                        ]
+                      },
+                      "minVersion": {
+                        "description": "MinVersion is the minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string",
+                        "enum": [
+                          "TLS10",
+                          "TLS11",
+                          "TLS12",
+                          "TLS13"
+                        ]
+                      },
+                      "serverName": {
+                        "description": "ServerName is used to verify the hostname for the targets.",
+                        "type": "string"
+                      }
+                    },
+                    "x-kubernetes-validations": [
+                      {
+                        "rule": "has(self.cert) == has(self.key)",
+                        "message": "client cert and client key must be provided together, when either is provided"
+                      }
+                    ]
+                  },
+                  "tokenURL": {
+                    "description": "TokenURL is the URL to fetch the token from.",
+                    "type": "string"
+                  }
+                }
+              },
+              "params": {
+                "description": "HTTP GET params to use when scraping.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "path": {
+                "description": "HTTP path to scrape metrics from. Defaults to \"/metrics\".",
+                "type": "string"
+              },
+              "port": {
+                "description": "Name or number of the port to scrape.\nThe container metadata label is only populated if the port is referenced by name\nbecause port numbers are not unique across containers.",
+                "maxLength": 253,
+                "minLength": 1,
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "x-kubernetes-int-or-string": true,
+                "x-kubernetes-validations": [
+                  {
+                    "rule": "self != 0",
+                    "message": "Port is required"
+                  }
+                ]
+              },
+              "proxyUrl": {
+                "description": "ProxyURL is the HTTP proxy server to use to connect to the targets.\n\nEncoded passwords are not supported.",
+                "type": "string",
+                "maxLength": 2000,
+                "x-kubernetes-validations": [
+                  {
+                    "rule": "isURL(self) \u0026\u0026 !self.matches('@')"
+                  }
+                ]
+              },
+              "scheme": {
+                "description": "Protocol scheme to use to scrape.",
+                "type": "string",
+                "enum": [
+                  "http",
+                  "https"
+                ]
+              },
+              "timeout": {
+                "description": "Timeout for metrics scrapes. Must be a valid Prometheus duration.\nMust not be larger than the scrape interval.",
+                "type": "string",
+                "format": "duration"
+              },
+              "tls": {
+                "description": "TLS configures the scrape request's TLS settings.",
+                "type": "object",
+                "properties": {
+                  "ca": {
+                    "description": "SecretSelector references a secret from a secret provider e.g. Kubernetes Secret. Only one\nprovider can be used at a time.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "cert": {
+                    "description": "Cert uses the secret as the certificate for client authentication to the server.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "insecureSkipVerify": {
+                    "description": "InsecureSkipVerify disables target certificate validation.",
+                    "type": "boolean"
+                  },
+                  "key": {
+                    "description": "Key uses the secret as the private key for client authentication to the server.",
+                    "type": "object",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "maxVersion": {
+                    "description": "MaxVersion is the maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                    "type": "string",
+                    "enum": [
+                      "TLS10",
+                      "TLS11",
+                      "TLS12",
+                      "TLS13"
+                    ]
+                  },
+                  "minVersion": {
+                    "description": "MinVersion is the minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                    "type": "string",
+                    "enum": [
+                      "TLS10",
+                      "TLS11",
+                      "TLS12",
+                      "TLS13"
+                    ]
+                  },
+                  "serverName": {
+                    "description": "ServerName is used to verify the hostname for the targets.",
+                    "type": "string"
+                  }
+                },
+                "x-kubernetes-validations": [
+                  {
+                    "rule": "has(self.cert) == has(self.key)",
+                    "message": "client cert and client key must be provided together, when either is provided"
+                  }
+                ]
+              }
+            },
+            "x-kubernetes-validations": [
+              {
+                "rule": "!has(self.timeout) || self.timeout \u003c= self.interval",
+                "messageExpression": "'scrape timeout (%s) must not be greater than scrape interval (%s)'.format([self.timeout, self.interval])"
+              },
+              {
+                "rule": "((has(self.authorization) ? 1 : 0) + (has(self.basicAuth) ? 1 : 0) + (has(self.oauth2) ? 1 : 0)) \u003c= 1"
+              }
+            ]
+          }
+        },
+        "filterRunning": {
+          "description": "FilterRunning will drop any pods that are in the \"Failed\" or \"Succeeded\"\npod lifecycle.\nSee: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase",
+          "type": "boolean"
+        },
+        "limits": {
+          "description": "Limits to apply at scrape time.",
+          "type": "object",
+          "properties": {
+            "labelNameLength": {
+              "description": "Maximum label name length.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "labelValueLength": {
+              "description": "Maximum label value length.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "labels": {
+              "description": "Maximum number of labels accepted for a single sample.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "samples": {
+              "description": "Maximum number of samples accepted within a single scrape.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "selector": {
+          "description": "Label selector that specifies which pods are selected for this monitoring\nconfiguration.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                }
+              },
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "targetLabels": {
+          "description": "Labels to add to the Prometheus target for discovered endpoints.\nThe `instance` label is always set to `\u003cpod_name\u003e:\u003cport\u003e` or `\u003cnode_name\u003e:\u003cport\u003e`\nif the scraped pod is controlled by a DaemonSet.",
+          "type": "object",
+          "default": {},
+          "properties": {
+            "fromPod": {
+              "description": "Labels to transfer from the Kubernetes Pod to Prometheus target labels.\nMappings are applied in order.",
+              "type": "array",
+              "maxItems": 100,
+              "items": {
+                "description": "LabelMapping specifies how to transfer a label from a Kubernetes resource\nonto a Prometheus target.",
+                "type": "object",
+                "required": [
+                  "from"
+                ],
+                "properties": {
+                  "from": {
+                    "description": "Kubernetes resource label to remap.",
+                    "type": "string"
+                  },
+                  "to": {
+                    "description": "Remapped Prometheus target label.\nDefaults to the same name as `From`.",
+                    "type": "string",
+                    "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                    "x-kubernetes-validations": [
+                      {
+                        "rule": "self != 'project_id' \u0026\u0026 self != 'location' \u0026\u0026 self != 'cluster' \u0026\u0026 self != 'namespace' \u0026\u0026 self != 'job' \u0026\u0026 self != 'instance' \u0026\u0026 self != 'top_level_controller' \u0026\u0026 self != 'top_level_controller_type' \u0026\u0026 self != '__address__'",
+                        "messageExpression": "'cannot relabel onto protected label \"%s\"'.format([self])"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "metadata": {
+              "description": "Pod metadata labels that are set on all scraped targets.\nPermitted keys are `container`, `node`, `pod`, `top_level_controller_name`,\nand `top_level_controller_type`. The `container`\nlabel is only populated if the scrape port is referenced by name.\nDefaults to [container, pod, top_level_controller_name, top_level_controller_type].\nIf set to null, it will be interpreted as the empty list.\nThis is for backwards-compatibility only.",
+              "type": "array",
+              "default": [
+                "container",
+                "pod",
+                "top_level_controller_name",
+                "top_level_controller_type"
+              ],
+              "items": {
+                "type": "string",
+                "enum": [
+                  "container",
+                  "node",
+                  "pod",
+                  "top_level_controller_name",
+                  "top_level_controller_type"
+                ]
+              },
+              "x-kubernetes-list-type": "set"
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "type": "array",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "endpointStatuses": {
+          "description": "Represents the latest available observations of target state for each ScrapeEndpoint.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "activeTargets": {
+                "description": "Total number of active targets.",
+                "type": "integer",
+                "format": "int64"
+              },
+              "collectorsFraction": {
+                "description": "Fraction of collectors included in status, bounded [0,1].\nIdeally, this should always be 1. Anything less can\nbe considered a problem and should be investigated.",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "Last time this status was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "name": {
+                "description": "The name of the ScrapeEndpoint.",
+                "type": "string"
+              },
+              "sampleGroups": {
+                "description": "A fixed sample of targets grouped by error type.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "description": "Total count of similar errors.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "sampleTargets": {
+                      "description": "Targets emitting the error message.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "health": {
+                            "description": "Health status.",
+                            "type": "string"
+                          },
+                          "labels": {
+                            "description": "The label set, keys and values, of the target.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "description": "A LabelValue is an associated value for a LabelName.",
+                              "type": "string"
+                            }
+                          },
+                          "lastError": {
+                            "description": "Error message.",
+                            "type": "string"
+                          },
+                          "lastScrapeDurationSeconds": {
+                            "description": "Scrape duration in seconds.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "unhealthyTargets": {
+                "description": "Total number of active, unhealthy targets.",
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    }
+  },
+  "x-kubernetes-validations": [
+    {
+      "rule": "self.spec.endpoints.all(e, !has(e.authorization) || !has(e.authorization.credentials) || !has(e.authorization.credentials.secret) || !has(e.authorization.credentials.secret.__namespace__))",
+      "message": "Namespace not allowed on PodMonitoring secret references.",
+      "reason": "FieldValueForbidden"
+    },
+    {
+      "rule": "self.spec.endpoints.all(e, !has(e.basicAuth) || !has(e.basicAuth.password) || !has(e.basicAuth.password.secret) || !has(e.basicAuth.password.secret.__namespace__))",
+      "message": "Namespace not allowed on PodMonitoring secret references.",
+      "reason": "FieldValueForbidden"
+    },
+    {
+      "rule": "self.spec.endpoints.all(e, !has(e.tls) || !has(e.tls.ca) || !has(e.tls.ca.secret) || !has(e.tls.ca.secret.__namespace__))",
+      "message": "Namespace not allowed on PodMonitoring secret references.",
+      "reason": "FieldValueForbidden"
+    },
+    {
+      "rule": "self.spec.endpoints.all(e, !has(e.tls) || !has(e.tls.cert) || !has(e.tls.cert.secret) || !has(e.tls.cert.secret.__namespace__))",
+      "message": "Namespace not allowed on PodMonitoring secret references.",
+      "reason": "FieldValueForbidden"
+    },
+    {
+      "rule": "self.spec.endpoints.all(e, !has(e.tls) || !has(e.tls.key) || !has(e.tls.key.secret) || !has(e.tls.key.secret.__namespace__))",
+      "message": "Namespace not allowed on PodMonitoring secret references.",
+      "reason": "FieldValueForbidden"
+    },
+    {
+      "rule": "self.spec.endpoints.all(e, !has(e.oauth2) || !has(e.oauth2.clientSecret) || !has(e.oauth2.clientSecret.secret) || !has(e.oauth2.clientSecret.secret.__namespace__))",
+      "message": "Namespace not allowed on PodMonitoring secret references.",
+      "reason": "FieldValueForbidden"
+    }
+  ]
+}

--- a/schemas/podmonitoring-monitoring-v1alpha1.json
+++ b/schemas/podmonitoring-monitoring-v1alpha1.json
@@ -1,0 +1,283 @@
+{
+  "description": "PodMonitoring defines monitoring for a set of pods.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Pod selection for target discovery by\nPrometheus.",
+      "type": "object",
+      "required": [
+        "endpoints",
+        "selector"
+      ],
+      "properties": {
+        "endpoints": {
+          "description": "The endpoints to scrape on the selected pods.",
+          "type": "array",
+          "items": {
+            "description": "ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.",
+            "type": "object",
+            "required": [
+              "port"
+            ],
+            "properties": {
+              "interval": {
+                "description": "Interval at which to scrape metrics. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "metricRelabeling": {
+                "description": "Relabeling rules for metrics scraped from this endpoint. Relabeling rules that\noverride protected target labels (project_id, location, cluster, namespace, job,\ninstance, or __address__) are not permitted. The labelmap action is not permitted\nin general.",
+                "type": "array",
+                "items": {
+                  "description": "RelabelingRule defines a single Prometheus relabeling rule.",
+                  "type": "object",
+                  "properties": {
+                    "action": {
+                      "description": "Action to perform based on regex matching. Defaults to 'replace'.",
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Defaults to '(.*)'.",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Defaults to '$1'.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. Defaults to ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "params": {
+                "description": "HTTP GET params to use when scraping.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "path": {
+                "description": "HTTP path to scrape metrics from. Defaults to \"/metrics\".",
+                "type": "string"
+              },
+              "port": {
+                "description": "Name or number of the port to scrape.",
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "x-kubernetes-int-or-string": true
+              },
+              "proxyUrl": {
+                "description": "Proxy URL to scrape through. Encoded passwords are not supported.",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Protocol scheme to use to scrape.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout for metrics scrapes. Must be a valid Prometheus duration.\nMust not be larger then the scrape interval.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "limits": {
+          "description": "Limits to apply at scrape time.",
+          "type": "object",
+          "properties": {
+            "labelNameLength": {
+              "description": "Maximum label name length.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "labelValueLength": {
+              "description": "Maximum label value length.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "labels": {
+              "description": "Maximum number of labels accepted for a single sample.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "samples": {
+              "description": "Maximum number of samples accepted within a single scrape.\nUses Prometheus default if left unspecified.",
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "selector": {
+          "description": "Label selector that specifies which pods are selected for this monitoring\nconfiguration.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                }
+              },
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "targetLabels": {
+          "description": "Labels to add to the Prometheus target for discovered endpoints.",
+          "type": "object",
+          "properties": {
+            "fromPod": {
+              "description": "Labels to transfer from the Kubernetes Pod to Prometheus target labels.\nMappings are applied in order.",
+              "type": "array",
+              "items": {
+                "description": "LabelMapping specifies how to transfer a label from a Kubernetes resource\nonto a Prometheus target.",
+                "type": "object",
+                "required": [
+                  "from"
+                ],
+                "properties": {
+                  "from": {
+                    "description": "Kubernetes resource label to remap.",
+                    "type": "string"
+                  },
+                  "to": {
+                    "description": "Remapped Prometheus target label.\nDefaults to the same name as `From`.",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "metadata": {
+              "description": "Pod metadata labels that are set on all scraped targets.\nPermitted keys are `pod`, `container`, and `node` for PodMonitoring and\n`pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring.\nDefaults to [pod, container] for PodMonitoring and [namespace, pod, container]\nfor ClusterPodMonitoring.\nIf set to null, it will be interpreted as the empty list for PodMonitoring\nand to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility\nonly.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "type": "array",
+          "items": {
+            "description": "MonitoringCondition describes a condition of a PodMonitoring.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    }
+  }
+}

--- a/schemas/rules-monitoring-v1.json
+++ b/schemas/rules-monitoring-v1.json
@@ -1,0 +1,160 @@
+{
+  "description": "Rules defines Prometheus alerting and recording rules that are scoped\nto the namespace of the resource. Only metric data from this namespace is processed\nand all rule results have their project_id, cluster, and namespace label preserved\nfor query processing.\nIf the location label is not preserved by the rule, it defaults to the cluster's location.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "type": "object",
+      "required": [
+        "groups"
+      ],
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "type": "array",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "type": "object",
+            "required": [
+              "name",
+              "rules"
+            ],
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string",
+                "format": "duration",
+                "default": "1m"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "type": "object",
+                  "required": [
+                    "expr"
+                  ],
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string",
+                      "format": "duration"
+                    },
+                    "labels": {
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "rule": "(has(self.record) ? 1 : 0) + (has(self.alert) ? 1 : 0) == 1",
+                      "message": "Must set exactly one of Record or Alert"
+                    },
+                    {
+                      "rule": "!has(self.annotations) || has(self.alert)",
+                      "message": "Annotations are only allowed for alerting rules"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "type": "array",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    }
+  }
+}

--- a/schemas/rules-monitoring-v1alpha1.json
+++ b/schemas/rules-monitoring-v1alpha1.json
@@ -1,0 +1,99 @@
+{
+  "description": "Rules defines Prometheus alerting and recording rules that are scoped\nto the namespace of the resource. Only metric data from this namespace is processed\nand all rule results have their project_id, cluster, and namespace label preserved\nfor query processing.\nIf the location label is not preserved by the rule, it defaults to the cluster's location.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "type": "object",
+      "required": [
+        "groups"
+      ],
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "type": "array",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "type": "object",
+            "required": [
+              "interval",
+              "name",
+              "rules"
+            ],
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "type": "array",
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "type": "object",
+                  "required": [
+                    "expr"
+                  ],
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `schemas/` with JSON schemas extracted from operator CRDs (flux2-schemas naming: `{singular}-monitoring-{version}.json`)
- Add `hack/gen-jsonschemas` to generate schemas from `charts/operator/crds`
- Wire schema generation into `./hack/presubmit.sh crdgen` and `all`
- Document kubeconform usage in `schemas/README.md`

Fixes #922

## Test plan
- [x] `go run ./hack/gen-jsonschemas` generates 13 schema files from current CRDs
- [ ] `./hack/presubmit.sh diff` passes after regeneration