### PR TITLE
PO to GMP Migration Tool: Add gmp-migrate agent skill

### DIFF
--- a/cmd/gmp-migrate/SKILL.md
+++ b/cmd/gmp-migrate/SKILL.md
@@ -126,23 +126,29 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
        interval: 30s
   ```
 
-#### 1.2 Missing Backing Service (`TODO_RESOLVE_PORT` & `TODO_SET_POD_SELECTOR`)
+#### 1.2 Missing Backing Service (`TODO_RESOLVE_PORT` & `TODO_SET_POD_LABELS`)
+* **Context**: `gmp-migrate` emits `TODO_SET_POD_LABELS: TODO_SET_POD_LABELS` as a safe guardrail placeholder. Replace this placeholder with the complete set of pod template labels for the target workload.
 * **Annotation**: `[ERROR] Corresponding Kubernetes Service was not found... ACTION: Define target pod selector in 'spec.selector.matchLabels' and verify endpoint ports.`
 * **Commands**:
   ```bash
   kubectl get svc -n <namespace> -o wide
+  kubectl get deployment,statefulset,daemonset -n <namespace> -o wide
   ```
 * **Agent Interactive Step**:
-  - If a matching Service is identified, copy its `spec.selector` into `spec.selector.matchLabels` and resolve the endpoint port.
-  - If no Service exists or multiple ambiguous Services match, prompt the user:
-    > *"Could not find a unique backing Service for `<name>`. Please provide the target Pod label selector (e.g. `app=payment`) and container port."*
+  - If a matching Service or workload is identified, copy its pod label selector into `spec.selector.matchLabels` and resolve endpoint ports.
+  - If multiple ambiguous workloads match, prompt the user:
+    > *"Could not find a backing Service for `<name>`. Discovered candidate workloads: `[app=payment-processor, app=payment-worker]`. Please confirm the target pod labels."*
 * **Diff**:
   ```diff
+   metadata:
+  -  annotations:
+  -    gmp.googleapis.com/todo-1: "[ERROR] Corresponding Kubernetes Service was not found..."
    spec:
      selector:
        matchLabels:
-  -      app: TODO_SET_POD_SELECTOR
+  -      TODO_SET_POD_LABELS: TODO_SET_POD_LABELS
   +      app.kubernetes.io/name: payment-processor
+  +      app.kubernetes.io/component: backend
      endpoints:
   -  - port: TODO_RESOLVE_PORT
   +  - port: 9102
@@ -210,10 +216,13 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 #### 2.3 Corrupt Base64 Data (`TODO_CORRUPT_SECRET_DATA_<KEY>`)
 * **Annotation**: `[ERROR] Failed to base64-decode key "<key>" in Secret "<name>"...`
 * **Agent Interactive Step**:
-  Do NOT fabricate passwords or placeholders. Prompt the user:
+  Do NOT fabricate key values or placeholders. Prompt the user:
   > *"Key `<key>` in Secret `<name>` contains invalid base64 data. Please provide the correct value or fix the Secret in the cluster."*
 * **Diff**:
   ```diff
+   metadata:
+  -  annotations:
+  -    gmp.googleapis.com/todo-1: "[ERROR] Failed to base64-decode key \"user\" in Secret \"app-auth\"..."
    spec:
      endpoints:
      - port: 8080
@@ -293,16 +302,36 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
              key: client-secret
   ```
 
-#### 4.2 Proxy URL Configuration (`TODO_SET_VALID_PROXY_URL` & Plaintext Passwords)
-* **Annotation**: `[ERROR] Proxy URL contains embedded plaintext credentials...`
-* **Resolution**: Prompt user for proxy host. Note that GMP endpoints do not support embedded basic auth in proxy URLs.
-* **Diff**:
+#### 4.2 Proxy URL Configuration (Malformed URLs & Stripped Credentials)
+* **Context**: GMP CRDs only support an unauthenticated `proxyUrl` string. GMP does not support proxy credentials (there are no Secret fields for proxies, and embedded credentials like `user:pass@` in `proxyUrl` are rejected by CRD admission rules).
+* **Annotations**:
+  * `[ERROR] Proxy URL "<url>" is invalid or malformed. ACTION: Specify a valid proxy URL (e.g. 'http://proxy.example.com:8080').`
+  * `[ERROR] Proxy URL contains embedded plaintext credentials. Credentials were removed. ACTION: Configure proxy authentication via proxy server configuration or network allowlist.`
+* **Agent Interactive Step**:
+  1. **Malformed URL (`TODO_SET_VALID_PROXY_URL`)**: Prompt the user for the valid corporate proxy host and port.
+  2. **Stripped Credentials**: `gmp-migrate` automatically strips `user:password@` so the manifest passes GMP validation while preserving the proxy host and port. Prompt the user:
+     > *"Proxy URL credentials were removed because GMP CRDs do not support proxy authentication. Please ensure proxy authentication is handled at the network level (e.g. IP allowlisting the GKE cluster at the proxy server or routing through an in-cluster forward proxy). If the target is inside the cluster/VPC, `proxyUrl` can be removed entirely."*
+  3. Once confirmed, remove the TODO annotation from `metadata.annotations`.
+* **Diff (Case A: Resolving Malformed URL Placeholder)**:
   ```diff
+   metadata:
+  -  annotations:
+  -    gmp.googleapis.com/todo-1: "[ERROR] Proxy URL is invalid or malformed..."
    spec:
      endpoints:
      - port: 8080
   -    proxyUrl: TODO_SET_VALID_PROXY_URL
   +    proxyUrl: http://proxy.corp.internal:3128
+  ```
+* **Diff (Case B: Reconciling Stripped Credentials Annotation)**:
+  ```diff
+   metadata:
+  -  annotations:
+  -    gmp.googleapis.com/todo-1: "[ERROR] Proxy URL contains embedded plaintext credentials. Credentials were removed..."
+   spec:
+     endpoints:
+     - port: 8080
+       proxyUrl: http://proxy.corp.internal:3128
   ```
 
 ---
@@ -386,17 +415,30 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   ```
 
 #### 5.2 Conflicting Keep Relabelings
-* **Annotation**: `[ERROR] Conflicting relabeling keep rules for label "<label>"...`
+* **Annotation**: `[ERROR] Conflicting relabeling keep rules for label "<label>": cannot require both "<val1>" and "<val2>" simultaneously...` (or `[ERROR] Selector conflict: label "<label>" has conflicting values...`)
 * **Agent Interactive Step**:
-  Check `Stderr` logs for conflicting values and ask the user to clarify:
-  > *"Detected conflicting label rules for label `env` (`prod` vs `staging`). Which workload should this PodMonitoring target?"*
-* **Diff**:
+  Check the annotation or `Stderr` logs for conflicting values and ask the user to clarify:
+  > *"Detected conflicting label rules for label `env` (`production` vs `staging`). Which workload should this PodMonitoring target?"*
+* **Diff (Case A: Update to Target Staging Workload)**:
   ```diff
+   metadata:
+  -  annotations:
+  -    gmp.googleapis.com/todo-1: "[ERROR] Conflicting relabeling keep rules for label \"env\": cannot require both \"production\" and \"staging\" simultaneously..."
    spec:
      selector:
        matchLabels:
