### PR TITLE
refactor(ops): switch gmpctl from GPG/annotated tags to lightweight tags

### DIFF
--- a/ops/gmpctl/README.md
+++ b/ops/gmpctl/README.md
@@ -16,7 +16,6 @@ It's a starting point for smaller or bigger automation on OSS side (e.g. releasi
    * new-ish `bash` (MacOS: `brew install bash`)
    * `gsed` (MacOS: `brew install gsed`)
    * `gcloud` (https://docs.cloud.google.com/sdk/docs/install-sdk) (and `gcloud auth login`)
-   * `gpg` (MacOS: `brew install gpg`)
 
 3. You can configure different work directory for gmpctl via `-c` flag. By default, `gmpctl` does the work in `ops/gmpctl/.data`
 
@@ -59,8 +58,6 @@ Usage: gmpctl [COMMAND] [FLAGS]
     	Release branch to work on; Project is auto-detected from this
   -patch
     	If true, and --tag is empty, forces a new patch version as a new TAG.
-  -skip-tag-signing
-    	If true, creates an unsigned annotated tag instead of a GPG signed tag.
   -t string
     	Tag to release. If empty, next TAG version will be auto-detected (double check this!)
 

--- a/ops/gmpctl/cmd_release.go
+++ b/ops/gmpctl/cmd_release.go
@@ -21,11 +21,10 @@ import (
 )
 
 var (
-	releaseFlags          = flag.NewFlagSet("release", flag.ExitOnError)
-	releaseBranch         = releaseFlags.String("b", "", "Release branch to work on; Project is auto-detected from this")
-	releaseTag            = releaseFlags.String("t", "", "Tag to release. If empty, next TAG version will be auto-detected (double check this!)")
-	releasePatch          = releaseFlags.Bool("patch", false, "If true, and --tag is empty, forces a new patch version as a new TAG.")
-	releaseSkipTagSigning = releaseFlags.Bool("skip-tag-signing", false, "If true, creates an unsigned annotated tag instead of a GPG signed tag.")
+	releaseFlags = flag.NewFlagSet("release", flag.ExitOnError)
+	releaseBranch = releaseFlags.String("b", "", "Release branch to work on; Project is auto-detected from this")
+	releaseTag    = releaseFlags.String("t", "", "Tag to release. If empty, next TAG version will be auto-detected (double check this!)")
+	releasePatch  = releaseFlags.Bool("patch", false, "If true, and --tag is empty, forces a new patch version as a new TAG.")
 )
 
 func release() error {
@@ -94,7 +93,7 @@ func release() error {
 	}
 
 	// TODO(bwplotka): Check if tag exists.
-	mustCreateTag(dir, tag, !*releaseSkipTagSigning)
+	mustCreateTag(dir, tag)
 	if confirmf("About to git push %q tag from %q to \"origin/%v\"; are you sure?", tag, dir, branch) {
 		mustPush(dir, tag)
 	} else {

--- a/ops/gmpctl/git.go
+++ b/ops/gmpctl/git.go
@@ -49,40 +49,13 @@ func mustFetchAll(dir string) {
 	}
 }
 
-func getTTY(dir string) string {
-	out, err := runCommand(&cmdOpts{Dir: dir, HideOutputs: true}, "tty")
-	if err != nil {
-		return ""
-	}
-	out = strings.TrimSpace(out)
-	if out == "" || strings.HasPrefix(out, "not a tty") {
-		return ""
-	}
-	return out
-}
-
-func mustCreateTag(dir, tag string, signed bool) {
-	var (
-		args = []string{"git", "tag"}
-		envs []string
-	)
-	if signed {
-		logf("Creating a signed tag %v...", tag)
-		args = append(args, "-s")
-		if tty := getTTY(dir); tty != "" {
-			envs = append(envs, "GPG_TTY="+tty)
-		}
-	} else {
-		logf("Creating an unsigned tag %v...", tag)
-		args = append(args, "-a")
-	}
-	args = append(args, tag, "-m", tag)
-
+func mustCreateTag(dir, tag string) {
+	logf("Creating a lightweight tag %v...", tag)
 	// TODO(bwplotka): Consider adding v0.x second tag for Prometheus fork (similar to how v0.300 Prometheus releases are structured).
 	// This is to have a little bit cleaner prometheus-engine go.mod version against the fork.
 	if _, err := runCommand(
-		&cmdOpts{Dir: dir, Envs: envs},
-		args...,
+		&cmdOpts{Dir: dir},
+		"git", "tag", tag,
 	); err != nil {
 		panicf(err.Error())
 	}


### PR DESCRIPTION
Switched `gmpctl` release workflow from GPG signed / annotated tags (`git tag -s/-a ...`) to lightweight tags (`git tag <tag>`).

Fixes b/465700234

### Changes
- Updated `mustCreateTag` in `ops/gmpctl/git.go` to execute `git tag <tag>` for lightweight tags.
- Removed unused `getTTY` helper and GPG environment setting logic.
- Removed the `-skip-tag-signing` flag from `cmd_release.go`.
- Updated `ops/gmpctl/README.md` to remove `gpg` from setup requirements and remove deleted flag from help docs.