### PR TITLE
chore: bump config-reloader memory limit to 64M

### DIFF
--- a/charts/operator/templates/collector.yaml
+++ b/charts/operator/templates/collector.yaml
@@ -74,7 +74,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        resources: {{- toYaml $.Values.resources.bash | nindent 10}}
+        resources: {{- toYaml $.Values.resources.configReloader | nindent 10}}
         volumeMounts:
         - name: config
           readOnly: true

--- a/charts/values.global.yaml
+++ b/charts/values.global.yaml
@@ -61,7 +61,7 @@ resources:
       memory: 32M
   configReloader:
     limits:
-      memory: 32M
+      memory: 64M
     requests:
       cpu: 1m
       memory: 4M

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -397,7 +397,7 @@ spec:
               fieldPath: spec.nodeName
         resources:
           limits:
-            memory: 32M
+            memory: 64M
           requests:
             cpu: 1m
             memory: 4M

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -737,7 +737,7 @@ spec:
           containerPort: 19093
         resources:
           limits:
-            memory: 32M
+            memory: 64M
           requests:
             cpu: 1m
             memory: 4M
@@ -906,7 +906,7 @@ spec:
               fieldPath: spec.nodeName
         resources:
           limits:
-            memory: 32M
+            memory: 64M
           requests:
             cpu: 1m
             memory: 4M

--- a/manifests/rule-evaluator.yaml
+++ b/manifests/rule-evaluator.yaml
@@ -184,7 +184,7 @@ spec:
           containerPort: 9093
         resources:
           limits:
-            memory: 32M
+            memory: 64M
           requests:
             cpu: 1m
             memory: 4M


### PR DESCRIPTION
Bumps config-reloader container memory limit from 32M to 64M in charts/values.global.yaml and regenerates manifests.