-  -      env: production # Conflicted with staging
-  +      env: production
+  -      env: production
+  +      env: staging
+  ```
+* **Diff (Case B: Retain Production Workload)**:
+  ```diff
+   metadata:
+  -  annotations:
+  -    gmp.googleapis.com/todo-1: "[ERROR] Conflicting relabeling keep rules for label \"env\": cannot require both \"production\" and \"staging\" simultaneously..."
+   spec:
+     selector:
+       matchLabels:
+         env: production
   ```
 
 ---

--- a/cmd/gmp-migrate/SKILL.md
+++ b/cmd/gmp-migrate/SKILL.md
@@ -1,0 +1,521 @@
+---
+name: gmp-migrate
+description: >-
+  Run the gmp-migrate CLI tool to convert Prometheus Operator manifests (PodMonitor,
+  ServiceMonitor) to Google Managed Prometheus (GMP) CRDs (PodMonitoring,
+  ClusterPodMonitoring), and reconcile generated TODOs, port placeholders, and errors.
+---
+
+# GMP Migration & Reconciliation Skill
+
+This skill guides agents through executing the migration CLI tool, interpreting migration reports, diagnosing `Stderr` logs, resolving safety guardrails and `gmp.googleapis.com/todo-*` annotations, and safely validating converted GMP manifests.
+
+---
+
+## 1. Tool Execution Interface
+
+> [!NOTE]
+> All commands in this skill invoke the `gmp-migrate` binary. If the underlying CLI binary name or command syntax changes in the future, only this invocation section needs to be updated.
+
+### Core CLI Invocations
+
+1. **Default Mode (Ready-Only)**: Emits strictly 100% ready manifests to `Stdout`. Orompts/omits any best-effort drafts requiring human/agent review.
+   ```bash
+   gmp-migrate -f <input-path> > ready_manifests.yaml 2> migration.log
+   ```
+
+2. **Full Review Mode (`--all` / `-a`)**: Emits all converted manifests to `Stdout`, including best-effort draft configurations with inline `gmp.googleapis.com/todo-*` annotations for human / agent reconciliation.
+   ```bash
+   gmp-migrate --all -f <input-path> > all_manifests.yaml 2> migration.log
+   ```
+
+3. **Multiple Input Sources (Monitors + Backing Services/Secrets)**:
+   ```bash
+   gmp-migrate --all -f path/to/monitors/ -f path/to/services/ > all_manifests.yaml 2> migration.log
+   ```
+
+4. **Live Cluster Ingestion via Stdin**:
+   ```bash
+   kubectl get podmonitors,servicemonitors,services,configmaps,secrets -A -o yaml | gmp-migrate --all -f - > all_manifests.yaml 2> migration.log
+   ```
+
+---
+
+## 2. Input Discovery Strategy
+
+1. **Local Files**:
+   - Check the workspace for Prometheus Operator YAML manifests (`kind: PodMonitor` or `kind: ServiceMonitor`).
+   - When migrating local files, also include directories containing backing `kind: Service`, `kind: Secret`, and `kind: ConfigMap` resources so the tool can perform cross-resource port and auth resolution.
+2. **Live Cluster Context**:
+   - If no local manifests exist, or if the user asks to migrate an active cluster, stream cluster resources directly via `kubectl ... | gmp-migrate --all -f -`.
+3. **Ambiguous Source**:
+   - If both local files and an active `kubectl` context exist, ask the user whether they want to migrate local manifests or pull live resources from the cluster.
+
+---
+
+## 3. Exit Code, Stderr Logs & Diagnostic Handling
+
+The CLI strictly separates streams: converted YAML manifests are written to `Stdout`, while diagnostics and summary tables are written to `Stderr`. Workload selectors (`spec.selector.matchLabels` and `spec.selector.matchExpressions`) remain **100% pure and untouched**.
+
+```
+=========================================
+Migration Complete Summary:
+  Successfully Migrated:      X
+  Migrated with Warnings:     Y
+  Migrated with Action Items: Z
+  Skipped (Unsupported):      W
+  Failed:                     V
+=========================================
+```
+
+| Exit Code / Report | Status | Stream Behavior & Recommended Agent Action |
+| :--- | :--- | :--- |
+| **Exit Code 0** (`ActionItemsCount == 0`, `FailedCount == 0`) | Clean Parity | All manifests are 100% ready. Written to `Stdout`. Proceed directly to dry-run verification and diff presentation. |
+| **Exit Code 1** (`ActionItemsCount > 0`, `FailedCount == 0`) | Action Items Present | • Default mode: emits only ready manifests to `Stdout` and notes omitted drafts on `Stderr`.<br>• `--all` mode: emits all manifests (including drafts with inline `gmp.googleapis.com/todo-*` annotations) to `Stdout`.<br>Follow Section 5 to reconcile drafts. |
+| **Exit Code 1** (`FailedCount > 0`) | Fatal Conversion Failure | Zero manifests were written to `Stdout` (0 bytes). Inspect `Stderr` logs to identify missing dependencies or malformed YAML inputs, resolve them, and re-run. |
+
+### Inspecting CLI Diagnostics in `Stderr` Logs:
+When investigating why a TODO or warning was added, inspect the `Stderr` log (or `migration.log`) for pre-scoped resource logs:
+```bash
+# Filter logs for a specific resource
+grep "PodMonitor:default/my-app" migration.log
+
+# Filter all warnings and fatal errors
+grep -E "\[WARNING\]|\[ERROR\]" migration.log
+```
+
+---
+
+## 4. Secret Creation & Namespacing Rules
+
+* **`PodMonitoring` (Namespaced CRD)**: Kubernetes forbids cross-namespace Secret references. If a Secret or converted ConfigMap is referenced, **it must exist in the same namespace as the `PodMonitoring`**. `gmp-migrate` automatically generates a companion `Secret` clone in every target namespace where the `PodMonitoring` is created.
+* **`ClusterPodMonitoring` (Cluster-Scoped CRD)**: Supports an explicit `namespace` field in `SecretKeySelector`. Companion Secrets live in a central namespace (e.g. `gmp-system`), and `secret.namespace` is explicitly populated.
+
+---
+
+## 5. Action Plan Catalog for TODO Reconciliation
+
+> [!CAUTION]
+> **Strict Read-Only Investigation Policy**:
+> All `kubectl` commands executed during investigation (Recipes 1–6) MUST be strictly READ-ONLY (`get`, `describe`, `logs`, `--dry-run=client`).
+> Under NO circumstances should an agent run state-changing commands (`kubectl apply`, `kubectl create`, `kubectl patch`, `kubectl delete`) against a live cluster without reaching Section 7 and receiving explicit user approval.
+
+All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ERROR] <reason> ACTION: <action>"`. Match the placeholder or annotation message against the recipes below:
+
+---
+
+### Recipe 1: Port & Pod Selector Resolution
+
+#### 1.1 Unresolved Named Port (`TODO_RESOLVE_PORT_<NAME>`)
+* **Annotation**: `[WARNING] Named port "<name>" was not found on Service "<svc>"... ACTION: Replace TODO_RESOLVE_PORT_<NAME> with the target container port name or number.`
+* **Commands**:
+  ```bash
+  kubectl get svc <service-name> -n <namespace> -o jsonpath='{.spec.ports}' | jq .
+  kubectl get pod -n <namespace> -l <selector> -o jsonpath='{.items[0].spec.containers[*].ports}' | jq .
+  ```
+* **Resolution**:
+  1. If Service `targetPort` is an integer (e.g. `8080`), replace placeholder with integer `8080`.
+  2. If Service `targetPort` is a named string (e.g. `http-metrics`), set `port: http-metrics`.
+  3. If Service `targetPort` is omitted, replace with the Service's integer `port`.
+* **Diff**:
+  ```diff
+   spec:
+     endpoints:
+  -  - port: TODO_RESOLVE_PORT_METRICS
+  +  - port: 8080
+       interval: 30s
+  ```
+
+#### 1.2 Missing Backing Service (`TODO_RESOLVE_PORT` & `TODO_SET_POD_SELECTOR`)
+* **Annotation**: `[ERROR] Corresponding Kubernetes Service was not found... ACTION: Define target pod selector in 'spec.selector.matchLabels' and verify endpoint ports.`
+* **Commands**:
+  ```bash
+  kubectl get svc -n <namespace> -o wide
+  ```
+* **Agent Interactive Step**:
+  - If a matching Service is identified, copy its `spec.selector` into `spec.selector.matchLabels` and resolve the endpoint port.
+  - If no Service exists or multiple ambiguous Services match, prompt the user:
+    > *"Could not find a unique backing Service for `<name>`. Please provide the target Pod label selector (e.g. `app=payment`) and container port."*
+* **Diff**:
+  ```diff
+   spec:
+     selector:
+       matchLabels:
+  -      app: TODO_SET_POD_SELECTOR
+  +      app.kubernetes.io/name: payment-processor
+     endpoints:
+  -  - port: TODO_RESOLVE_PORT
+  +  - port: 9102
+  ```
+
+#### 1.3 Missing Endpoint Port (`TODO_SET_PORT`)
+* **Annotation**: `[ERROR] Endpoint [N] does not specify a 'port' or 'targetPort'...`
+* **Commands**:
+  ```bash
+  kubectl get pod -n <namespace> -l <selector> -o jsonpath='{.items[0].spec.containers[*].ports}' | jq .
+  ```
+* **Agent Interactive Step**:
+  - If a single container metrics port is found, resolve to that port.
+  - If the pod has multiple containers or multiple ports (e.g. `8080` vs `15090`), **do not guess**—prompt the user to choose the intended metrics port.
+* **Diff**:
+  ```diff
+   spec:
+     endpoints:
+  -  - port: TODO_SET_PORT
+  +  - port: metrics
+  ```
+
+---
+
+### Recipe 2: Missing or Incomplete Secrets & ConfigMaps
+
+#### 2.1 Missing Source Secret / ConfigMap (`TODO_SET_<KEY>_FROM_<KIND>_<NAME>`)
+* **Annotation**: `[ERROR] Referenced SECRET "<name>" for key "<key>" was not found in migration inputs...`
+* **Commands**:
+  ```bash
+  # Fetch Secret data from cluster
+  kubectl get secret <secret-name> -n <namespace> -o jsonpath='{.data.<key>}' | base64 --decode
+  
+  # Or fetch ConfigMap data
+  kubectl get configmap <cm-name> -n <namespace> -o jsonpath='{.data.<key>}'
+  ```
+* **Diff**:
+  ```diff
+   spec:
+     endpoints:
+     - port: 8080
+       basicAuth:
+  -      username: TODO_SET_USER_FROM_SECRET_APP-AUTH
+  +      username: prometheus-scraper
+  ```
+
+#### 2.2 Missing Key in Secret/ConfigMap (`TODO_MISSING_KEY_<KEY>_IN_<KIND>_<NAME>`)
+* **Annotation**: `[ERROR] Key "<key>" was not found in referenced SECRET "<name>"...`
+* **Commands**:
+  ```bash
+  # Inspect available keys in Secret/ConfigMap
+  kubectl get secret <secret-name> -n <namespace> -o jsonpath='{.data}' | jq 'keys'
+  ```
+* **Resolution**: If the key was misspelled in the source monitor (e.g. `user` instead of `username`), extract value from the correct key.
+* **Diff**:
+  ```diff
+   spec:
+     endpoints:
+     - port: 8080
+       basicAuth:
+  -      username: TODO_MISSING_KEY_USERNAME_IN_SECRET_APP-AUTH
+  +      username: admin
+  ```
+
+#### 2.3 Corrupt Base64 Data (`TODO_CORRUPT_SECRET_DATA_<KEY>`)
+* **Annotation**: `[ERROR] Failed to base64-decode key "<key>" in Secret "<name>"...`
+* **Agent Interactive Step**:
+  Do NOT fabricate passwords or placeholders. Prompt the user:
+  > *"Key `<key>` in Secret `<name>` contains invalid base64 data. Please provide the correct value or fix the Secret in the cluster."*
+* **Diff**:
+  ```diff
+   spec:
+     endpoints:
+     - port: 8080
+       basicAuth:
+  -      username: TODO_CORRUPT_SECRET_DATA_USER
+  +      username: valid-user
+  ```
+
+---
+
+### Recipe 3: Converted ConfigMap TLS & Auth References
+
+#### 3.1 Companion Secret Manifest Generation (`secret-<configmap-name>`)
+* **Cause**: Prometheus Operator allowed TLS CAs in `ConfigMap`; GMP strictly requires Kubernetes `Secret` objects.
+* **Manifest Generation Commands**:
+  ```bash
+  # Check if companion Secret was generated in output.yaml
+  grep -A 10 "name: secret-<configmap-name>" output.yaml
+  
+  # If missing, generate companion Secret manifest locally (do NOT apply directly to cluster)
+  kubectl create secret generic secret-<configmap-name> -n <namespace> \
+    --from-file=ca.crt=/path/to/ca.crt --dry-run=client -o yaml >> output.yaml
+  ```
+* **Companion Secret Manifest**:
+  ```yaml
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: secret-cluster-ca
+    namespace: prod
+  stringData:
+    ca.crt: "-----BEGIN CERTIFICATE-----\n..."
+  ```
+
+#### 3.2 Empty Secret Reference Selectors (`TODO_SET_SECRET_NAME`, `TODO_SET_SECRET_KEY`)
+* **Annotation**: `[ERROR] Referenced Secret has an empty name for key...`
+* **Commands**:
+  ```bash
+  kubectl get secrets -n <namespace>
+  ```
+* **Diff**:
+  ```diff
+   spec:
+     endpoints:
+     - port: https
+       tls:
+         ca:
+           secret:
+  -          name: TODO_SET_SECRET_NAME
+  -          key: TODO_SET_SECRET_KEY
+  +          name: my-tls-ca
+  +          key: ca.crt
+  ```
+
+---
+
+### Recipe 4: OAuth2 & Proxy URL Configurations (Interactive User Prompting)
+
+#### 4.1 OAuth2 Placeholders (`TODO_SET_OAUTH2_CLIENT_ID`, `TODO_SET_OAUTH2_TOKEN_URL`)
+* **Annotation**: `[ERROR] OAuth2 clientID must be defined as either Secret or ConfigMap...`
+* **Agent Interactive Step**:
+  Do **NOT** guess public endpoints via curl. Inspect local Secrets in the namespace for OAuth credentials, and prompt the user:
+  > *"OAuth2 configuration requires a `clientID` and `tokenUrl` (e.g. Google Cloud OAuth: `https://oauth2.googleapis.com/token`, Keycloak, Okta). Please provide the token endpoint URL and client ID for this workload."*
+* **Diff**:
+  ```diff
+   spec:
+     endpoints:
+     - port: 8080
+       oauth2:
+  -      clientID: TODO_SET_OAUTH2_CLIENT_ID
+  -      tokenUrl: TODO_SET_OAUTH2_TOKEN_URL
+  +      clientID: "123456789.apps.googleusercontent.com"
+  +      tokenUrl: "https://oauth2.googleapis.com/token"
+         clientSecret:
+           secret:
+             name: oauth-secret
+             key: client-secret
+  ```
+
+#### 4.2 Proxy URL Configuration (`TODO_SET_VALID_PROXY_URL` & Plaintext Passwords)
+* **Annotation**: `[ERROR] Proxy URL contains embedded plaintext credentials...`
+* **Resolution**: Prompt user for proxy host. Note that GMP endpoints do not support embedded basic auth in proxy URLs.
+* **Diff**:
+  ```diff
+   spec:
+     endpoints:
+     - port: 8080
+  -    proxyUrl: TODO_SET_VALID_PROXY_URL
+  +    proxyUrl: http://proxy.corp.internal:3128
+  ```
+
+---
+
+### Recipe 5: Relabeling Rules & Scope Expansion (Interactive User Guidance)
+
+#### 5.1 Dropped Pre-Scrape Keep/Drop Rules (Scope Expansion Warning)
+* **Annotation**: `[WARNING] Dropped target filtering rule ('keep'|'drop' on '__meta_kubernetes_pod_annotation_...'). ACTION: Add equivalent pod label selector in 'spec.selector.matchLabels'.`
+* **Agent Interactive Step**:
+  GMP `spec.selector` **only matches Kubernetes Pod labels**, never Pod annotations. In Prometheus Operator, scraped pods are the intersection of the monitor's `spec.selector` and the annotation rule:
+  $$\text{Scraped Targets} = (\text{Pods matching } \texttt{spec.selector}) \cap (\text{Pods matching Annotation Rule})$$
+
+  ##### Case A: Reconciling `action: keep` (e.g. `prometheus.io/scrape: "true"`)
+  1. **Intersection Query**: Query for workloads matching **both** the monitor's original `spec.selector` AND the annotation:
+     ```bash
+     kubectl get deployment,statefulset,daemonset -n <namespace> -l <original-monitor-selector> \
+       -o jsonpath='{range .items[?(@.spec.template.metadata.annotations.prometheus\.io/scrape=="true")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
+     ```
+  2. **Update `PodMonitoring`**: Combine the original selector with the promoted label:
+     ```yaml
+     spec:
+       selector:
+         matchLabels:
+           app.kubernetes.io/name: payment-gateway
+           prometheus.io/scrape: "true"
+     ```
+  3. **Generate Companion Workload Patches**: Add `labels: { prometheus.io/scrape: "true" }` to each matching workload discovered in step 1.
+  4. **Warn & Prompt**: Warn the user that patching the workload pod templates will trigger a rolling restart of their pods, and request approval before applying.
+
+  ##### Case B: Reconciling `action: drop` (e.g. `prometheus.io/scrape: "false"`)
+  1. **Identify Excluded Workloads**: Query for workloads matching `spec.selector` that have the exclusion annotation:
+     ```bash
+     kubectl get deployment,statefulset,daemonset -n <namespace> -l <original-monitor-selector> \
+       -o jsonpath='{range .items[?(@.spec.template.metadata.annotations.prometheus\.io/scrape=="false")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
+     ```
+  2. **Inverted Selector via `matchExpressions: NotIn`**:
+     - Add `labels: { prometheus.io/scrape: "false" }` to the excluded workload(s).
+     - In `PodMonitoring.spec.selector`, use `matchExpressions` with `operator: NotIn`:
+       ```yaml
+       spec:
+         selector:
+           matchLabels:
+             app.kubernetes.io/name: payment-gateway
+           matchExpressions:
+           - key: prometheus.io/scrape
+             operator: NotIn
+             values:
+             - "false"
+       ```
+     > **Note**: Kubernetes `NotIn` matches all pods where the label is absent, or present with any value other than `"false"`.
+
+* **Diffs**:
+  ```diff
+   # PodMonitoring CRD (Case A: Keep Rule)
+   spec:
+     selector:
+       matchLabels:
+         app.kubernetes.io/name: payment-gateway
+  +      prometheus.io/scrape: "true"
+  ```
+  ```diff
+   # PodMonitoring CRD (Case B: Drop Rule via NotIn)
+   spec:
+     selector:
+       matchLabels:
+         app.kubernetes.io/name: payment-gateway
+  +    matchExpressions:
+  +    - key: prometheus.io/scrape
+  +      operator: NotIn
+  +      values:
+  +      - "false"
+  ```
+  ```diff
+   # Target Workload spec.template.metadata.labels (Companion Patch)
+   spec:
+     template:
+       metadata:
+         labels:
+           app.kubernetes.io/name: payment-gateway
+  +        prometheus.io/scrape: "true"
+  ```
+
+#### 5.2 Conflicting Keep Relabelings
+* **Annotation**: `[ERROR] Conflicting relabeling keep rules for label "<label>"...`
+* **Agent Interactive Step**:
+  Check `Stderr` logs for conflicting values and ask the user to clarify:
+  > *"Detected conflicting label rules for label `env` (`prod` vs `staging`). Which workload should this PodMonitoring target?"*
+* **Diff**:
+  ```diff
+   spec:
+     selector:
+       matchLabels:
+  -      env: production # Conflicted with staging
+  +      env: production
+  ```
+
+---
+
+### Recipe 6: Scrape Durations, Timeouts & Empty Selectors
+
+#### 6.1 Invalid Duration / Timeout Capping
+* **Annotation**: `[ERROR] Invalid scrape interval "<val>"...`
+* **Diff**:
+  ```diff
+   spec:
+     endpoints:
+     - port: metrics
+  -    interval: "30"
+  -    timeout: "45s"
+  +    interval: 30s
+  +    timeout: 30s
+  ```
+
+#### 6.2 Empty Selector Warning (Interactive User Guidance)
+* **Annotation**: `[WARNING] Resulting PodMonitoring selector is empty and matches all pods in this namespace.`
+* **Context**: In GMP, an empty label selector (`matchLabels: {}` or empty `selector`) acts as a wildcard and scrapes every pod in the namespace (or cluster) that exposes the endpoint port.
+* **Agent Interactive Step**:
+  1. Inspect running workloads in the namespace to identify candidate workloads and their pod template labels:
+     ```bash
+     kubectl get deployment,daemonset,statefulset -n <namespace> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.metadata.labels}{"\n"}{end}'
+     ```
+  2. Correlate the monitor's name and port with the discovered workloads.
+  3. Prompt the user for confirmation:
+     > *"PodMonitoring `<name>` has an empty selector and will scrape all pods in namespace `<namespace>`. Discovered workloads: `[app=redis, app=web]`. Please confirm if you want to target a specific workload label, or keep the wildcard selector to scrape all pods in the namespace."*
+  4. If a specific workload is confirmed, apply `matchLabels`. If namespace-wide scraping was intentional, delete the TODO annotation and leave the selector as-is.
+* **Diff (Target Specific Workload)**:
+  ```diff
+   spec:
+     selector:
+  -    matchLabels: {}
+  +    matchLabels:
+  +      app.kubernetes.io/name: redis
+  ```
+
+---
+
+## 6. Action Item Resolution & TODO Cleanup Protocol
+
+> [!IMPORTANT]
+> Generated manifests maintain 100% pure workload selectors. Safety is preserved through stream gating and exit codes.
+
+**Strict Protocol for Finalizing Reconciled Manifests:**
+1. Verify that all `TODO_*` placeholders have been replaced with valid ports/names.
+2. Verify all companion `kind: Secret` manifests are included in the bundle.
+3. Validate scrape intervals, timeouts, and pod selectors against running workloads.
+4. **Document Reconciliation Steps**: For every TODO item or placeholder being resolved, maintain a traceable record of:
+   - **Original TODO / Placeholder**: The specific annotation key (`gmp.googleapis.com/todo-N`) or placeholder string (e.g. `TODO_RESOLVE_PORT_METRICS`).
+   - **Investigation Conducted**: Exact `kubectl` commands, file lookups, or user clarifications used to gather the required context.
+   - **Reconciliation Action**: The exact change applied to the manifest (e.g. mapped port `8080`, converted annotation to label selector).
+5. Delete all `gmp.googleapis.com/todo-*` annotations from `metadata.annotations` once resolved.
+
+### Reconciliation Audit & Code Diff Reporting Format
+When presenting reconciled manifests to the user, always provide:
+1. A structured audit table summarizing how each TODO was resolved.
+2. Complete, per-file code diffs showing the exact before-and-after modifications for every affected file (including companion Secrets or patched workload Deployments).
+
+#### Example Audit Table:
+| Resource (`<Kind>:<ns>/<name>`) | TODO Key / Placeholder | Investigation Step / Source | Resolution Action Taken |
+| :--- | :--- | :--- | :--- |
+| `PodMonitoring: payments/payment-gateway` | `gmp.googleapis.com/todo-1` (`TODO_RESOLVE_PORT_METRICS`) | Queried `svc/payment-service` via `kubectl get svc` | Mapped Service port `metrics` to container port `8443`. |
+| `PodMonitoring: payments/payment-gateway` | `gmp.googleapis.com/todo-2` (Scope Expansion) | Inspected pod labels with `kubectl get pods --show-labels` | Added `prometheus.io/scrape: "true"` to `matchLabels` and created Deployment patch. |
+| `PodMonitoring: payments/payment-gateway` | `TODO_SET_VALID_PROXY_URL` | User prompted for corporate proxy endpoint | Stripped embedded basic auth and configured `http://proxy.corp.internal:3128`. |
+
+#### Example Per-File Code Diffs:
+```diff
+# File: manifests/gmp/podmonitoring-payment-gateway.yaml
+ metadata:
+   name: payment-gateway-monitor
+   namespace: payments
+-  annotations:
+-    gmp.googleapis.com/todo-1: "[WARNING] Dropped target filtering rule ('keep' on '__meta_kubernetes_pod_annotation_prometheus_io_scrape')..."
+-    gmp.googleapis.com/todo-2: "[ERROR] Named port 'metrics' was not found on Service 'payment-service'..."
+ spec:
+   selector:
+     matchExpressions:
+     - key: component
+       operator: In
+       values:
+       - checkout-api
+       - webhook-handler
+     matchLabels:
+       app.kubernetes.io/name: payment-gateway
++      prometheus.io/scrape: "true"
+   endpoints:
+-  - port: TODO_RESOLVE_PORT_METRICS
++  - port: 8443
+     interval: 15s
+```
+
+```diff
+# File: manifests/apps/deployment-payment-gateway.yaml (Companion Workload Patch)
+ spec:
+   template:
+     metadata:
+       labels:
+         app.kubernetes.io/name: payment-gateway
++        prometheus.io/scrape: "true"
+```
+
+---
+
+## 7. Verification & User Agency
+
+Before applying changes to a live cluster:
+1. **Present Reconciliation Steps & Per-File Code Diffs**: Output the structured Reconciliation Audit Table detailing the steps taken for each TODO, followed by complete per-file diffs showing the exact before-and-after modifications for all reconciled manifests and companion files.
+2. **Server-Side Dry Run**:
+   ```bash
+   kubectl apply --dry-run=server -f <output-manifests.yaml>
+   ```
+3. **Explicit User Approval**: Ask the user before running `kubectl apply`.
+4. **Post-Apply Verification**:
+   ```bash
+   kubectl get podmonitoring,clusterpodmonitoring -A
+   kubectl describe podmonitoring <name> -n <namespace>
+   ```
+   Check that `status.conditions` reports `ConfigurationCreateSuccess`.

