### PR TITLE
feat: support Service discovery for Alertmanager

### DIFF
--- a/charts/operator/crds/monitoring.googleapis.com_operatorconfigs.yaml
+++ b/charts/operator/crds/monitoring.googleapis.com_operatorconfigs.yaml
@@ -265,9 +265,8 @@ spec:
                     description: Alertmanagers contains endpoint configuration for
                       designated Alertmanagers.
                     items:
-                      description: |-
-                        AlertmanagerEndpoints defines a selection of a single Endpoints object
-                        containing alertmanager IPs to fire alerts against.
+                      description: AlertmanagerEndpoints defines a selection of Alertmanager
+                        targets to fire alerts against.
                       properties:
                         apiVersion:
                           description: |-
@@ -312,11 +311,22 @@ spec:
                                 error.
                               type: string
                           type: object
+                        discoveryType:
+                          description: |-
+                            DiscoveryType controls how Alertmanager targets are discovered. Endpoints, the default,
+                            discovers each Alertmanager replica from a Kubernetes Endpoints object. Service routes
+                            through the Kubernetes Service DNS name and requires a numeric Port. Service discovery
+                            supports Services without Endpoints, such as ExternalName Services.
+                          enum:
+                          - Endpoints
+                          - Service
+                          type: string
                         name:
-                          description: Name of Endpoints object in Namespace.
+                          description: Name of the Endpoints object or Service in
+                            Namespace.
                           type: string
                         namespace:
-                          description: Namespace of Endpoints object.
+                          description: Namespace of the Endpoints object or Service.
                           type: string
                         pathPrefix:
                           description: Prefix for the HTTP path alerts are pushed
@@ -674,9 +684,8 @@ spec:
                     description: Alertmanagers contains endpoint configuration for
                       designated Alertmanagers.
                     items:
-                      description: |-
-                        AlertmanagerEndpoints defines a selection of a single Endpoints object
-                        containing alertmanager IPs to fire alerts against.
+                      description: AlertmanagerEndpoints defines a selection of Alertmanager
+                        targets to fire alerts against.
                       properties:
                         apiVersion:
                           description: |-
@@ -718,11 +727,22 @@ spec:
                                 error.
                               type: string
                           type: object
+                        discoveryType:
+                          description: |-
+                            DiscoveryType controls how Alertmanager targets are discovered. Endpoints, the default,
+                            discovers each Alertmanager replica from a Kubernetes Endpoints object. Service routes
+                            through the Kubernetes Service DNS name and requires a numeric Port. Service discovery
+                            supports Services without Endpoints, such as ExternalName Services.
+                          enum:
+                          - Endpoints
+                          - Service
+                          type: string
                         name:
-                          description: Name of Endpoints object in Namespace.
+                          description: Name of the Endpoints object or Service in
+                            Namespace.
                           type: string
                         namespace:
-                          description: Namespace of Endpoints object.
+                          description: Namespace of the Endpoints object or Service.
                           type: string
                         pathPrefix:
                           description: Prefix for the HTTP path alerts are pushed

--- a/doc/api.md
+++ b/doc/api.md
@@ -12,6 +12,8 @@ Resource Types:
 <ul><li>
 <a href="#monitoring.googleapis.com/v1.AlertingSpec">AlertingSpec</a>
 </li><li>
+<a href="#monitoring.googleapis.com/v1.AlertmanagerDiscoveryType">AlertmanagerDiscoveryType</a>
+</li><li>
 <a href="#monitoring.googleapis.com/v1.AlertmanagerEndpoints">AlertmanagerEndpoints</a>
 </li><li>
 <a href="#monitoring.googleapis.com/v1.Auth">Auth</a>
@@ -159,6 +161,31 @@ Resource Types:
 </tr>
 </tbody>
 </table>
+<h3 id="monitoring.googleapis.com/v1.AlertmanagerDiscoveryType">
+<span id="AlertmanagerDiscoveryType">AlertmanagerDiscoveryType
+(<code>string</code> alias)</span>
+</h3>
+<p>
+(<em>Appears in: </em><a href="#monitoring.googleapis.com/v1.AlertmanagerEndpoints">AlertmanagerEndpoints</a>)
+</p>
+<div>
+<p>AlertmanagerDiscoveryType defines how Alertmanager targets are discovered.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Endpoints&#34;</p></td>
+<td><p>AlertmanagerDiscoveryTypeEndpoints discovers individual Alertmanager replicas from Endpoints.</p>
+</td>
+</tr><tr><td><p>&#34;Service&#34;</p></td>
+<td><p>AlertmanagerDiscoveryTypeService routes alerts through a Kubernetes Service DNS name.</p>
+</td>
+</tr></tbody>
+</table>
 <h3 id="monitoring.googleapis.com/v1.AlertmanagerEndpoints">
 <span id="AlertmanagerEndpoints">AlertmanagerEndpoints
 </span>
