### PR TITLE
revert: revert to WithCredentialsFile

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -162,7 +162,8 @@ func main() {
 	{
 		opts := []option.ClientOption{
 			option.WithScopes("https://www.googleapis.com/auth/monitoring.read"),
-			option.WithAuthCredentialsFile(option.ServiceAccount, *credentialsFile),
+			//nolint:staticcheck // Keep using deprecated WithCredentialsFile for now.
+			option.WithCredentialsFile(*credentialsFile),
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/rule-evaluator/main.go
+++ b/cmd/rule-evaluator/main.go
@@ -525,7 +525,8 @@ func newAPI(ctx context.Context, opts *evaluatorOptions, version string) (v1.API
 		option.WithUserAgent(fmt.Sprintf("rule-evaluator/%s", version)),
 	}
 	if opts.CredentialsFile != "" {
-		clientOpts = append(clientOpts, option.WithAuthCredentialsFile(option.ServiceAccount, opts.CredentialsFile))
+		//nolint:staticcheck // Keep using deprecated WithCredentialsFile for now.
+		clientOpts = append(clientOpts, option.WithCredentialsFile(opts.CredentialsFile))
 	}
 	if opts.DisableAuth {
 		clientOpts = append(clientOpts,

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -180,7 +180,8 @@ func newMetricClient(ctx context.Context) (*gcm.MetricClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return gcm.NewMetricClient(ctx, option.WithAuthCredentialsJSON(option.ServiceAccount, gcmSA))
+	//nolint:staticcheck // Keep using deprecated WithCredentialsJSON for now.
+	return gcm.NewMetricClient(ctx, option.WithCredentialsJSON(gcmSA))
 }
 
 func configureOperatorExplicitCredentials(ctx context.Context, kubeClient client.Client) error {


### PR DESCRIPTION
Reverts the migration to `WithAuthCredentialsFile` and `WithAuthCredentialsJSON` on `release/0.19`, returning to `WithCredentialsFile` and `WithCredentialsJSON` with `//nolint:staticcheck` annotations.