--- a/cmd/gmp-migrate/SKILL.md
+++ b/cmd/gmp-migrate/SKILL.md
@@ -284,8 +284,8 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 #### 4.1 OAuth2 Placeholders (`TODO_SET_OAUTH2_CLIENT_ID`, `TODO_SET_OAUTH2_TOKEN_URL`)
 * **Annotation**: `[ERROR] OAuth2 clientID must be defined as either Secret or ConfigMap...`
 * **Agent Interactive Step**:
-  Do **NOT** guess public endpoints via curl. Inspect local Secrets in the namespace for OAuth credentials, and prompt the user:
-  > *"OAuth2 configuration requires a `clientID` and `tokenUrl` (e.g. Google Cloud OAuth: `https://oauth2.googleapis.com/token`, Keycloak, Okta). Please provide the token endpoint URL and client ID for this workload."*
+  Inspect local Secrets in the namespace for any existing OAuth credentials (`kubectl get secrets -n <namespace>`). If missing or incomplete, prompt the user directly:
+  > *"OAuth2 configuration requires an explicit `tokenUrl` and `clientID`. Please provide the token endpoint URL and client credentials for this workload (or configure the backing Secret)."*
 * **Diff**:
   ```diff
    spec:
@@ -294,8 +294,8 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
        oauth2:
   -      clientID: TODO_SET_OAUTH2_CLIENT_ID
   -      tokenUrl: TODO_SET_OAUTH2_TOKEN_URL
-  +      clientID: "123456789.apps.googleusercontent.com"
-  +      tokenUrl: "https://oauth2.googleapis.com/token"
+  +      clientID: "<your-client-id>"
+  +      tokenUrl: "<your-token-endpoint-url>"
          clientSecret:
            secret:
              name: oauth-secret

--- a/cmd/gmp-migrate/SKILL.md
+++ b/cmd/gmp-migrate/SKILL.md
@@ -110,6 +110,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 ### Recipe 1: Port & Pod Selector Resolution
 
 #### 1.1 Unresolved Named Port (`TODO_RESOLVE_PORT_<NAME>`)
+
 * **Annotation**: `[WARNING] Named port "<name>" was not found on Service "<svc>"... ACTION: Replace TODO_RESOLVE_PORT_<NAME> with the target container port name or number.`
 * **Commands**:
 
@@ -132,6 +133,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   ```
 
 #### 1.2 Missing Backing Service (`TODO_RESOLVE_PORT` & `TODO_SET_POD_LABELS`)
