### PR TITLE
ci(configs): use excludePackageNames for root Go module grouping in renovate (#2088)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,10 +87,9 @@
       "description": "Group root Go module dependencies into one PR as single update already updates co-located deps",
       "matchManagers": ["gomod"],
       "matchFileNames": ["go.mod"],
-      "matchPackageNames": [
-        "*",
-        "!k8s.io/**",
-        "!sigs.k8s.io/**"
+      "excludePackageNames": [
+        "k8s.io/**",
+        "sigs.k8s.io/**"
       ],
       "groupName": "deps",
       "groupSlug": "deps"


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/prometheus-engine/issues/2088