### PR TITLE
ci: fix github actions security issues using zizmor for release/0.17

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Auto-assign issue
-      uses: pozil/auto-assign-issue@e0a56afd8846954587b00fff254caf1ec918554e # v1
+      uses: pozil/auto-assign-issue@d11e715efc663fe323c3d8d4d3cbbfdddd539baf # v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         assignees: ${{ secrets.DEFAULT_ISSUE_ASSIGNEE }}

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: siderolabs/conform@v0.1.0-alpha.27
+      - uses: siderolabs/conform@6380738b7fdfc68b208ce0674c4ac1ba314ba600 # v0.1.0-alpha.27
         name: Conform Action
   golangci-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Automated security fixes for GitHub Actions using zizmor for `release/0.17` branch.