@@ -167,8 +194,7 @@ Resource Types:
 (<em>Appears in: </em><a href="#monitoring.googleapis.com/v1.AlertingSpec">AlertingSpec</a>)
 </p>
 <div>
-<p>AlertmanagerEndpoints defines a selection of a single Endpoints object
-containing alertmanager IPs to fire alerts against.</p>
+<p>AlertmanagerEndpoints defines a selection of Alertmanager targets to fire alerts against.</p>
 </div>
 <table>
 <thead>
@@ -186,7 +212,7 @@ string
 </em>
 </td>
 <td>
-<p>Namespace of Endpoints object.</p>
+<p>Namespace of the Endpoints object or Service.</p>
 </td>
 </tr>
 <tr>
@@ -197,7 +223,7 @@ string
 </em>
 </td>
 <td>
-<p>Name of Endpoints object in Namespace.</p>
+<p>Name of the Endpoints object or Service in Namespace.</p>
 </td>
 </tr>
 <tr>
@@ -209,6 +235,22 @@ k8s.io/apimachinery/pkg/util/intstr.IntOrString
 </td>
 <td>
 <p>Port the Alertmanager API is exposed on.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>discoveryType</code><br/>
+<em>
+<a href="#monitoring.googleapis.com/v1.AlertmanagerDiscoveryType">
+AlertmanagerDiscoveryType
+</a>
+</em>
+</td>
+<td>
+<p>DiscoveryType controls how Alertmanager targets are discovered. Endpoints, the default,
+discovers each Alertmanager replica from a Kubernetes Endpoints object. Service routes
+through the Kubernetes Service DNS name and requires a numeric Port. Service discovery
+supports Services without Endpoints, such as ExternalName Services.</p>
 </td>
 </tr>
 <tr>

--- a/e2e/ruler_test.go
+++ b/e2e/ruler_test.go
@@ -306,6 +306,14 @@ alerting:
                 own_namespace: false
                 names:
                     - monitoring