+
 * **Context**: `gmp-migrate` emits `TODO_SET_POD_LABELS: TODO_SET_POD_LABELS` as a safe guardrail placeholder. Replace this placeholder with the complete set of pod template labels for the target workload.
 * **Annotation**: `[ERROR] Corresponding Kubernetes Service was not found... ACTION: Define target pod selector in 'spec.selector.matchLabels' and verify endpoint ports.`
 * **Commands**:
@@ -163,6 +165,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   ```
 
 #### 1.3 Missing Endpoint Port (`TODO_SET_PORT`)
+
 * **Annotation**: `[ERROR] Endpoint [N] does not specify a 'port' or 'targetPort'...`
 * **Commands**:
 
@@ -186,19 +189,20 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 ### Recipe 2: Missing or Incomplete Secrets & ConfigMaps
 
 #### Security Policy: Zero Secret Ingestion & Human-In-The-Loop
+
 * **Do Not Read Secrets via CLI**: Agents must never run `kubectl get secret` to inspect secret payloads. Reading cluster secrets risks leaking sensitive credentials (passwords, tokens, private keys) into agent context logs and transcripts.
 * **Dual-Path User Handoff**: When a Secret placeholder (`TODO_SET_USERNAME_FROM_SECRET_*` or `TODO_SET_CLIENT-ID_FROM_SECRET_*`) is encountered, the agent must output the targeted `jsonpath` command for the user to run in their terminal, along with the exact resource identifier, file link, field path, and resolution options:
   1. **Option A (Interactive)**: The user replies in chat with the non-sensitive string (e.g. `username: <output>`) and the agent updates the manifest and removes the TODO annotation.
   2. **Option B (Direct Edit)**: The user updates the manifest directly using the provided file link, target field path, and diff snippet.
 
 #### 2.1 Missing Source Secret / ConfigMap (`TODO_SET_<KEY>_FROM_<KIND>_<NAME>`)
+
 * **Annotation**: `[ERROR] Referenced SECRET "<name>" for key "<key>" was not found in migration inputs...`
 * **Agent Handoff Output Format**:
-
-  ```markdown
   In GMP, `basicAuth.username` is configured directly as a string, while `password` remains securely referenced from Secret `<secret-name>`.
 
   ### 1. Retrieve the username in your terminal:
+
   ```bash
   kubectl get secret <secret-name> -n <namespace> -o jsonpath='{.data.<key>}' | base64 -d
   ```
@@ -224,18 +228,14 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
       ```
     * Remove the `gmp.googleapis.com/todo-*` annotation from `metadata.annotations`.
 
-  ```
-
-  ```
-
 #### 2.2 Missing Key in Secret/ConfigMap (`TODO_MISSING_KEY_<KEY>_IN_<KIND>_<NAME>`)
+
 * **Annotation**: `[ERROR] Key "<key>" was not found in referenced SECRET "<name>"...`
 * **Agent Handoff Output Format**:
-
-  ```markdown
   Key `<key>` was not found in Secret `<secret-name>`.
 
   ### 1. List available keys in the Secret on your terminal:
+
   ```bash
   kubectl get secret <secret-name> -n <namespace> -o jsonpath='{.data}' | jq 'keys'
   ```
@@ -244,11 +244,8 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   * **Option A (Interactive)**: If the key was misspelled in the source monitor, reply with `Use key: <correct-key>` or `The username is: <value>`.
   * **Option B (Direct Edit)**: Update `spec.endpoints[<index>].basicAuth.username` directly in `<path-to-manifest>.yaml` and remove the TODO annotation.
 
-  ```
-
-  ```
-
 #### 2.3 Corrupt Base64 Data (`TODO_CORRUPT_SECRET_DATA_<KEY>`)
+
 * **Annotation**: `[ERROR] Failed to base64-decode key "<key>" in Secret "<name>"...`
 * **Agent Interactive Step**:
   Do NOT fabricate key values or placeholders. Prompt the user:
@@ -273,6 +270,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 ### Recipe 3: Converted ConfigMap TLS & Auth References
 
 #### 3.1 Companion Secret Manifest Generation (`secret-<configmap-name>`)
+
 * **Cause**: Prometheus Operator allowed TLS CAs in `ConfigMap`; GMP strictly requires Kubernetes `Secret` objects.
 * **Manifest Generation Commands**:
 
@@ -297,13 +295,13 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   ```
 
 #### 3.2 Empty Secret Reference Selectors (`TODO_SET_SECRET_NAME`, `TODO_SET_SECRET_KEY`)
+
 * **Annotation**: `[ERROR] Referenced Secret has an empty name for key...`
 * **Agent Handoff Output Format**:
-
-  ```markdown
   Referenced TLS Secret has an empty name in the source manifest.
 
   ### 1. Identify the TLS Secret in your namespace:
+
   ```bash
   kubectl get secrets -n <namespace>
   ```
@@ -312,22 +310,18 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   * **Option A (Interactive)**: Reply with `The TLS secret name is: <secret-name>` and I will update the manifest.
   * **Option B (Direct Edit)**: Update `spec.endpoints[<index>].tls.ca.secret.name` in `<path-to-manifest>.yaml` and remove the TODO annotation.
 
-  ```
-
-  ```
-
 ---
 
 ### Recipe 4: OAuth2 & Proxy URL Configurations (Interactive User Prompting)
 
 #### 4.1 OAuth2 Placeholders (`TODO_SET_OAUTH2_CLIENT_ID`, `TODO_SET_OAUTH2_TOKEN_URL`)
+
 * **Annotation**: `[ERROR] OAuth2 clientID must be defined as either Secret or ConfigMap...`
 * **Agent Handoff Output Format**:
-
-  ```markdown
   In GMP, `oauth2.clientID` and `oauth2.tokenURL` are configured directly as strings, while `clientSecret` remains securely referenced from Secret `<secret-name>`.
 
   ### 1. Retrieve the client ID in your terminal (if stored in a Secret):
+
   ```bash
   kubectl get secret <secret-name> -n <namespace> -o jsonpath='{.data.<client-id-key>}' | base64 -d
   ```
@@ -358,11 +352,8 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
       ```
     * Remove the `gmp.googleapis.com/todo-*` annotations from `metadata.annotations`.
 
-  ```
-
-  ```
-
 #### 4.2 Proxy URL Configuration (Malformed URLs & Stripped Credentials)