+        - follow_redirects: true
+          enable_http2: true
+          scheme: https
+          timeout: 10s
+          api_version: v2
+          static_configs:
+            - targets:
+                - external-alertmanager.monitoring.svc:443
 rule_files:
     - /etc/rules/*.yaml
 google_cloud:{exportCredentialsEntry}
@@ -760,6 +768,13 @@ func createRuleEvaluatorOperatorConfig(ctx context.Context, kubeClient client.Cl
 					},
 					KeySecret: keySecret,
 				},
+			},
+			{
+				Name:          "external-alertmanager",
+				Namespace:     "monitoring",
+				Port:          intstr.FromInt32(443),
+				Scheme:        "https",
+				DiscoveryType: monitoringv1.AlertmanagerDiscoveryTypeService,
 			},
 		},
 	}

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -2094,9 +2094,7 @@ spec:
                     alertmanagers:
                       description: Alertmanagers contains endpoint configuration for designated Alertmanagers.
                       items:
-                        description: |-
-                          AlertmanagerEndpoints defines a selection of a single Endpoints object
-                          containing alertmanager IPs to fire alerts against.
+                        description: AlertmanagerEndpoints defines a selection of Alertmanager targets to fire alerts against.
                         properties:
                           apiVersion:
                             description: |-
@@ -2137,11 +2135,21 @@ spec:
                                   error.
                                 type: string
                             type: object
+                          discoveryType:
+                            description: |-
+                              DiscoveryType controls how Alertmanager targets are discovered. Endpoints, the default,
+                              discovers each Alertmanager replica from a Kubernetes Endpoints object. Service routes
+                              through the Kubernetes Service DNS name and requires a numeric Port. Service discovery
+                              supports Services without Endpoints, such as ExternalName Services.
+                            enum:
+                              - Endpoints
+                              - Service
+                            type: string
                           name:
-                            description: Name of Endpoints object in Namespace.
+                            description: Name of the Endpoints object or Service in Namespace.
                             type: string
                           namespace:
-                            description: Namespace of Endpoints object.
+                            description: Namespace of the Endpoints object or Service.
                             type: string
                           pathPrefix:
                             description: Prefix for the HTTP path alerts are pushed to.
@@ -2477,9 +2485,7 @@ spec:
                     alertmanagers:
                       description: Alertmanagers contains endpoint configuration for designated Alertmanagers.
                       items:
-                        description: |-
-                          AlertmanagerEndpoints defines a selection of a single Endpoints object
-                          containing alertmanager IPs to fire alerts against.
+                        description: AlertmanagerEndpoints defines a selection of Alertmanager targets to fire alerts against.
                         properties:
                           apiVersion:
                             description: |-
@@ -2517,11 +2523,21 @@ spec:
                                   error.
                                 type: string
                             type: object
+                          discoveryType:
+                            description: |-
+                              DiscoveryType controls how Alertmanager targets are discovered. Endpoints, the default,
+                              discovers each Alertmanager replica from a Kubernetes Endpoints object. Service routes
+                              through the Kubernetes Service DNS name and requires a numeric Port. Service discovery
+                              supports Services without Endpoints, such as ExternalName Services.
+                            enum:
+                              - Endpoints
+                              - Service
+                            type: string
                           name:
-                            description: Name of Endpoints object in Namespace.
+                            description: Name of the Endpoints object or Service in Namespace.
                             type: string
                           namespace:
-                            description: Namespace of Endpoints object.
+                            description: Namespace of the Endpoints object or Service.
                             type: string
                           pathPrefix:
                             description: Prefix for the HTTP path alerts are pushed to.

--- a/pkg/operator/apis/monitoring/v1/operator_types.go
+++ b/pkg/operator/apis/monitoring/v1/operator_types.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,6 +89,16 @@ func validateRules(rules *RuleEvaluatorSpec) error {
 }
 
 func validateAlertManagerEndpoint(alertManagerEndpoint *AlertmanagerEndpoints) error {
+	switch alertManagerEndpoint.DiscoveryType {
+	case "", AlertmanagerDiscoveryTypeEndpoints:
+	case AlertmanagerDiscoveryTypeService:
+		port, err := strconv.ParseUint(alertManagerEndpoint.Port.String(), 10, 16)
+		if err != nil || port == 0 {
+			return fmt.Errorf("service discovery requires a numeric port between 1 and 65535, got %q", alertManagerEndpoint.Port.String())
+		}
+	default:
+		return fmt.Errorf("unknown discovery type %q", alertManagerEndpoint.DiscoveryType)
+	}
 	if alertManagerEndpoint.Authorization != nil {
 		if err := validateSecretKeySelector(alertManagerEndpoint.Authorization.Credentials); err != nil {
 			return fmt.Errorf("invalid authorization credentials: %w", err)
@@ -301,15 +312,30 @@ type ManagedAlertmanagerSpec struct {
 	ExternalURL string `json:"externalURL,omitempty"`
 }
 
-// AlertmanagerEndpoints defines a selection of a single Endpoints object
-// containing alertmanager IPs to fire alerts against.
+// AlertmanagerDiscoveryType defines how Alertmanager targets are discovered.
+type AlertmanagerDiscoveryType string
+
+const (
+	// AlertmanagerDiscoveryTypeEndpoints discovers individual Alertmanager replicas from Endpoints.
+	AlertmanagerDiscoveryTypeEndpoints AlertmanagerDiscoveryType = "Endpoints"
+	// AlertmanagerDiscoveryTypeService routes alerts through a Kubernetes Service DNS name.
+	AlertmanagerDiscoveryTypeService AlertmanagerDiscoveryType = "Service"
+)
+
+// AlertmanagerEndpoints defines a selection of Alertmanager targets to fire alerts against.
 type AlertmanagerEndpoints struct {
-	// Namespace of Endpoints object.
+	// Namespace of the Endpoints object or Service.
 	Namespace string `json:"namespace"`
-	// Name of Endpoints object in Namespace.
+	// Name of the Endpoints object or Service in Namespace.
 	Name string `json:"name"`
 	// Port the Alertmanager API is exposed on.
 	Port intstr.IntOrString `json:"port"`
+	// DiscoveryType controls how Alertmanager targets are discovered. Endpoints, the default,
+	// discovers each Alertmanager replica from a Kubernetes Endpoints object. Service routes
+	// through the Kubernetes Service DNS name and requires a numeric Port. Service discovery
+	// supports Services without Endpoints, such as ExternalName Services.
+	// +kubebuilder:validation:Enum=Endpoints;Service
+	DiscoveryType AlertmanagerDiscoveryType `json:"discoveryType,omitempty"`
 	// Scheme to use when firing alerts.
 	Scheme string `json:"scheme,omitempty"`
 	// Prefix for the HTTP path alerts are pushed to.

--- a/pkg/operator/apis/monitoring/v1/operator_types_test.go
+++ b/pkg/operator/apis/monitoring/v1/operator_types_test.go
@@ -20,6 +20,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestOperatorConfigValidate(t *testing.T) {
@@ -36,6 +37,40 @@ func TestOperatorConfigValidate(t *testing.T) {
 					Name:      "config",
 				},
 			},
+		},
+		{
+			desc: "service discovery with numeric port",
+			oc: &OperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "config"},
+				Rules: RuleEvaluatorSpec{Alerting: AlertingSpec{Alertmanagers: []AlertmanagerEndpoints{{
+					Name:          "bar",
+					Port:          intstr.FromInt32(9093),
+					DiscoveryType: AlertmanagerDiscoveryTypeService,
+				}}}},
+			},
+		},
+		{
+			desc: "service discovery with numeric string port",
+			oc: &OperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "config"},
+				Rules: RuleEvaluatorSpec{Alerting: AlertingSpec{Alertmanagers: []AlertmanagerEndpoints{{
+					Name:          "bar",
+					Port:          intstr.FromString("9093"),
+					DiscoveryType: AlertmanagerDiscoveryTypeService,
+				}}}},
+			},
+		},
+		{
+			desc: "service discovery with named port",
+			oc: &OperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "config"},
+				Rules: RuleEvaluatorSpec{Alerting: AlertingSpec{Alertmanagers: []AlertmanagerEndpoints{{
+					Name:          "bar",
+					Port:          intstr.FromString("web"),
+					DiscoveryType: AlertmanagerDiscoveryTypeService,
+				}}}},
+			},
+			err: `service discovery requires a numeric port between 1 and 65535, got "web"`,
 		},
 		{
 			desc: "bad scrape interval",

--- a/pkg/operator/apis/monitoring/v1alpha1/types.go
+++ b/pkg/operator/apis/monitoring/v1alpha1/types.go
@@ -95,15 +95,30 @@ type AlertingSpec struct {
 	Alertmanagers []AlertmanagerEndpoints `json:"alertmanagers,omitempty"`
 }
 
-// AlertmanagerEndpoints defines a selection of a single Endpoints object
-// containing alertmanager IPs to fire alerts against.
+// AlertmanagerDiscoveryType defines how Alertmanager targets are discovered.
+type AlertmanagerDiscoveryType string
+
+const (
+	// AlertmanagerDiscoveryTypeEndpoints discovers individual Alertmanager replicas from Endpoints.
+	AlertmanagerDiscoveryTypeEndpoints AlertmanagerDiscoveryType = "Endpoints"
+	// AlertmanagerDiscoveryTypeService routes alerts through a Kubernetes Service DNS name.
+	AlertmanagerDiscoveryTypeService AlertmanagerDiscoveryType = "Service"
+)
+
+// AlertmanagerEndpoints defines a selection of Alertmanager targets to fire alerts against.
 type AlertmanagerEndpoints struct {
-	// Namespace of Endpoints object.
+	// Namespace of the Endpoints object or Service.
 	Namespace string `json:"namespace"`
-	// Name of Endpoints object in Namespace.
+	// Name of the Endpoints object or Service in Namespace.
 	Name string `json:"name"`
 	// Port the Alertmanager API is exposed on.
 	Port intstr.IntOrString `json:"port"`
+	// DiscoveryType controls how Alertmanager targets are discovered. Endpoints, the default,
+	// discovers each Alertmanager replica from a Kubernetes Endpoints object. Service routes
+	// through the Kubernetes Service DNS name and requires a numeric Port. Service discovery
+	// supports Services without Endpoints, such as ExternalName Services.
+	// +kubebuilder:validation:Enum=Endpoints;Service
+	DiscoveryType AlertmanagerDiscoveryType `json:"discoveryType,omitempty"`
 	// Scheme to use when firing alerts.
 	Scheme string `json:"scheme,omitempty"`
 	// Prefix for the HTTP path alerts are pushed to.

--- a/pkg/operator/operator_config.go
+++ b/pkg/operator/operator_config.go
@@ -651,6 +651,19 @@ func (r *operatorConfigReconciler) makeAlertmanagerConfigs(ctx context.Context, 
 			cfg.HTTPClientConfig.TLSConfig = tlsCfg
 		}
 
+		if am.DiscoveryType == monitoringv1.AlertmanagerDiscoveryTypeService {
+			svcDNSName := fmt.Sprintf("%s.%s.svc:%s", am.Name, am.Namespace, am.Port.String())
+			cfg.ServiceDiscoveryConfigs = discovery.Configs{
+				discovery.StaticConfig{
+					&targetgroup.Group{
+						Targets: []prommodel.LabelSet{{prommodel.AddressLabel: prommodel.LabelValue(svcDNSName)}},
+					},
+				},
+			}
+			configs = append(configs, &cfg)
+			continue
+		}
+
 		// Configure discovery of AM endpoints via Kubernetes API.
 		cfg.ServiceDiscoveryConfigs = discovery.Configs{
 			&discoverykube.SDConfig{

--- a/pkg/operator/operator_config_test.go
+++ b/pkg/operator/operator_config_test.go
@@ -20,7 +20,9 @@ import (
 	monitoringv1 "github.com/GoogleCloudPlatform/prometheus-engine/pkg/operator/apis/monitoring/v1"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
+	prommodel "github.com/prometheus/common/model"
 	promforkconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
 	gcmconfig "github.com/prometheus/prometheus/google/config"
 	"github.com/prometheus/prometheus/google/export"
 	"github.com/stretchr/testify/require"
@@ -28,9 +30,35 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+func TestMakeAlertmanagerConfigsSupportsServiceDiscovery(t *testing.T) {
+	reconciler := newOperatorConfigReconciler(newFakeClientBuilder().Build(), Options{})
+	configs, secretData, err := reconciler.makeAlertmanagerConfigs(t.Context(), &monitoringv1.AlertingSpec{
+		Alertmanagers: []monitoringv1.AlertmanagerEndpoints{{
+			Namespace:     "monitoring",
+			Name:          "external-alertmanager",
+			Port:          intstr.FromInt32(9093),
+			DiscoveryType: monitoringv1.AlertmanagerDiscoveryTypeService,
+		}},
+	})
+	require.NoError(t, err)
+	require.Empty(t, secretData)
+	require.Len(t, configs, 1)
+	require.Len(t, configs[0].ServiceDiscoveryConfigs, 1)
+
+	staticConfig, ok := configs[0].ServiceDiscoveryConfigs[0].(discovery.StaticConfig)
+	require.True(t, ok)
+	require.Len(t, staticConfig, 1)
+	require.Len(t, staticConfig[0].Targets, 1)
+	require.Equal(t,
+		prommodel.LabelValue("external-alertmanager.monitoring.svc:9093"),
+		staticConfig[0].Targets[0][prommodel.AddressLabel],
+	)
+}
 
 func TestPrometheusConfigForRuleEvaluator(t *testing.T) {
 	configYAML := `


### PR DESCRIPTION
## What this change does

- Adds an opt-in `Service` discovery mode to `AlertmanagerEndpoints` while preserving existing `Endpoints` discovery as the default.
- Generates a static Alertmanager target using the Kubernetes Service DNS name (`<name>.<namespace>.svc:<port>`), so portless `ExternalName` Services work without an Endpoints object.
- Requires a numeric port for Service discovery and retains the existing authorization, TLS, scheme, path prefix, API version, timeout, redirect, and HTTP/2 configuration.
- Regenerates the OperatorConfig CRDs, combined setup manifest, and API documentation.
- Adds validation, configuration-generation, and rule-evaluator golden coverage for the new mode.

## Why

The current Kubernetes discovery path requires an Endpoints object. Services without Endpoints, including the `ExternalName` setup described in #595, therefore cannot be used as Alertmanager targets without manually maintaining an Endpoints object.

Fixes #595.

## Validation

- `go test ./pkg/operator/... -count=1` in Go 1.25
- Repository-wide `./hack/presubmit.sh test` in the repository's hermetic Go 1.26.5 image
- Uncached `./hack/presubmit.sh all diff` in the repository's hermetic image
- Generated CRD, manifest, API documentation, and rule-evaluator golden output verified by the presubmit

## Assistance disclosure

This contribution was prepared with Codex assistance and the resulting code, generated artifacts, and tests were reviewed and validated locally before publication.