+
 * **Context**: GMP CRDs only support an unauthenticated `proxyUrl` string. GMP does not support proxy credentials (there are no Secret fields for proxies, and embedded credentials like `user:pass@` in `proxyUrl` are rejected by CRD admission rules).
 * **Annotations**:
   * `[ERROR] Proxy URL "<url>" is invalid or malformed. ACTION: Specify a valid proxy URL (e.g. 'http://proxy.example.com:8080').`
@@ -402,6 +393,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 ### Recipe 5: Relabeling Rules & Scope Expansion (Interactive User Guidance)
 
 #### 5.1 Dropped Pre-Scrape Keep/Drop Rules (Scope Expansion Warning)
+
 * **Annotation**: `[WARNING] Dropped target filtering rule ('keep'|'drop' on '__meta_kubernetes_pod_annotation_...'). ACTION: Add equivalent pod label selector in 'spec.selector.matchLabels'.`
 * **Agent Interactive Step**:
   GMP `spec.selector` **only matches Kubernetes Pod labels**, never Pod annotations. In Prometheus Operator, scraped pods are the intersection of the monitor's `spec.selector` and the annotation rule:
@@ -487,6 +479,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   ```
 
 #### 5.2 Conflicting Keep Relabelings
+
 * **Annotation**: `[ERROR] Conflicting relabeling keep rules for label "<label>": cannot require both "<val1>" and "<val2>" simultaneously...` (or `[ERROR] Selector conflict: label "<label>" has conflicting values...`)
 * **Agent Interactive Step**:
   Check the annotation or `Stderr` logs for conflicting values and ask the user to clarify:
@@ -521,6 +514,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 ### Recipe 6: Scrape Durations, Timeouts & Empty Selectors
 
 #### 6.1 Invalid Duration / Timeout Capping
+
 * **Annotation**: `[ERROR] Invalid scrape interval "<val>"...`
 * **Diff**:
 
@@ -535,6 +529,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   ```
 
 #### 6.2 Empty Selector Warning (Interactive User Guidance)
+
 * **Annotation**: `[WARNING] Resulting PodMonitoring selector is empty and matches all pods in this namespace.`
 * **Context**: In GMP, an empty label selector (`matchLabels: {}` or empty `selector`) acts as a wildcard and scrapes every pod in the namespace (or cluster) that exposes the endpoint port.
 * **Agent Interactive Step**:

--- a/cmd/gmp-migrate/SKILL.md
+++ b/cmd/gmp-migrate/SKILL.md
@@ -19,7 +19,7 @@ This skill guides agents through executing the migration CLI tool, interpreting 
 
 ### Core CLI Invocations
 
-1. **Default Mode (Ready-Only)**: Emits strictly 100% ready manifests to `Stdout`. Orompts/omits any best-effort drafts requiring human/agent review.
+1. **Default Mode (Ready-only)**: Emits strictly 100% ready manifests to `Stdout`. Omits any best-effort drafts requiring human/agent review.
    ```bash
    gmp-migrate -f <input-path> > ready_manifests.yaml 2> migration.log
    ```
@@ -319,7 +319,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   1. **Intersection Query**: Query for workloads matching **both** the monitor's original `spec.selector` AND the annotation:
      ```bash
      kubectl get deployment,statefulset,daemonset -n <namespace> -l <original-monitor-selector> \
-       -o jsonpath='{range .items[?(@.spec.template.metadata.annotations.prometheus\.io/scrape=="true")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
+       -o jsonpath='{range .items[?(@.spec.template.metadata.annotations["prometheus.io/scrape"]=="true")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
      ```
   2. **Update `PodMonitoring`**: Combine the original selector with the promoted label:
      ```yaml
@@ -336,7 +336,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   1. **Identify Excluded Workloads**: Query for workloads matching `spec.selector` that have the exclusion annotation:
      ```bash
      kubectl get deployment,statefulset,daemonset -n <namespace> -l <original-monitor-selector> \
-       -o jsonpath='{range .items[?(@.spec.template.metadata.annotations.prometheus\.io/scrape=="false")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
+       -o jsonpath='{range .items[?(@.spec.template.metadata.annotations["prometheus.io/scrape"]=="false")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
      ```
   2. **Inverted Selector via `matchExpressions: NotIn`**:
      - Add `labels: { prometheus.io/scrape: "false" }` to the excluded workload(s).

--- a/cmd/gmp-migrate/SKILL.md
+++ b/cmd/gmp-migrate/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: gmp-migrate
-description: >-
-  Run the gmp-migrate CLI tool to convert Prometheus Operator manifests (PodMonitor,
-  ServiceMonitor) to Google Managed Prometheus (GMP) CRDs (PodMonitoring,
-  ClusterPodMonitoring), and reconcile generated TODOs, port placeholders, and errors.
+description: Run the gmp-migrate CLI tool to convert Prometheus Operator manifests (PodMonitor, ServiceMonitor) to Google Managed Prometheus (GMP) CRDs (PodMonitoring, ClusterPodMonitoring), and reconcile generated TODOs, port placeholders, and errors.
 ---
 
 # GMP Migration & Reconciliation Skill
@@ -20,21 +17,25 @@ This skill guides agents through executing the migration CLI tool, interpreting 
 ### Core CLI Invocations
 
 1. **Default Mode (Ready-only)**: Emits strictly 100% ready manifests to `Stdout`. Omits any best-effort drafts requiring human/agent review.
+
    ```bash
    gmp-migrate -f <input-path> > ready_manifests.yaml 2> migration.log
    ```
 
 2. **Full Review Mode (`--all` / `-a`)**: Emits all converted manifests to `Stdout`, including best-effort draft configurations with inline `gmp.googleapis.com/todo-*` annotations for human / agent reconciliation.
+
    ```bash
    gmp-migrate --all -f <input-path> > all_manifests.yaml 2> migration.log
    ```
 
 3. **Multiple Input Sources (Monitors + Backing Services/Secrets)**:
+
    ```bash
    gmp-migrate --all -f path/to/monitors/ -f path/to/services/ > all_manifests.yaml 2> migration.log
    ```
 
 4. **Live Cluster Ingestion via Stdin**:
+
    ```bash
    kubectl get podmonitors,servicemonitors,services,configmaps,secrets -A -o yaml | gmp-migrate --all -f - > all_manifests.yaml 2> migration.log
    ```
@@ -68,14 +69,16 @@ Migration Complete Summary:
 =========================================
 ```
 
-| Exit Code / Report | Status | Stream Behavior & Recommended Agent Action |
-| :--- | :--- | :--- |
-| **Exit Code 0** (`ActionItemsCount == 0`, `FailedCount == 0`) | Clean Parity | All manifests are 100% ready. Written to `Stdout`. Proceed directly to dry-run verification and diff presentation. |
-| **Exit Code 1** (`ActionItemsCount > 0`, `FailedCount == 0`) | Action Items Present | • Default mode: emits only ready manifests to `Stdout` and notes omitted drafts on `Stderr`.<br>• `--all` mode: emits all manifests (including drafts with inline `gmp.googleapis.com/todo-*` annotations) to `Stdout`.<br>Follow Section 5 to reconcile drafts. |
-| **Exit Code 1** (`FailedCount > 0`) | Fatal Conversion Failure | Zero manifests were written to `Stdout` (0 bytes). Inspect `Stderr` logs to identify missing dependencies or malformed YAML inputs, resolve them, and re-run. |
+| Exit Code / Report                                            | Status                   | Stream Behavior & Recommended Agent Action                                                                                                                                                                                                                       |
+|:--------------------------------------------------------------|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Exit Code 0** (`ActionItemsCount == 0`, `FailedCount == 0`) | Clean Parity             | All manifests are 100% ready. Written to `Stdout`. Proceed directly to dry-run verification and diff presentation.                                                                                                                                               |
+| **Exit Code 1** (`ActionItemsCount > 0`, `FailedCount == 0`)  | Action Items Present     | • Default mode: emits only ready manifests to `Stdout` and notes omitted drafts on `Stderr`.<br>• `--all` mode: emits all manifests (including drafts with inline `gmp.googleapis.com/todo-*` annotations) to `Stdout`.<br>Follow Section 5 to reconcile drafts. |
+| **Exit Code 1** (`FailedCount > 0`)                           | Fatal Conversion Failure | Zero manifests were written to `Stdout` (0 bytes). Inspect `Stderr` logs to identify missing dependencies or malformed YAML inputs, resolve them, and re-run.                                                                                                    |
 
 ### Inspecting CLI Diagnostics in `Stderr` Logs:
+
 When investigating why a TODO or warning was added, inspect the `Stderr` log (or `migration.log`) for pre-scoped resource logs:
+
 ```bash
 # Filter logs for a specific resource
 grep "PodMonitor:default/my-app" migration.log
@@ -109,6 +112,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 #### 1.1 Unresolved Named Port (`TODO_RESOLVE_PORT_<NAME>`)
 * **Annotation**: `[WARNING] Named port "<name>" was not found on Service "<svc>"... ACTION: Replace TODO_RESOLVE_PORT_<NAME> with the target container port name or number.`
 * **Commands**:
+
   ```bash
   kubectl get svc <service-name> -n <namespace> -o jsonpath='{.spec.ports}' | jq .
   kubectl get pod -n <namespace> -l <selector> -o jsonpath='{.items[0].spec.containers[*].ports}' | jq .
@@ -118,6 +122,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   2. If Service `targetPort` is a named string (e.g. `http-metrics`), set `port: http-metrics`.
   3. If Service `targetPort` is omitted, replace with the Service's integer `port`.
 * **Diff**:
+
   ```diff
    spec:
      endpoints:
@@ -130,6 +135,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 * **Context**: `gmp-migrate` emits `TODO_SET_POD_LABELS: TODO_SET_POD_LABELS` as a safe guardrail placeholder. Replace this placeholder with the complete set of pod template labels for the target workload.
 * **Annotation**: `[ERROR] Corresponding Kubernetes Service was not found... ACTION: Define target pod selector in 'spec.selector.matchLabels' and verify endpoint ports.`
 * **Commands**:
+
   ```bash
   kubectl get svc -n <namespace> -o wide
   kubectl get deployment,statefulset,daemonset -n <namespace> -o wide
@@ -137,8 +143,10 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 * **Agent Interactive Step**:
   - If a matching Service or workload is identified, copy its pod label selector into `spec.selector.matchLabels` and resolve endpoint ports.
   - If multiple ambiguous workloads match, prompt the user:
+
     > *"Could not find a backing Service for `<name>`. Discovered candidate workloads: `[app=payment-processor, app=payment-worker]`. Please confirm the target pod labels."*
 * **Diff**:
+
   ```diff
    metadata:
   -  annotations:
@@ -157,6 +165,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 #### 1.3 Missing Endpoint Port (`TODO_SET_PORT`)
 * **Annotation**: `[ERROR] Endpoint [N] does not specify a 'port' or 'targetPort'...`
 * **Commands**:
+
   ```bash
   kubectl get pod -n <namespace> -l <selector> -o jsonpath='{.items[0].spec.containers[*].ports}' | jq .
   ```
@@ -164,6 +173,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   - If a single container metrics port is found, resolve to that port.
   - If the pod has multiple containers or multiple ports (e.g. `8080` vs `15090`), **do not guess**—prompt the user to choose the intended metrics port.
 * **Diff**:
+
   ```diff
    spec:
      endpoints:
@@ -175,50 +185,77 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 
 ### Recipe 2: Missing or Incomplete Secrets & ConfigMaps
 
+#### Security Policy: Zero Secret Ingestion & Human-In-The-Loop
+* **Do Not Read Secrets via CLI**: Agents must never run `kubectl get secret` to inspect secret payloads. Reading cluster secrets risks leaking sensitive credentials (passwords, tokens, private keys) into agent context logs and transcripts.
+* **Dual-Path User Handoff**: When a Secret placeholder (`TODO_SET_USERNAME_FROM_SECRET_*` or `TODO_SET_CLIENT-ID_FROM_SECRET_*`) is encountered, the agent must output the targeted `jsonpath` command for the user to run in their terminal, along with the exact resource identifier, file link, field path, and resolution options:
+  1. **Option A (Interactive)**: The user replies in chat with the non-sensitive string (e.g. `username: <output>`) and the agent updates the manifest and removes the TODO annotation.
+  2. **Option B (Direct Edit)**: The user updates the manifest directly using the provided file link, target field path, and diff snippet.
+
 #### 2.1 Missing Source Secret / ConfigMap (`TODO_SET_<KEY>_FROM_<KIND>_<NAME>`)
 * **Annotation**: `[ERROR] Referenced SECRET "<name>" for key "<key>" was not found in migration inputs...`
-* **Commands**:
+* **Agent Handoff Output Format**:
+
+  ```markdown
+  In GMP, `basicAuth.username` is configured directly as a string, while `password` remains securely referenced from Secret `<secret-name>`.
+
+  ### 1. Retrieve the username in your terminal:
   ```bash
-  # Fetch Secret data from cluster
-  kubectl get secret <secret-name> -n <namespace> -o jsonpath='{.data.<key>}' | base64 --decode
-  
-  # Or fetch ConfigMap data
-  kubectl get configmap <cm-name> -n <namespace> -o jsonpath='{.data.<key>}'
+  kubectl get secret <secret-name> -n <namespace> -o jsonpath='{.data.<key>}' | base64 -d
   ```
-* **Diff**:
-  ```diff
-   spec:
-     endpoints:
-     - port: 8080
-       basicAuth:
-  -      username: TODO_SET_USER_FROM_SECRET_APP-AUTH
-  +      username: prometheus-scraper
+
+  ### 2. Resolution Options:
+  * **Option A (Interactive)**: Reply with `The username is: <value>` and I will update the manifest and remove the TODOs for you.
+  * **Option B (Direct Edit)**:
+    * **Resource**: `PodMonitoring:<namespace>/<name>`
+    * **File**: [`<path-to-manifest>.yaml`](file:///<path-to-manifest>.yaml#L<line>)
+    * **Target Field**: `spec.endpoints[<index>].basicAuth.username`
+    * **Diff**:
+
+      ```diff
+        spec:
+          endpoints:
+          - basicAuth:
+      -       username: TODO_SET_<KEY>_FROM_SECRET_<NAME>
+      +       username: "<your-retrieved-username>"
+              password:
+                secret:
+                  name: <secret-name>
+                  key: password
+      ```
+    * Remove the `gmp.googleapis.com/todo-*` annotation from `metadata.annotations`.
+
+  ```
+
   ```
 
 #### 2.2 Missing Key in Secret/ConfigMap (`TODO_MISSING_KEY_<KEY>_IN_<KIND>_<NAME>`)
 * **Annotation**: `[ERROR] Key "<key>" was not found in referenced SECRET "<name>"...`
-* **Commands**:
+* **Agent Handoff Output Format**:
+
+  ```markdown
+  Key `<key>` was not found in Secret `<secret-name>`.
+
+  ### 1. List available keys in the Secret on your terminal:
   ```bash
-  # Inspect available keys in Secret/ConfigMap
   kubectl get secret <secret-name> -n <namespace> -o jsonpath='{.data}' | jq 'keys'
   ```
-* **Resolution**: If the key was misspelled in the source monitor (e.g. `user` instead of `username`), extract value from the correct key.
-* **Diff**:
-  ```diff
-   spec:
-     endpoints:
-     - port: 8080
-       basicAuth:
-  -      username: TODO_MISSING_KEY_USERNAME_IN_SECRET_APP-AUTH
-  +      username: admin
+
+  ### 2. Resolution Options:
+  * **Option A (Interactive)**: If the key was misspelled in the source monitor, reply with `Use key: <correct-key>` or `The username is: <value>`.
+  * **Option B (Direct Edit)**: Update `spec.endpoints[<index>].basicAuth.username` directly in `<path-to-manifest>.yaml` and remove the TODO annotation.
+
+  ```
+
   ```
 
 #### 2.3 Corrupt Base64 Data (`TODO_CORRUPT_SECRET_DATA_<KEY>`)
 * **Annotation**: `[ERROR] Failed to base64-decode key "<key>" in Secret "<name>"...`
 * **Agent Interactive Step**:
   Do NOT fabricate key values or placeholders. Prompt the user:
+
   > *"Key `<key>` in Secret `<name>` contains invalid base64 data. Please provide the correct value or fix the Secret in the cluster."*
 * **Diff**:
+
   ```diff
    metadata:
   -  annotations:
@@ -238,15 +275,17 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 #### 3.1 Companion Secret Manifest Generation (`secret-<configmap-name>`)
 * **Cause**: Prometheus Operator allowed TLS CAs in `ConfigMap`; GMP strictly requires Kubernetes `Secret` objects.
 * **Manifest Generation Commands**:
+
   ```bash
   # Check if companion Secret was generated in output.yaml
   grep -A 10 "name: secret-<configmap-name>" output.yaml
-  
+
   # If missing, generate companion Secret manifest locally (do NOT apply directly to cluster)
   kubectl create secret generic secret-<configmap-name> -n <namespace> \
     --from-file=ca.crt=/path/to/ca.crt --dry-run=client -o yaml >> output.yaml
   ```
 * **Companion Secret Manifest**:
+
   ```yaml
   apiVersion: v1
   kind: Secret
@@ -259,22 +298,22 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 
 #### 3.2 Empty Secret Reference Selectors (`TODO_SET_SECRET_NAME`, `TODO_SET_SECRET_KEY`)
 * **Annotation**: `[ERROR] Referenced Secret has an empty name for key...`
-* **Commands**:
+* **Agent Handoff Output Format**:
+
+  ```markdown
+  Referenced TLS Secret has an empty name in the source manifest.
+
+  ### 1. Identify the TLS Secret in your namespace:
   ```bash
   kubectl get secrets -n <namespace>
   ```
-* **Diff**:
-  ```diff
-   spec:
-     endpoints:
-     - port: https
-       tls:
-         ca:
-           secret:
-  -          name: TODO_SET_SECRET_NAME
-  -          key: TODO_SET_SECRET_KEY
-  +          name: my-tls-ca
-  +          key: ca.crt
+
+  ### 2. Resolution Options:
+  * **Option A (Interactive)**: Reply with `The TLS secret name is: <secret-name>` and I will update the manifest.
+  * **Option B (Direct Edit)**: Update `spec.endpoints[<index>].tls.ca.secret.name` in `<path-to-manifest>.yaml` and remove the TODO annotation.
+
+  ```
+
   ```
 
 ---
@@ -283,23 +322,44 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 
 #### 4.1 OAuth2 Placeholders (`TODO_SET_OAUTH2_CLIENT_ID`, `TODO_SET_OAUTH2_TOKEN_URL`)
 * **Annotation**: `[ERROR] OAuth2 clientID must be defined as either Secret or ConfigMap...`
-* **Agent Interactive Step**:
-  Inspect local Secrets in the namespace for any existing OAuth credentials (`kubectl get secrets -n <namespace>`). If missing or incomplete, prompt the user directly:
-  > *"OAuth2 configuration requires an explicit `tokenUrl` and `clientID`. Please provide the token endpoint URL and client credentials for this workload (or configure the backing Secret)."*
-* **Diff**:
-  ```diff
-   spec:
-     endpoints:
-     - port: 8080
-       oauth2:
-  -      clientID: TODO_SET_OAUTH2_CLIENT_ID
-  -      tokenUrl: TODO_SET_OAUTH2_TOKEN_URL
-  +      clientID: "<your-client-id>"
-  +      tokenUrl: "<your-token-endpoint-url>"
-         clientSecret:
-           secret:
-             name: oauth-secret
-             key: client-secret
+* **Agent Handoff Output Format**:
+
+  ```markdown
+  In GMP, `oauth2.clientID` and `oauth2.tokenURL` are configured directly as strings, while `clientSecret` remains securely referenced from Secret `<secret-name>`.
+
+  ### 1. Retrieve the client ID in your terminal (if stored in a Secret):
+  ```bash
+  kubectl get secret <secret-name> -n <namespace> -o jsonpath='{.data.<client-id-key>}' | base64 -d
+  ```
+
+  ### 2. Resolution Options:
+  * **Option A (Interactive)**: Reply with:
+    * `The clientID is: <value>`
+    * `The tokenURL is: <url>` (e.g. `https://auth.corp.internal/oauth/v2/token`)
+      and I will update the manifest and remove the TODOs for you.
+  * **Option B (Direct Edit)**:
+    * **Resource**: `PodMonitoring:<namespace>/<name>`
+    * **File**: [`<path-to-manifest>.yaml`](file:///<path-to-manifest>.yaml#L<line>)
+    * **Target Fields**: `spec.endpoints[<index>].oauth2.clientID` and `spec.endpoints[<index>].oauth2.tokenURL`
+    * **Diff**:
+
+      ```diff
+        spec:
+          endpoints:
+          - oauth2:
+      -       clientID: TODO_SET_OAUTH2_CLIENT_ID
+      -       tokenURL: TODO_SET_OAUTH2_TOKEN_URL
+      +       clientID: "<your-retrieved-client-id>"
+      +       tokenURL: "<your-token-endpoint-url>"
+              clientSecret:
+                secret:
+                  name: <secret-name>
+                  key: client-secret
+      ```
+    * Remove the `gmp.googleapis.com/todo-*` annotations from `metadata.annotations`.
+
+  ```
+
   ```
 
 #### 4.2 Proxy URL Configuration (Malformed URLs & Stripped Credentials)
@@ -310,9 +370,11 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 * **Agent Interactive Step**:
   1. **Malformed URL (`TODO_SET_VALID_PROXY_URL`)**: Prompt the user for the valid corporate proxy host and port.
   2. **Stripped Credentials**: `gmp-migrate` automatically strips `user:password@` so the manifest passes GMP validation while preserving the proxy host and port. Prompt the user:
+
      > *"Proxy URL credentials were removed because GMP CRDs do not support proxy authentication. Please ensure proxy authentication is handled at the network level (e.g. IP allowlisting the GKE cluster at the proxy server or routing through an in-cluster forward proxy). If the target is inside the cluster/VPC, `proxyUrl` can be removed entirely."*
   3. Once confirmed, remove the TODO annotation from `metadata.annotations`.
 * **Diff (Case A: Resolving Malformed URL Placeholder)**:
+
   ```diff
    metadata:
   -  annotations:
@@ -324,6 +386,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   +    proxyUrl: http://proxy.corp.internal:3128
   ```
 * **Diff (Case B: Reconciling Stripped Credentials Annotation)**:
+
   ```diff
    metadata:
   -  annotations:
@@ -346,11 +409,13 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 
   ##### Case A: Reconciling `action: keep` (e.g. `prometheus.io/scrape: "true"`)
   1. **Intersection Query**: Query for workloads matching **both** the monitor's original `spec.selector` AND the annotation:
+
      ```bash
      kubectl get deployment,statefulset,daemonset -n <namespace> -l <original-monitor-selector> \
        -o jsonpath='{range .items[?(@.spec.template.metadata.annotations["prometheus.io/scrape"]=="true")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
      ```
   2. **Update `PodMonitoring`**: Combine the original selector with the promoted label:
+
      ```yaml
      spec:
        selector:
@@ -363,6 +428,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 
   ##### Case B: Reconciling `action: drop` (e.g. `prometheus.io/scrape: "false"`)
   1. **Identify Excluded Workloads**: Query for workloads matching `spec.selector` that have the exclusion annotation:
+
      ```bash
      kubectl get deployment,statefulset,daemonset -n <namespace> -l <original-monitor-selector> \
        -o jsonpath='{range .items[?(@.spec.template.metadata.annotations["prometheus.io/scrape"]=="false")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
@@ -370,6 +436,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   2. **Inverted Selector via `matchExpressions: NotIn`**:
      - Add `labels: { prometheus.io/scrape: "false" }` to the excluded workload(s).
      - In `PodMonitoring.spec.selector`, use `matchExpressions` with `operator: NotIn`:
+
        ```yaml
        spec:
          selector:
@@ -381,9 +448,12 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
              values:
              - "false"
        ```
-     > **Note**: Kubernetes `NotIn` matches all pods where the label is absent, or present with any value other than `"false"`.
+
+     > [!WARNING]
+     > **Scope Expansion Risk with `NotIn`**: In Kubernetes label selectors, `operator: NotIn` matches any pod where the label is completely absent. Any existing or newly created pods sharing `spec.selector.matchLabels` will be scraped by default unless explicitly tagged with the `prometheus.io/scrape: "false"` label. Operators must verify whether unannotated pods are intended to be scraped, or use explicit opt-in label matching (`In: ["true"]`) instead.
 
 * **Diffs**:
+
   ```diff
    # PodMonitoring CRD (Case A: Keep Rule)
    spec:
@@ -392,6 +462,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
          app.kubernetes.io/name: payment-gateway
   +      prometheus.io/scrape: "true"
   ```
+
   ```diff
    # PodMonitoring CRD (Case B: Drop Rule via NotIn)
    spec:
@@ -404,6 +475,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   +      values:
   +      - "false"
   ```
+
   ```diff
    # Target Workload spec.template.metadata.labels (Companion Patch)
    spec:
@@ -418,8 +490,10 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 * **Annotation**: `[ERROR] Conflicting relabeling keep rules for label "<label>": cannot require both "<val1>" and "<val2>" simultaneously...` (or `[ERROR] Selector conflict: label "<label>" has conflicting values...`)
 * **Agent Interactive Step**:
   Check the annotation or `Stderr` logs for conflicting values and ask the user to clarify:
+
   > *"Detected conflicting label rules for label `env` (`production` vs `staging`). Which workload should this PodMonitoring target?"*
 * **Diff (Case A: Update to Target Staging Workload)**:
+
   ```diff
    metadata:
   -  annotations:
@@ -431,6 +505,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   +      env: staging
   ```
 * **Diff (Case B: Retain Production Workload)**:
+
   ```diff
    metadata:
   -  annotations:
@@ -448,6 +523,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 #### 6.1 Invalid Duration / Timeout Capping
 * **Annotation**: `[ERROR] Invalid scrape interval "<val>"...`
 * **Diff**:
+
   ```diff
    spec:
      endpoints:
@@ -463,14 +539,17 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 * **Context**: In GMP, an empty label selector (`matchLabels: {}` or empty `selector`) acts as a wildcard and scrapes every pod in the namespace (or cluster) that exposes the endpoint port.
 * **Agent Interactive Step**:
   1. Inspect running workloads in the namespace to identify candidate workloads and their pod template labels:
+
      ```bash
      kubectl get deployment,daemonset,statefulset -n <namespace> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.metadata.labels}{"\n"}{end}'
      ```
   2. Correlate the monitor's name and port with the discovered workloads.
   3. Prompt the user for confirmation:
+
      > *"PodMonitoring `<name>` has an empty selector and will scrape all pods in namespace `<namespace>`. Discovered workloads: `[app=redis, app=web]`. Please confirm if you want to target a specific workload label, or keep the wildcard selector to scrape all pods in the namespace."*
   4. If a specific workload is confirmed, apply `matchLabels`. If namespace-wide scraping was intentional, delete the TODO annotation and leave the selector as-is.
 * **Diff (Target Specific Workload)**:
+
   ```diff
    spec:
      selector:
@@ -497,18 +576,21 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 5. Delete all `gmp.googleapis.com/todo-*` annotations from `metadata.annotations` once resolved.
 
 ### Reconciliation Audit & Code Diff Reporting Format
+
 When presenting reconciled manifests to the user, always provide:
 1. A structured audit table summarizing how each TODO was resolved.
 2. Complete, per-file code diffs showing the exact before-and-after modifications for every affected file (including companion Secrets or patched workload Deployments).
 
 #### Example Audit Table:
-| Resource (`<Kind>:<ns>/<name>`) | TODO Key / Placeholder | Investigation Step / Source | Resolution Action Taken |
-| :--- | :--- | :--- | :--- |
-| `PodMonitoring: payments/payment-gateway` | `gmp.googleapis.com/todo-1` (`TODO_RESOLVE_PORT_METRICS`) | Queried `svc/payment-service` via `kubectl get svc` | Mapped Service port `metrics` to container port `8443`. |
-| `PodMonitoring: payments/payment-gateway` | `gmp.googleapis.com/todo-2` (Scope Expansion) | Inspected pod labels with `kubectl get pods --show-labels` | Added `prometheus.io/scrape: "true"` to `matchLabels` and created Deployment patch. |
-| `PodMonitoring: payments/payment-gateway` | `TODO_SET_VALID_PROXY_URL` | User prompted for corporate proxy endpoint | Stripped embedded basic auth and configured `http://proxy.corp.internal:3128`. |
+
+| Resource (`<Kind>:<ns>/<name>`)           | TODO Key / Placeholder                                    | Investigation Step / Source                                | Resolution Action Taken                                                             |
+|:------------------------------------------|:----------------------------------------------------------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------|
+| `PodMonitoring: payments/payment-gateway` | `gmp.googleapis.com/todo-1` (`TODO_RESOLVE_PORT_METRICS`) | Queried `svc/payment-service` via `kubectl get svc`        | Mapped Service port `metrics` to container port `8443`.                             |
+| `PodMonitoring: payments/payment-gateway` | `gmp.googleapis.com/todo-2` (Scope Expansion)             | Inspected pod labels with `kubectl get pods --show-labels` | Added `prometheus.io/scrape: "true"` to `matchLabels` and created Deployment patch. |
+| `PodMonitoring: payments/payment-gateway` | `TODO_SET_VALID_PROXY_URL`                                | User prompted for corporate proxy endpoint                 | Stripped embedded basic auth and configured `http://proxy.corp.internal:3128`.      |
 
 #### Example Per-File Code Diffs:
+
 ```diff
 # File: manifests/gmp/podmonitoring-payment-gateway.yaml
  metadata:
@@ -546,18 +628,18 @@ When presenting reconciled manifests to the user, always provide:
 
 ---
 
-## 7. Verification & User Agency
+## 7. Deployment Options & User Agency
 
-Before applying changes to a live cluster:
-1. **Present Reconciliation Steps & Per-File Code Diffs**: Output the structured Reconciliation Audit Table detailing the steps taken for each TODO, followed by complete per-file diffs showing the exact before-and-after modifications for all reconciled manifests and companion files.
-2. **Server-Side Dry Run**:
-   ```bash
-   kubectl apply --dry-run=server -f <output-manifests.yaml>
-   ```
-3. **Explicit User Approval**: Ask the user before running `kubectl apply`.
-4. **Post-Apply Verification**:
+1. **Present Reconciled Manifests & Diffs**: Output the structured Reconciliation Audit Table detailing how each TODO was resolved, followed by complete per-file diffs showing the exact modifications for all reconciled manifests and companion files.
+2. **Prompt for Next Steps**: Ask the user how they would like to proceed with deployment:
+   - **Option 1 (GitOps / CI/CD — Recommended)**: Review and commit the generated manifests and companion patches to the Git repository to let the GitOps reconciler (Config Sync, ArgoCD, Flux) or CI/CD pipeline deploy them declaratively without configuration drift.
+   - **Option 2 (Direct Cluster Apply)**: Run a server-side dry run (`kubectl apply --dry-run=server -f <manifests>`) and request explicit approval before applying directly to the cluster.
+   - **Option 3 (Keep Local / Review Only)**: Keep the generated manifests in the local directory for manual review, testing, or future staging without making any cluster changes.
+3. **Post-Apply Verification (If Applied Directly)**:
+
    ```bash
    kubectl get podmonitoring,clusterpodmonitoring -A
    kubectl describe podmonitoring <name> -n <namespace>
    ```
+
    Check that `status.conditions` reports `ConfigurationCreateSuccess`.

--- a/cmd/gmp-migrate/SKILL.md
+++ b/cmd/gmp-migrate/SKILL.md
@@ -412,8 +412,8 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   1. **Intersection Query**: Query for workloads matching **both** the monitor's original `spec.selector` AND the annotation:
 
      ```bash
-     kubectl get deployment,statefulset,daemonset -n <namespace> -l <original-monitor-selector> \
-       -o jsonpath='{range .items[?(@.spec.template.metadata.annotations["prometheus.io/scrape"]=="true")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
+     kubectl get deployment,statefulset,daemonset -n <namespace> -l <original-monitor-selector> -o json | \
+       jq -r '.items[] | select(.spec.template.metadata.annotations["prometheus.io/scrape"] == "true") | "\(.kind)/\(.metadata.name)"'
      ```
   2. **Update `PodMonitoring`**: Combine the original selector with the promoted label:
 
@@ -432,8 +432,8 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   1. **Identify Excluded Workloads**: Query for workloads matching `spec.selector` that have the exclusion annotation:
 
      ```bash
-     kubectl get deployment,statefulset,daemonset -n <namespace> -l <original-monitor-selector> \
-       -o jsonpath='{range .items[?(@.spec.template.metadata.annotations["prometheus.io/scrape"]=="false")]}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
+     kubectl get deployment,statefulset,daemonset -n <namespace> -l <original-monitor-selector> -o json | \
+       jq -r '.items[] | select(.spec.template.metadata.annotations["prometheus.io/scrape"] == "false") | "\(.kind)/\(.metadata.name)"'
      ```
   2. **Inverted Selector via `matchExpressions: NotIn`**:
      - Add `labels: { prometheus.io/scrape: "false" }` to the excluded workload(s).

--- a/cmd/gmp-migrate/SKILL.md
+++ b/cmd/gmp-migrate/SKILL.md
@@ -199,6 +199,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 
 * **Annotation**: `[ERROR] Referenced SECRET "<name>" for key "<key>" was not found in migration inputs...`
 * **Agent Handoff Output Format**:
+
   In GMP, `basicAuth.username` is configured directly as a string, while `password` remains securely referenced from Secret `<secret-name>`.
 
   ### 1. Retrieve the username in your terminal:
@@ -208,6 +209,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   ```
 
   ### 2. Resolution Options:
+
   * **Option A (Interactive)**: Reply with `The username is: <value>` and I will update the manifest and remove the TODOs for you.
   * **Option B (Direct Edit)**:
     * **Resource**: `PodMonitoring:<namespace>/<name>`
@@ -232,6 +234,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 
 * **Annotation**: `[ERROR] Key "<key>" was not found in referenced SECRET "<name>"...`
 * **Agent Handoff Output Format**:
+
   Key `<key>` was not found in Secret `<secret-name>`.
 
   ### 1. List available keys in the Secret on your terminal:
@@ -241,6 +244,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   ```
 
   ### 2. Resolution Options:
+
   * **Option A (Interactive)**: If the key was misspelled in the source monitor, reply with `Use key: <correct-key>` or `The username is: <value>`.
   * **Option B (Direct Edit)**: Update `spec.endpoints[<index>].basicAuth.username` directly in `<path-to-manifest>.yaml` and remove the TODO annotation.
 
@@ -298,6 +302,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 
 * **Annotation**: `[ERROR] Referenced Secret has an empty name for key...`
 * **Agent Handoff Output Format**:
+
   Referenced TLS Secret has an empty name in the source manifest.
 
   ### 1. Identify the TLS Secret in your namespace:
@@ -307,6 +312,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   ```
 
   ### 2. Resolution Options:
+
   * **Option A (Interactive)**: Reply with `The TLS secret name is: <secret-name>` and I will update the manifest.
   * **Option B (Direct Edit)**: Update `spec.endpoints[<index>].tls.ca.secret.name` in `<path-to-manifest>.yaml` and remove the TODO annotation.
 
@@ -318,6 +324,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
 
 * **Annotation**: `[ERROR] OAuth2 clientID must be defined as either Secret or ConfigMap...`
 * **Agent Handoff Output Format**:
+
   In GMP, `oauth2.clientID` and `oauth2.tokenURL` are configured directly as strings, while `clientSecret` remains securely referenced from Secret `<secret-name>`.
 
   ### 1. Retrieve the client ID in your terminal (if stored in a Secret):
@@ -327,6 +334,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   ```
 
   ### 2. Resolution Options:
+
   * **Option A (Interactive)**: Reply with:
     * `The clientID is: <value>`
     * `The tokenURL is: <url>` (e.g. `https://auth.corp.internal/oauth/v2/token`)
@@ -400,6 +408,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   $$\text{Scraped Targets} = (\text{Pods matching } \texttt{spec.selector}) \cap (\text{Pods matching Annotation Rule})$$
 
   ##### Case A: Reconciling `action: keep` (e.g. `prometheus.io/scrape: "true"`)
+
   1. **Intersection Query**: Query for workloads matching **both** the monitor's original `spec.selector` AND the annotation:
 
      ```bash
@@ -419,6 +428,7 @@ All TODO annotations follow the format: `gmp.googleapis.com/todo-N: "[WARNING|ER
   4. **Warn & Prompt**: Warn the user that patching the workload pod templates will trigger a rolling restart of their pods, and request approval before applying.
 
   ##### Case B: Reconciling `action: drop` (e.g. `prometheus.io/scrape: "false"`)
+
   1. **Identify Excluded Workloads**: Query for workloads matching `spec.selector` that have the exclusion annotation:
 
      ```bash

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -1403,7 +1403,7 @@ func (c *conversionContext) convertProxyURL(proxyURL *string) string {
 		c.todos = append(c.todos, todoItem{
 			category: "ERROR",
 			reason:   "Proxy URL contains embedded plaintext credentials. Credentials were removed.",
-			action:   "Configure proxy authentication via Kubernetes Secret or proxy server configuration.",
+			action:   "Configure proxy authentication via proxy server configuration or network allowlist.",
 		})
 		parsed.User = nil
 		return parsed.String()

--- a/pkg/migrate/podmonitor_test.go
+++ b/pkg/migrate/podmonitor_test.go
@@ -2637,7 +2637,7 @@ func TestPodMonitorConversion(t *testing.T) {
 						Name:      "proxy-pass-monitor",
 						Namespace: "default",
 						Annotations: map[string]string{
-							"gmp.googleapis.com/todo-1": "[ERROR] Proxy URL contains embedded plaintext credentials. Credentials were removed. ACTION: Configure proxy authentication via Kubernetes Secret or proxy server configuration.",
+							"gmp.googleapis.com/todo-1": "[ERROR] Proxy URL contains embedded plaintext credentials. Credentials were removed. ACTION: Configure proxy authentication via proxy server configuration or network allowlist.",
 						},
 					},
 					Spec: monitoringv1.PodMonitoringSpec{

--- a/pkg/migrate/servicemonitor.go
+++ b/pkg/migrate/servicemonitor.go
@@ -255,7 +255,7 @@ func (c *ServiceMonitorConverter) findAndGroupServices(
 		return []*serviceGroup{
 			{
 				selector: map[string]string{
-					"app": "TODO_SET_POD_SELECTOR",
+					"TODO_SET_POD_LABELS": "TODO_SET_POD_LABELS",
 				},
 				portMap:  portMap,
 				services: dummySvcs,

--- a/pkg/migrate/servicemonitor_test.go
+++ b/pkg/migrate/servicemonitor_test.go
@@ -685,7 +685,7 @@ func TestServiceMonitorConverter_Convert(t *testing.T) {
 					Spec: monitoringv1.PodMonitoringSpec{
 						Selector: metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"app": "TODO_SET_POD_SELECTOR",
+								"TODO_SET_POD_LABELS": "TODO_SET_POD_LABELS",
 							},
 						},
 						Endpoints: []monitoringv1.ScrapeEndpoint{
@@ -731,7 +731,7 @@ func TestServiceMonitorConverter_Convert(t *testing.T) {
 					Spec: monitoringv1.PodMonitoringSpec{
 						Selector: metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"app": "TODO_SET_POD_SELECTOR",
+								"TODO_SET_POD_LABELS": "TODO_SET_POD_LABELS",
 							},
 						},
 						Endpoints: []monitoringv1.ScrapeEndpoint{
@@ -754,7 +754,7 @@ func TestServiceMonitorConverter_Convert(t *testing.T) {
 					Spec: monitoringv1.PodMonitoringSpec{
 						Selector: metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"app": "TODO_SET_POD_SELECTOR",
+								"TODO_SET_POD_LABELS": "TODO_SET_POD_LABELS",
 							},
 						},
 						Endpoints: []monitoringv1.ScrapeEndpoint{
@@ -797,7 +797,7 @@ func TestServiceMonitorConverter_Convert(t *testing.T) {
 					Spec: monitoringv1.ClusterPodMonitoringSpec{
 						Selector: metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"app": "TODO_SET_POD_SELECTOR",
+								"TODO_SET_POD_LABELS": "TODO_SET_POD_LABELS",
 							},
 						},
 						Endpoints: []monitoringv1.ScrapeEndpoint{


### PR DESCRIPTION
This PR introduces the `gmp-migrate` agent skill (`cmd/gmp-migrate/SKILL.md`) to guide AI coding agents through running the migration CLI, diagnosing migration reports, and safely reconciling draft GMP manifests with `gmp.googleapis.com/todo-*` annotations and `TODO_*` placeholders.
### Key Highlights
* **CLI Stream Separation & Modes**: Documents `--all` vs default mode, `Stdout`/`Stderr` stream separation, and exit code semantics.
* **Strict Read-Only Investigation**: Enforces a strict policy where all cluster investigation commands (`kubectl get`, `describe`, `logs`) are strictly read-only, prohibiting unapproved live cluster mutations.
* **Action Plan Catalog & Interactive Recipes**:
  * **Port & Selector Resolution**: Guided resolution for missing backing Services, unresolved named ports, and ambiguous multi-container pods.
  * **Auth & Secret Management**: Ingests companion Secrets, handles base64 payload errors, and prompts for missing OAuth2/Proxy endpoints.
  * **Relabeling & Scope Expansion**: Interactive reconciliation for dropped `keep`/`drop` annotation rules (`prometheus.io/scrape`), including `spec.selector` intersection queries, companion workload label patches, and `matchExpressions: NotIn` inverted selectors.
  * **Rolling Restart Safeguards**: Explicitly requires warning users and requesting permission before modifying workload pod templates (`spec.template.metadata.labels`).
* **Audit Reporting & Per-File Diffs**: Mandates presenting a structured Reconciliation Audit Table and file-by-file code diffs prior to executing dry-runs or `kubectl apply`.